### PR TITLE
Remove metaobject and version fields from toml files

### DIFF
--- a/checkout/wasm/payment-methods/default/shopify.function.extension.toml.liquid
+++ b/checkout/wasm/payment-methods/default/shopify.function.extension.toml.liquid
@@ -1,13 +1,7 @@
 name = "{{name}}"
 type = "{{extensionType}}"
-version = "2"
 description = "Payment methods base script"
 api_version = "2022-07"
-
-[meta_object]
-type = "object"
-
-[meta_object.fields]
 
 [build]
 command = "echo 'build the wasm'"

--- a/checkout/wasm/shipping-methods/default/shopify.function.extension.toml.liquid
+++ b/checkout/wasm/shipping-methods/default/shopify.function.extension.toml.liquid
@@ -1,14 +1,7 @@
 name = "{{name}}"
 type = "{{extensionType}}"
-version = "2"
 description = "Shipping methods base script"
 api_version = "2022-07"
-
-[meta_object]
-type = "object"
-
-[meta_object.fields]
-
 
 [build]
 command = "echo 'build the wasm'"

--- a/checkout/wasm/shipping-rate-presenter/default/shopify.function.extension.toml.liquid
+++ b/checkout/wasm/shipping-rate-presenter/default/shopify.function.extension.toml.liquid
@@ -1,14 +1,7 @@
 name = "{{name}}"
 type = "{{extensionType}}"
-version = "2"
 description = "Shipping methods base script"
 api_version = "2022-07"
-
-[meta_object]
-type = "object"
-
-[meta_object.fields]
-
 
 [build]
 command = "echo 'build the wasm'"

--- a/checkout/wasm/shipping-rates-consolidation/default/shopify.function.extension.toml.liquid
+++ b/checkout/wasm/shipping-rates-consolidation/default/shopify.function.extension.toml.liquid
@@ -1,14 +1,7 @@
 name = "{{name}}"
 type = "{{extensionType}}"
-version = "2"
 description = "Shipping rates consolidation base script"
 api_version = "2022-07"
-
-[meta_object]
-type = "object"
-
-[meta_object.fields]
-
 
 [build]
 command = "echo 'build the wasm'"

--- a/discounts/rust/order-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/rust/order-discounts/default/shopify.function.extension.toml.liquid
@@ -1,12 +1,6 @@
 name = "{{name}}"
 type = "{{extensionType}}"
-version = "2"
 api_version = "2022-07"
-
-[meta_object]
-type = "object"
-
-[meta_object.fields]
 
 [build]
 command = "cargo wasi build --release"

--- a/discounts/rust/product-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/rust/product-discounts/default/shopify.function.extension.toml.liquid
@@ -1,12 +1,6 @@
 name = "{{name}}"
 type = "{{extensionType}}"
-version = "2"
 api_version = "2022-07"
-
-[meta_object]
-type = "object"
-
-[meta_object.fields]
 
 [build]
 command = "cargo wasi build --release"

--- a/discounts/rust/shipping-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/rust/shipping-discounts/default/shopify.function.extension.toml.liquid
@@ -1,12 +1,6 @@
 name = "{{name}}"
 type = "{{extensionType}}"
-version = "2"
 api_version = "2022-07"
-
-[meta_object]
-type = "object"
-
-[meta_object.fields]
 
 [build]
 command = "cargo wasi build --release"

--- a/discounts/wasm/order-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/wasm/order-discounts/default/shopify.function.extension.toml.liquid
@@ -1,13 +1,6 @@
 name = "{{name}}"
 type = "{{extensionType}}"
-version = "2"
 api_version = "2022-07"
-
-[meta_object]
-type = "object"
-
-[meta_object.fields]
-
 
 [build]
 command = "echo 'build the wasm'"

--- a/discounts/wasm/product-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/wasm/product-discounts/default/shopify.function.extension.toml.liquid
@@ -1,12 +1,6 @@
 name = "{{name}}"
 type = "{{extensionType}}"
-version = "2"
 api_version = "2022-07"
-
-[meta_object]
-type = "object"
-
-[meta_object.fields]
 
 [build]
 command = "echo 'build the wasm'"

--- a/discounts/wasm/shipping-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/wasm/shipping-discounts/default/shopify.function.extension.toml.liquid
@@ -1,13 +1,6 @@
 name = "{{name}}"
 type = "{{extensionType}}"
-version = "2"
 api_version = "2022-07"
-
-[meta_object]
-type = "object"
-
-[meta_object.fields]
-
 
 [build]
 command = "echo 'build the wasm'"

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/shopify.function.extension.toml
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/shopify.function.extension.toml
@@ -1,12 +1,6 @@
 name = "Order Discount"
 type = "order_discounts"
-version = "2"
 api_version = "2022-07"
-
-[meta_object]
-type = "object"
-
-[meta_object.fields]
 
 [ui.paths]
 create = "/order-discount/new"

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/shopify.function.extension.toml
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/shopify.function.extension.toml
@@ -1,12 +1,6 @@
 name = "Product Discount"
 type = "product_discounts"
-version = "2"
 api_version = "2022-07"
-
-[meta_object]
-type = "object"
-
-[meta_object.fields]
 
 [ui.paths]
 create = "/product-discount/new"

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/shopify.function.extension.toml
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/shopify.function.extension.toml
@@ -1,12 +1,6 @@
 name = "Shipping Discount"
 type = "shipping_discounts"
-version = "2"
 api_version = "2022-07"
-
-[meta_object]
-type = "object"
-
-[meta_object.fields]
 
 [ui.paths]
 create = "/shipping-discount/new"


### PR DESCRIPTION
CLI 3.0 has been updated to stop sending configuration values on deploy. This means we can remove the `metaobject` and `version` fields from the toml files. 