### PR TITLE
Load function IDs from the CLI .env to reduce manual steps

### DIFF
--- a/sample-apps/discount-functions-sample-app/README.md
+++ b/sample-apps/discount-functions-sample-app/README.md
@@ -20,9 +20,9 @@ It also provides [Shopify Functions](#) that allow merchants to set up discounts
 
 ## Installation
 
-1. `yarn deploy` from the app root. This will allow you to create a new app, if needed.
-2. Rename the `.env.sample` file in `web/frontend` to `.env` and fill in the function UUIDs for each of your functions from the root `.env`
-3. Run `yarn dev` to start the server
+1. Run `yarn deploy` from the app root. This will allow you to create a new app, if needed.
+2. Run `yarn dev` to start the local dev server.
+3. Follow the output instructions to install your app.
 
 ## Developer resources
 

--- a/sample-apps/discount-functions-sample-app/web/frontend/.env.example
+++ b/sample-apps/discount-functions-sample-app/web/frontend/.env.example
@@ -1,3 +1,0 @@
-ORDER_DISCOUNT_ID=<your order_discounts function UUID>
-PRODUCT_DISCOUNT_ID=<your product_discounts function UUID>
-SHIPPING_DISCOUNT_ID=<your shipping_discounts function UUID>

--- a/sample-apps/discount-functions-sample-app/web/frontend/pages/order-discount/new.jsx
+++ b/sample-apps/discount-functions-sample-app/web/frontend/pages/order-discount/new.jsx
@@ -7,7 +7,7 @@ import {
 export default function CreateOrderDiscountPage() {
   return (
     <DiscountCreatePage
-      functionId={process.env.ORDER_DISCOUNT_ID}
+      functionId={process.env.SHOPIFY_ORDER_DISCOUNT_ID}
       defaultConfiguration={DEFAULT_CONFIGURATION}
       renderConfigurationForm={(configuration, onConfigurationChange) => (
         <OrderDiscount

--- a/sample-apps/discount-functions-sample-app/web/frontend/pages/product-discount/new.jsx
+++ b/sample-apps/discount-functions-sample-app/web/frontend/pages/product-discount/new.jsx
@@ -7,7 +7,7 @@ import {
 export default function CreateProductDiscountPage() {
   return (
     <DiscountCreatePage
-      functionId={process.env.PRODUCT_DISCOUNT_ID}
+      functionId={process.env.SHOPIFY_PRODUCT_DISCOUNT_ID}
       defaultConfiguration={DEFAULT_CONFIGURATION}
       renderConfigurationForm={(configuration, onConfigurationChange) => (
         <ProductDiscount

--- a/sample-apps/discount-functions-sample-app/web/frontend/pages/shipping-discount/new.jsx
+++ b/sample-apps/discount-functions-sample-app/web/frontend/pages/shipping-discount/new.jsx
@@ -7,7 +7,7 @@ import {
 export default function CreateShippingDiscountPage() {
   return (
     <DiscountCreatePage
-      functionId={process.env.SHIPPING_DISCOUNT_ID}
+      functionId={process.env.SHOPIFY_SHIPPING_DISCOUNT_ID}
       defaultConfiguration={DEFAULT_CONFIGURATION}
       renderConfigurationForm={(configuration, onConfigurationChange) => (
         <ShippingDiscount

--- a/sample-apps/discount-functions-sample-app/web/frontend/vite.config.js
+++ b/sample-apps/discount-functions-sample-app/web/frontend/vite.config.js
@@ -1,18 +1,23 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import path from 'path';
-import 'dotenv/config';
 
 // prettier-ignore
 const INDEX_ROUTE = "^/(\\?.*)?$";
 const API_ROUTE = '^/api/';
 const ENV_KEYS = [
   'SHOPIFY_API_KEY',
-  'ORDER_DISCOUNT_ID',
-  'PRODUCT_DISCOUNT_ID',
-  'SHIPPING_DISCOUNT_ID',
+  'SHOPIFY_ORDER_DISCOUNT_ID',
+  'SHOPIFY_SHIPPING_DISCOUNT_ID',
+  'SHOPIFY_PRODUCT_DISCOUNT_ID',
 ];
 
 const root = new URL('.', import.meta.url).pathname;
+
+// Function IDs are populated in ../../.env by the Shopify CLI after being deployed
+if (process.env.npm_lifecycle_event === 'dev') {
+  const envFile = loadEnv('dev', path.join(process.cwd(), '..', '..'), '');
+  process.env = { ...process.env, ...envFile };
+}
 
 export default defineConfig({
   root,


### PR DESCRIPTION
## Why?

Currently to use this sample, there is a manual step to copy Function IDs between `.env` files, so that the deployed function IDs are available to the front-end.

## What does this PR do?

When running the `dev` npm target, it attempts to load the `.env` file that the CLI creates following a `deploy`. This contains the function IDs already.

## How to test?

`yarn deploy`
`yarn dev`

Then attempt to create discounts and watch the IDs in the Network Panel. Discount creation will fail at the moment due to API changes, but you'll see the function IDs in the payload.

* `/product-discount/new`
* `/shipping-discount/new`
* `/order-discount/new`