### PR TITLE
Add api_version to each default project toml file

### DIFF
--- a/checkout/rust/payment-customization/default/shopify.function.extension.toml.liquid
+++ b/checkout/rust/payment-customization/default/shopify.function.extension.toml.liquid
@@ -1,3 +1,4 @@
 name = "{{name}}"
 type = "{{extensionType}}"
 title = "{{name}}"
+api_version = "2022-07"

--- a/checkout/rust/payment-methods/default/shopify.function.extension.toml.liquid
+++ b/checkout/rust/payment-methods/default/shopify.function.extension.toml.liquid
@@ -1,3 +1,4 @@
 name = "{{name}}"
 type = "{{extensionType}}"
 title = "{{name}}"
+api_version = "2022-07"

--- a/checkout/rust/shipping-methods/default/shopify.function.extension.toml.liquid
+++ b/checkout/rust/shipping-methods/default/shopify.function.extension.toml.liquid
@@ -1,3 +1,4 @@
 name = "{{name}}"
 type = "{{extensionType}}"
 title = "{{name}}"
+api_version = "2022-07"

--- a/checkout/rust/shipping-rate-presenter/default/shopify.function.extension.toml.liquid
+++ b/checkout/rust/shipping-rate-presenter/default/shopify.function.extension.toml.liquid
@@ -1,3 +1,4 @@
 name = "{{name}}"
 type = "{{extensionType}}"
 title = "{{name}}"
+api_version = "2022-07"

--- a/checkout/typescript/payment-methods/default/shopify.function.extension.toml.liquid
+++ b/checkout/typescript/payment-methods/default/shopify.function.extension.toml.liquid
@@ -1,3 +1,4 @@
 name = "{{name}}"
 type = "{{extensionType}}"
 title = "{{name}}"
+api_version = "2022-07"

--- a/checkout/typescript/shipping-methods/default/shopify.function.extension.toml.liquid
+++ b/checkout/typescript/shipping-methods/default/shopify.function.extension.toml.liquid
@@ -1,3 +1,4 @@
 name = "{{name}}"
 type = "{{extensionType}}"
 title = "{{name}}"
+api_version = "2022-07"

--- a/checkout/wasm/payment-methods/default/shopify.function.extension.toml.liquid
+++ b/checkout/wasm/payment-methods/default/shopify.function.extension.toml.liquid
@@ -2,6 +2,7 @@ name = "{{name}}"
 type = "{{extensionType}}"
 version = "2"
 description = "Payment methods base script"
+api_version = "2022-07"
 
 [meta_object]
 type = "object"

--- a/checkout/wasm/shipping-methods/default/shopify.function.extension.toml.liquid
+++ b/checkout/wasm/shipping-methods/default/shopify.function.extension.toml.liquid
@@ -2,6 +2,7 @@ name = "{{name}}"
 type = "{{extensionType}}"
 version = "2"
 description = "Shipping methods base script"
+api_version = "2022-07"
 
 [meta_object]
 type = "object"

--- a/checkout/wasm/shipping-rate-presenter/default/shopify.function.extension.toml.liquid
+++ b/checkout/wasm/shipping-rate-presenter/default/shopify.function.extension.toml.liquid
@@ -2,6 +2,7 @@ name = "{{name}}"
 type = "{{extensionType}}"
 version = "2"
 description = "Shipping methods base script"
+api_version = "2022-07"
 
 [meta_object]
 type = "object"

--- a/checkout/wasm/shipping-rates-consolidation/default/shopify.function.extension.toml.liquid
+++ b/checkout/wasm/shipping-rates-consolidation/default/shopify.function.extension.toml.liquid
@@ -2,6 +2,7 @@ name = "{{name}}"
 type = "{{extensionType}}"
 version = "2"
 description = "Shipping rates consolidation base script"
+api_version = "2022-07"
 
 [meta_object]
 type = "object"

--- a/discounts/rust/order-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/rust/order-discounts/default/shopify.function.extension.toml.liquid
@@ -1,6 +1,7 @@
 name = "{{name}}"
 type = "{{extensionType}}"
 version = "2"
+api_version = "2022-07"
 
 [meta_object]
 type = "object"

--- a/discounts/rust/product-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/rust/product-discounts/default/shopify.function.extension.toml.liquid
@@ -1,6 +1,7 @@
 name = "{{name}}"
 type = "{{extensionType}}"
 version = "2"
+api_version = "2022-07"
 
 [meta_object]
 type = "object"

--- a/discounts/rust/shipping-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/rust/shipping-discounts/default/shopify.function.extension.toml.liquid
@@ -1,6 +1,7 @@
 name = "{{name}}"
 type = "{{extensionType}}"
 version = "2"
+api_version = "2022-07"
 
 [meta_object]
 type = "object"

--- a/discounts/wasm/order-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/wasm/order-discounts/default/shopify.function.extension.toml.liquid
@@ -1,6 +1,7 @@
 name = "{{name}}"
 type = "{{extensionType}}"
 version = "2"
+api_version = "2022-07"
 
 [meta_object]
 type = "object"

--- a/discounts/wasm/product-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/wasm/product-discounts/default/shopify.function.extension.toml.liquid
@@ -1,6 +1,7 @@
 name = "{{name}}"
 type = "{{extensionType}}"
 version = "2"
+api_version = "2022-07"
 
 [meta_object]
 type = "object"

--- a/discounts/wasm/shipping-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/wasm/shipping-discounts/default/shopify.function.extension.toml.liquid
@@ -1,6 +1,7 @@
 name = "{{name}}"
 type = "{{extensionType}}"
 version = "2"
+api_version = "2022-07"
 
 [meta_object]
 type = "object"


### PR DESCRIPTION
Part of https://github.com/Shopify/script-service/issues/4714

Adding API versioning to input queries.