### PR TITLE
Update sample app discounts to use metafield configuration

### DIFF
--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/input.graphql
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/input.graphql
@@ -1,9 +1,4 @@
 query Input {
-  merchandiseLines {
-    variant {
-      id
-    }
-  }
   discountNode {
     metafield(namespace: "discount-functions-sample-app", key: "function-configuration") {
       value

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/src/api.rs
@@ -19,6 +19,18 @@ pub mod input {
         pub delivery_lines: Option<Vec<DeliveryLine>>,
         pub locale: Option<String>,
         pub merchandise_lines: Option<Vec<MerchandiseLine>>,
+        pub discount_node: Option<DiscountNode>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Default)]
+    pub struct DiscountNode {
+        pub metafield: Option<Metafield>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Default)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Metafield {
+        pub value: Option<String>,
     }
 
     #[derive(Clone, Debug, Deserialize)]

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
@@ -3,57 +3,60 @@ use serde::{Deserialize, Serialize};
 mod api;
 use api::*;
 
-#[derive(Clone, Debug, Deserialize)]
-pub struct Payload {
-    pub input: input::Input,
-    pub configuration: Configuration,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all(deserialize = "camelCase"))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Configuration {
-    pub value: Option<String>,
-    pub excluded_variant_ids: Option<Vec<ID>>,
+    pub value: f64,
+    pub excluded_variant_ids: Vec<ID>,
 }
 
 impl Configuration {
     const DEFAULT_VALUE: f64 = 50.0;
 
-    fn get_value(&self) -> f64 {
-        match &self.value {
-            Some(value) => value.parse().unwrap(),
-            _ => Self::DEFAULT_VALUE,
+    fn from_str(str: &str) -> Self {
+        serde_json::from_str(str).unwrap_or_default()
+    }
+}
+
+impl Default for Configuration {
+    fn default() -> Self {
+        Configuration {
+            value: Self::DEFAULT_VALUE,
+            excluded_variant_ids: vec![],
         }
     }
+}
 
-    fn excluded_variant_ids(&self) -> Vec<ID> {
-        self.excluded_variant_ids
-            .as_ref()
-            .unwrap_or(&vec![])
-            .to_vec()
+impl input::Input {
+    fn configuration(&self) -> Configuration {
+        let value: Option<&str> = self.discount_node.as_ref().and_then(|discount_node| {
+            discount_node
+                .metafield
+                .as_ref()
+                .and_then(|metafield| metafield.value.as_deref())
+        });
+        value.map(Configuration::from_str).unwrap_or_default()
     }
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let payload: Payload = serde_json::from_reader(std::io::BufReader::new(std::io::stdin()))?;
+    let input: input::Input = serde_json::from_reader(std::io::BufReader::new(std::io::stdin()))?;
     let mut out = std::io::stdout();
     let mut serializer = serde_json::Serializer::new(&mut out);
-    function(payload)?.serialize(&mut serializer)?;
+    function(input)?.serialize(&mut serializer)?;
     Ok(())
 }
 
-fn function(payload: Payload) -> Result<FunctionResult, Box<dyn std::error::Error>> {
-    let config = payload.configuration;
-    let value = config.get_value();
-    let excluded_variant_ids = config.excluded_variant_ids();
+fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::Error>> {
+    let config: Configuration = input.configuration();
     Ok(FunctionResult {
         discounts: vec![Discount {
-            message: Some(format!("{}% off", value)),
+            message: None,
             conditions: None,
             targets: vec![Target::OrderSubtotal {
-                excluded_variant_ids,
+                excluded_variant_ids: config.excluded_variant_ids
             }],
-            value: Value::Percentage(Percentage { value }),
+            value: Value::Percentage(Percentage { value: config.value }),
         }],
         discount_application_strategy: DiscountApplicationStrategy::First,
     })
@@ -63,40 +66,28 @@ fn function(payload: Payload) -> Result<FunctionResult, Box<dyn std::error::Erro
 mod tests {
     use super::*;
 
-    fn payload(configuration: Configuration) -> Payload {
-        let input = r#"
-        {
-            "input": {
-                "merchandiseLines": [
-                    { "variant": { "id": "gid://shopify/ProductVariant/0" } },
-                    { "variant": { "id": "gid://shopify/ProductVariant/1" } }
-                ]
-            },
-            "configuration": {
-                "value": null,
-                "excludedVariantIds": null
-            }
-        }
-        "#;
-        let default_payload: Payload = serde_json::from_str(input).unwrap();
-        Payload {
-            configuration,
-            ..default_payload
+    fn input(configuration: Option<Configuration>) -> input::Input {
+        let default_input: input::Input = serde_json::from_str("{}").unwrap();
+        let discount_node = Some(input::DiscountNode {
+            metafield: Some(input::Metafield {
+                value: serde_json::to_string(&configuration).ok(),
+            }),
+        });
+
+        input::Input {
+            discount_node,
+            ..default_input
         }
     }
 
     #[test]
-    fn test_discount_with_default_value() {
-        let payload = payload(Configuration {
-            value: None,
-            excluded_variant_ids: None,
-        });
-        let result = serde_json::json!(function(payload).unwrap());
+    fn test_discount_with_no_configuration() {
+        let input = input(None);
+        let handle_result = serde_json::json!(function(input).unwrap());
 
         let expected_json = r#"
             {
                 "discounts": [{
-                    "message": "50% off",
                     "targets": [{ "orderSubtotal": { "excludedVariantIds": [] } }],
                     "value": { "percentage": { "value": 50.0 } }
                 }],
@@ -104,22 +95,25 @@ mod tests {
             }
         "#;
 
-        let expected_result: serde_json::Value = serde_json::from_str(expected_json).unwrap();
-        assert_eq!(result.to_string(), expected_result.to_string());
+        let expected_handle_result: serde_json::Value =
+            serde_json::from_str(expected_json).unwrap();
+        assert_eq!(
+            handle_result.to_string(),
+            expected_handle_result.to_string()
+        );
     }
 
     #[test]
     fn test_discount_with_value() {
-        let payload = payload(Configuration {
-            value: Some("10".to_string()),
-            excluded_variant_ids: None,
-        });
-        let result = serde_json::json!(function(payload).unwrap());
+        let input = input(Some(Configuration {
+            value: 10.0,
+            excluded_variant_ids: vec![],
+        }));
+        let result = serde_json::json!(function(input).unwrap());
 
         let expected_json = r#"
             {
                 "discounts": [{
-                    "message": "10% off",
                     "targets": [{ "orderSubtotal": { "excludedVariantIds": [] } }],
                     "value": { "percentage": { "value": 10.0 } }
                 }],
@@ -133,21 +127,16 @@ mod tests {
 
     #[test]
     fn test_discount_with_excluded_variant_ids() {
-        let payload = payload(Configuration {
-            value: None,
-            excluded_variant_ids: Some(vec!["gid://shopify/ProductVariant/1".to_string()]),
-        });
-        let result = serde_json::json!(function(payload).unwrap());
+        let input = input(Some(Configuration {
+            value: Configuration::DEFAULT_VALUE,
+            excluded_variant_ids: vec!["gid://shopify/ProductVariant/1".to_string()],
+        }));
+        let result = serde_json::json!(function(input).unwrap());
 
         let expected_json = r#"
             {
                 "discounts": [{
-                    "message": "50% off",
-                    "targets": [{
-                        "orderSubtotal": {
-                            "excludedVariantIds": ["gid://shopify/ProductVariant/1"]
-                        }
-                    }],
+                    "targets": [{ "orderSubtotal": { "excludedVariantIds": ["gid://shopify/ProductVariant/1"] } }],
                     "value": { "percentage": { "value": 50.0 } }
                 }],
                 "discountApplicationStrategy": "FIRST"

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/src/api.rs
@@ -19,6 +19,18 @@ pub mod input {
         pub delivery_lines: Option<Vec<DeliveryLine>>,
         pub locale: Option<String>,
         pub merchandise_lines: Option<Vec<MerchandiseLine>>,
+        pub discount_node: Option<DiscountNode>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Default)]
+    pub struct DiscountNode {
+        pub metafield: Option<Metafield>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Default)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Metafield {
+        pub value: Option<String>,
     }
 
     #[derive(Clone, Debug, Deserialize)]

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/src/main.rs
@@ -3,52 +3,62 @@ use serde::{Deserialize, Serialize};
 mod api;
 use api::*;
 
-#[derive(Clone, Debug, Deserialize)]
-pub struct Payload {
-    pub input: input::Input,
-    pub configuration: Configuration,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all(deserialize = "camelCase"))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Configuration {
-    pub value: Option<String>,
-    pub excluded_variant_ids: Option<Vec<ID>>,
+    pub value: f64,
+    pub excluded_variant_ids: Vec<ID>,
 }
 
 impl Configuration {
     const DEFAULT_VALUE: f64 = 50.0;
 
-    fn get_value(&self) -> f64 {
-        match &self.value {
-            Some(value) => value.parse().unwrap(),
-            _ => Self::DEFAULT_VALUE,
+    fn from_str(str: &str) -> Self {
+        serde_json::from_str(str).unwrap_or_default()
+    }
+}
+
+impl Default for Configuration {
+    fn default() -> Self {
+        Configuration {
+            value: Self::DEFAULT_VALUE,
+            excluded_variant_ids: vec![],
         }
     }
+}
 
-    fn excluded_variant_ids(&self) -> Vec<ID> {
-        self.excluded_variant_ids
-            .as_ref()
-            .unwrap_or(&vec![])
-            .to_vec()
+impl input::Input {
+    fn configuration(&self) -> Configuration {
+        let value: Option<&str> = self.discount_node.as_ref().and_then(|discount_node| {
+            discount_node
+                .metafield
+                .as_ref()
+                .and_then(|metafield| metafield.value.as_deref())
+        });
+        value.map(Configuration::from_str).unwrap_or_default()
     }
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let payload: Payload = serde_json::from_reader(std::io::BufReader::new(std::io::stdin()))?;
+    let input: input::Input = serde_json::from_reader(std::io::BufReader::new(std::io::stdin()))?;
     let mut out = std::io::stdout();
     let mut serializer = serde_json::Serializer::new(&mut out);
-    function(payload)?.serialize(&mut serializer)?;
+    function(input)?.serialize(&mut serializer)?;
     Ok(())
 }
 
-fn function(payload: Payload) -> Result<FunctionResult, Box<dyn std::error::Error>> {
-    let (input, config) = (payload.input, payload.configuration);
-    let value: f64 = config.get_value();
-    let merchandise_lines = &input.merchandise_lines.unwrap_or_default();
-    let excluded_variant_ids = config.excluded_variant_ids();
-    let targets = targets(merchandise_lines, &excluded_variant_ids);
-    Ok(build_result(value, targets))
+fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::Error>> {
+    if input.merchandise_lines.is_none() {
+        return Ok(FunctionResult {
+            discounts: vec![],
+            discount_application_strategy: DiscountApplicationStrategy::First,
+        });
+    }
+
+    let merchandise_lines = input.merchandise_lines.as_ref().unwrap();
+    let config: Configuration = input.configuration();
+    let targets = targets(merchandise_lines, &config.excluded_variant_ids);
+    Ok(build_result(config.value, targets))
 }
 
 fn variant_ids(merchandise_lines: &[input::MerchandiseLine]) -> Vec<ID> {
@@ -83,7 +93,7 @@ fn build_result(value: f64, targets: Vec<Target>) -> FunctionResult {
         vec![]
     } else {
         vec![Discount {
-            message: Some(format!("{}% off", value)),
+            message: None,
             conditions: None,
             targets,
             value: Value::Percentage(Percentage { value }),
@@ -99,40 +109,36 @@ fn build_result(value: f64, targets: Vec<Target>) -> FunctionResult {
 mod tests {
     use super::*;
 
-    fn payload(configuration: Configuration) -> Payload {
+    fn input(configuration: Option<Configuration>) -> input::Input {
         let input = r#"
         {
-            "input": {
-                "merchandiseLines": [
-                    { "variant": { "id": "gid://shopify/ProductVariant/0" } },
-                    { "variant": { "id": "gid://shopify/ProductVariant/1" } }
-                ]
-            },
-            "configuration": {
-                "value": null,
-                "excludedVariantIds": null
-            }
+            "merchandiseLines": [
+                { "variant": { "id": "gid://shopify/ProductVariant/0" } },
+                { "variant": { "id": "gid://shopify/ProductVariant/1" } }
+            ]
         }
         "#;
-        let default_payload: Payload = serde_json::from_str(input).unwrap();
-        Payload {
-            configuration,
-            ..default_payload
+        let default_input: input::Input = serde_json::from_str(input).unwrap();
+        let discount_node = Some(input::DiscountNode {
+            metafield: Some(input::Metafield {
+                value: serde_json::to_string(&configuration).ok(),
+            }),
+        });
+
+        input::Input {
+            discount_node,
+            ..default_input
         }
     }
 
     #[test]
-    fn test_discount_with_default_value() {
-        let payload = payload(Configuration {
-            value: None,
-            excluded_variant_ids: None,
-        });
-        let handle_result = serde_json::json!(function(payload).unwrap());
+    fn test_discount_with_no_configuration() {
+        let input = input(None);
+        let handle_result = serde_json::json!(function(input).unwrap());
 
         let expected_json = r#"
             {
                 "discounts": [{
-                    "message": "50% off",
                     "targets": [
                         { "productVariant": { "id": "gid://shopify/ProductVariant/0" } },
                         { "productVariant": { "id": "gid://shopify/ProductVariant/1" } }
@@ -153,16 +159,15 @@ mod tests {
 
     #[test]
     fn test_discount_with_value() {
-        let payload = payload(Configuration {
-            value: Some("10".to_string()),
-            excluded_variant_ids: None,
-        });
-        let handle_result = serde_json::json!(function(payload).unwrap());
+        let input = input(Some(Configuration {
+            value: 10.0,
+            excluded_variant_ids: vec![],
+        }));
+        let result = serde_json::json!(function(input).unwrap());
 
         let expected_json = r#"
             {
                 "discounts": [{
-                    "message": "10% off",
                     "targets": [
                         { "productVariant": { "id": "gid://shopify/ProductVariant/0" } },
                         { "productVariant": { "id": "gid://shopify/ProductVariant/1" } }
@@ -173,58 +178,44 @@ mod tests {
             }
         "#;
 
-        let expected_handle_result: serde_json::Value =
-            serde_json::from_str(expected_json).unwrap();
-        assert_eq!(
-            handle_result.to_string(),
-            expected_handle_result.to_string()
-        );
+        let expected_result: serde_json::Value = serde_json::from_str(expected_json).unwrap();
+        assert_eq!(result.to_string(), expected_result.to_string());
     }
 
     #[test]
-    fn test_discount_with_excluded_variant_gids() {
-        let payload = payload(Configuration {
-            value: None,
-            excluded_variant_ids: Some(vec!["gid://shopify/ProductVariant/0".to_string()]),
-        });
-        let handle_result = serde_json::json!(function(payload).unwrap());
+    fn test_discount_with_excluded_variant_ids() {
+        let input = input(Some(Configuration {
+            value: Configuration::DEFAULT_VALUE,
+            excluded_variant_ids: vec!["gid://shopify/ProductVariant/1".to_string()],
+        }));
+        let result = serde_json::json!(function(input).unwrap());
 
         let expected_json = r#"
-        {
-            "discounts": [{
-                "message": "50% off",
-                "targets": [
-                    { "productVariant": { "id": "gid://shopify/ProductVariant/1" } }
-                ],
-                "value": { "percentage": { "value": 50.0 } }
-            }],
-            "discountApplicationStrategy": "FIRST"
-        }
+            {
+                "discounts": [{
+                    "targets": [
+                        { "productVariant": { "id": "gid://shopify/ProductVariant/0" } }
+                    ],
+                    "value": { "percentage": { "value": 50.0 } }
+                }],
+                "discountApplicationStrategy": "FIRST"
+            }
         "#;
 
-        let expected_handle_result: serde_json::Value =
-            serde_json::from_str(expected_json).unwrap();
-        assert_eq!(
-            handle_result.to_string(),
-            expected_handle_result.to_string()
-        );
+        let expected_result: serde_json::Value = serde_json::from_str(expected_json).unwrap();
+        assert_eq!(result.to_string(), expected_result.to_string());
     }
 
     #[test]
     fn test_discount_with_no_merchandise_lines() {
-        let payload = Payload {
-            input: input::Input {
-                delivery_lines: None,
-                merchandise_lines: None,
-                customer: None,
-                locale: None,
-            },
-            configuration: Configuration {
-                value: None,
-                excluded_variant_ids: None,
-            },
+        let input = input::Input {
+            delivery_lines: None,
+            merchandise_lines: None,
+            customer: None,
+            locale: None,
+            discount_node: None,
         };
-        let handle_result = serde_json::json!(function(payload).unwrap());
+        let handle_result = serde_json::json!(function(input).unwrap());
 
         let expected_json = r#"
             {
@@ -243,33 +234,28 @@ mod tests {
 
     #[test]
     fn test_discount_with_no_variant_ids() {
-        let payload = Payload {
-            input: input::Input {
-                delivery_lines: None,
-                merchandise_lines: Some(vec![input::MerchandiseLine {
+        let input = input::Input {
+            delivery_lines: None,
+            merchandise_lines: Some(vec![input::MerchandiseLine {
+                id: None,
+                variant: Some(input::Variant {
                     id: None,
-                    variant: Some(input::Variant {
-                        id: None,
-                        compare_at_price: None,
-                        product: None,
-                        sku: None,
-                        title: None,
-                    }),
-                    price: None,
-                    properties: None,
-                    quantity: None,
-                    selling_plan: None,
-                    weight: None,
-                }]),
-                customer: None,
-                locale: None,
-            },
-            configuration: Configuration {
-                value: None,
-                excluded_variant_ids: None,
-            },
+                    compare_at_price: None,
+                    product: None,
+                    sku: None,
+                    title: None,
+                }),
+                price: None,
+                properties: None,
+                quantity: None,
+                selling_plan: None,
+                weight: None,
+            }]),
+            customer: None,
+            locale: None,
+            discount_node: None,
         };
-        let handle_result = serde_json::json!(function(payload).unwrap());
+        let handle_result = serde_json::json!(function(input).unwrap());
 
         let expected_json = r#"
             {

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/input.graphql
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/input.graphql
@@ -2,4 +2,9 @@ query Input {
   deliveryLines {
     id
   }
+  discountNode {
+    metafield(namespace: "discount-functions-sample-app", key: "function-configuration") {
+      value
+    }
+  }
 }

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/api.rs
@@ -19,6 +19,18 @@ pub mod input {
         pub delivery_lines: Option<Vec<DeliveryLineWithStrategy>>,
         pub locale: Option<String>,
         pub merchandise_lines: Option<Vec<MerchandiseLine>>,
+        pub discount_node: Option<DiscountNode>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Default)]
+    pub struct DiscountNode {
+        pub metafield: Option<Metafield>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Default)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Metafield {
+        pub value: Option<String>,
     }
 
     #[derive(Clone, Debug, Deserialize)]

--- a/sample-apps/discount-functions-sample-app/web/frontend/components/function-configuration/OrderDiscount.jsx
+++ b/sample-apps/discount-functions-sample-app/web/frontend/components/function-configuration/OrderDiscount.jsx
@@ -19,7 +19,7 @@ export default function OrderDiscount({
   const handleValueChange = (value) => {
     onConfigurationChange({
       ...configuration,
-      value,
+      value: parseFloat(value),
     });
   };
 

--- a/sample-apps/discount-functions-sample-app/web/frontend/components/function-configuration/ProductDiscount.jsx
+++ b/sample-apps/discount-functions-sample-app/web/frontend/components/function-configuration/ProductDiscount.jsx
@@ -19,7 +19,7 @@ export default function ProductDiscount({
   const handleValueChange = (value) => {
     onConfigurationChange({
       ...configuration,
-      value,
+      value: parseFloat(value),
     });
   };
 

--- a/sample-apps/discount-functions-sample-app/web/frontend/components/function-configuration/ShippingDiscount.jsx
+++ b/sample-apps/discount-functions-sample-app/web/frontend/components/function-configuration/ShippingDiscount.jsx
@@ -7,7 +7,7 @@ export default function ShippingDiscount({
   const handleValueChange = (value) => {
     onConfigurationChange({
       ...configuration,
-      value,
+      value: parseFloat(value),
     });
   };
 

--- a/sample-apps/discount-functions-sample-app/web/frontend/hooks/useDiscount.js
+++ b/sample-apps/discount-functions-sample-app/web/frontend/hooks/useDiscount.js
@@ -16,12 +16,14 @@ export function useDiscount({
   const [configuration, setConfiguration] = useState(
     savedDiscount?.configuration ?? defaultConfiguration,
   );
+  const configurationId = savedDiscount?.configurationId;
 
   const discount = {
     title,
     startsAt,
     endsAt,
     configuration,
+    configurationId,
   };
 
   const isDirty = useMemo(() => {

--- a/sample-apps/discount-functions-sample-app/web/frontend/hooks/useSavedDiscount.js
+++ b/sample-apps/discount-functions-sample-app/web/frontend/hooks/useSavedDiscount.js
@@ -10,7 +10,10 @@ const QUERY = gql`
       automaticDiscount {
         ... on DiscountAutomaticApp {
           title
-          configuration
+          configurationField: metafield(namespace: 'discount-functions-sample-app', key: 'function-configuration') {
+            id
+            value
+          }
           startsAt
           endsAt
         }
@@ -35,14 +38,15 @@ export function useSavedDiscount(id) {
       title,
       startsAt,
       endsAt,
-      configuration: unparsedConfiguration,
+      configurationField,
     } = data.data.automaticDiscountNode.automaticDiscount;
 
     return {
       title,
       startsAt,
       endsAt,
-      configuration: JSON.parse(unparsedConfiguration),
+      configuration: JSON.parse(configurationField?.value ?? '{}'),
+      configurationId: configurationField?.id,
     };
   }, [data]);
 

--- a/sample-apps/discount-functions-sample-app/web/frontend/hooks/useSavedDiscount.js
+++ b/sample-apps/discount-functions-sample-app/web/frontend/hooks/useSavedDiscount.js
@@ -7,13 +7,13 @@ import { useShopifyQuery } from './useShopifyQuery';
 const QUERY = gql`
   query GetDiscount($id: ID!) {
     automaticDiscountNode(id: $id) {
+      configurationField: metafield(namespace: "discount-functions-sample-app", key: "function-configuration") {
+        id
+        value
+      }
       automaticDiscount {
         ... on DiscountAutomaticApp {
           title
-          configurationField: metafield(namespace: 'discount-functions-sample-app', key: 'function-configuration') {
-            id
-            value
-          }
           startsAt
           endsAt
         }
@@ -38,8 +38,8 @@ export function useSavedDiscount(id) {
       title,
       startsAt,
       endsAt,
-      configurationField,
     } = data.data.automaticDiscountNode.automaticDiscount;
+    const {configurationField} = data.data.automaticDiscountNode;
 
     return {
       title,

--- a/sample-apps/discount-functions-sample-app/web/frontend/utilities/serializeDiscount.js
+++ b/sample-apps/discount-functions-sample-app/web/frontend/utilities/serializeDiscount.js
@@ -1,7 +1,26 @@
 export function serializeDiscount(discount) {
-  return {
+  const METAFIELD_NAMESPACE = 'discount-functions-sample-app';
+  const METAFIELD_CONFIGURATION_KEY = 'function-configuration';
+
+  const serialized = {
     title: discount.title,
-    configuration: JSON.stringify(discount.configuration),
     startsAt: new Date(),
+    discountClass: discount.discountClass,
+    metafields: [
+      // store configuration in app metafield
+      {
+        namespace: METAFIELD_NAMESPACE,
+        key: METAFIELD_CONFIGURATION_KEY,
+        type: 'json',
+        value: JSON.stringify(discount.configuration)
+      }
+    ]
   };
+
+  // metafield id is required for update
+  if (discount.configurationId) {
+    serialized.metafields[0].id = discount.configurationId;
+  }
+
+  return serialized;
 }


### PR DESCRIPTION
Part of https://github.com/Shopify/script-service/issues/5030

🎩 

```shell
yarn create @shopify/app --template https://github.com/Shopify/scripts-apis-examples/sample-apps/discount-functions-sample-app#discounts/sample-app-config
```

```shell
export WASM_OPT=/opt/homebrew/bin/wasm-opt
```

```shell
yarn build
```

```shell
yarn deploy
```

### Create pages

- `/product-discount/new`
- `/order-discount/new`
- `/shipping-discount/new`