### PR TITLE
Bump shopify packages in sample app

### DIFF
--- a/sample-apps/discount-functions-sample-app/package.json
+++ b/sample-apps/discount-functions-sample-app/package.json
@@ -12,8 +12,8 @@
     "deploy": "shopify app deploy"
   },
   "dependencies": {
-    "@shopify/app": "2.0.5",
-    "@shopify/cli": "2.0.5",
+    "@shopify/app": "3.0.11",
+    "@shopify/cli": "3.0.11",
     "lodash": "^4.17.21",
     "react": "17.0.2"
   },


### PR DESCRIPTION
They're stale and we're running into a bunch of issues. With 3.0.11, `yarn dev` runs successfully.