### PR TITLE
[Discounts] Fixed amount examples

### DIFF
--- a/discounts/rust/order-discounts/default/Cargo.toml.liquid
+++ b/discounts/rust/order-discounts/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{name | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/order-discounts/default/Cargo.toml.liquid
+++ b/discounts/rust/order-discounts/default/Cargo.toml.liquid
@@ -2,7 +2,7 @@
 name = "{{name | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-include = ["*.graphql"]
+include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/order-discounts/default/schema.graphql
+++ b/discounts/rust/order-discounts/default/schema.graphql
@@ -3407,7 +3407,7 @@ input OrderMinimumSubtotal {
   """
   The minimum subtotal amount of the order.
   """
-  minimumAmount: Float!
+  minimumAmount: Decimal!
 
   """
   The target type of the condition.
@@ -3436,7 +3436,7 @@ input Percentage {
 
   The value is validated against: >= 0.
   """
-  value: Float!
+  value: Decimal!
 }
 
 """
@@ -3538,7 +3538,7 @@ input ProductMinimumSubtotal {
   """
   The minimum subtotal amount of the product.
   """
-  minimumAmount: Float!
+  minimumAmount: Decimal!
 
   """
   The target type of the condition.

--- a/discounts/rust/order-discounts/default/src/api.rs
+++ b/discounts/rust/order-discounts/default/src/api.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use serde_with::{serde_as, DisplayFromStr};
-
 pub type Boolean = bool;
 pub type Decimal = f64;
 pub type Int = i32;
@@ -17,12 +15,12 @@ pub mod input {
         pub discount_node: DiscountNode,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Metafield {
         pub value: String,
@@ -30,7 +28,7 @@ pub mod input {
 }
 
 use serde::Serialize;
-use serde_with::skip_serializing_none;
+use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]

--- a/discounts/rust/order-discounts/default/src/api.rs
+++ b/discounts/rust/order-discounts/default/src/api.rs
@@ -1,11 +1,12 @@
 #![allow(dead_code)]
 
 pub type Boolean = bool;
-pub type Float = f64;
+pub type Decimal = String;
 pub type Int = i32;
 pub type ID = String;
 
 pub mod input {
+    use super::*;
     use serde::Deserialize;
 
     #[derive(Clone, Debug, Deserialize)]
@@ -60,14 +61,13 @@ pub enum Value {
 }
 
 #[derive(Clone, Debug, Serialize)]
-#[serde(rename_all(serialize = "camelCase"))]
 pub struct FixedAmount {
-    pub value: Float,
+    pub amount: Decimal,
 }
 
 #[derive(Clone, Debug, Serialize)]
 pub struct Percentage {
-    pub value: Float,
+    pub value: Decimal,
 }
 
 #[skip_serializing_none]
@@ -90,7 +90,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     OrderMinimumSubtotal {
         excluded_variant_ids: Vec<ID>,
-        minimum_amount: Float,
+        minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
     #[serde(rename_all(serialize = "camelCase"))]
@@ -102,7 +102,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
-        minimum_amount: Float,
+        minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
 }

--- a/discounts/rust/order-discounts/default/src/api.rs
+++ b/discounts/rust/order-discounts/default/src/api.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
+use serde_with::{serde_as, DisplayFromStr};
+
 pub type Boolean = bool;
-pub type Decimal = String;
+pub type Decimal = f64;
 pub type Int = i32;
 pub type ID = String;
 
@@ -53,21 +55,19 @@ pub struct Discount {
     pub conditions: Option<Vec<Condition>>,
 }
 
+#[skip_serializing_none]
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Value {
-    FixedAmount(FixedAmount),
-    Percentage(Percentage),
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct FixedAmount {
-    pub amount: Decimal,
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct Percentage {
-    pub value: Decimal,
+    FixedAmount {
+        #[serde_as(as = "DisplayFromStr")]
+        amount: Decimal,
+    },
+    Percentage {
+        #[serde_as(as = "DisplayFromStr")]
+        value: Decimal,
+    },
 }
 
 #[skip_serializing_none]

--- a/discounts/rust/order-discounts/default/src/api.rs
+++ b/discounts/rust/order-discounts/default/src/api.rs
@@ -9,18 +9,18 @@ pub mod input {
     use super::*;
     use serde::Deserialize;
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Metafield {
         pub value: String,
@@ -82,12 +82,14 @@ pub enum Target {
     },
 }
 
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     OrderMinimumSubtotal {
         excluded_variant_ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
@@ -100,6 +102,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },

--- a/discounts/rust/order-discounts/default/src/main.rs
+++ b/discounts/rust/order-discounts/default/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::Error>> {
-    let _config: Configuration = input.configuration();
+    let _config = input.configuration();
     Ok(FunctionResult {
         discounts: vec![],
         discount_application_strategy: DiscountApplicationStrategy::First,

--- a/discounts/rust/order-discounts/default/src/main.rs
+++ b/discounts/rust/order-discounts/default/src/main.rs
@@ -42,14 +42,28 @@ fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::E
 mod tests {
     use super::*;
 
-    fn input(configuration: Option<Configuration>) -> input::Input {
-        let discount_node = input::DiscountNode {
-            metafield: configuration.map(|value| {
-                let value = serde_json::to_string(&value).unwrap();
-                input::Metafield { value }
-            }),
-        };
-        input::Input { discount_node }
+    impl Default for input::Input {
+        fn default() -> Self {
+            let json = r#"
+            {
+                "discountNode": { "metafield": null }
+            }
+            "#;
+            serde_json::from_str(json).unwrap()
+        }
+    }
+
+    fn input(config: Option<Configuration>) -> input::Input {
+        let default_input = input::Input::default();
+        let discount_node = config.map(|value| {
+            let value = serde_json::to_string(&value).unwrap();
+            input::DiscountNode {
+                metafield: Some(input::Metafield { value }),
+            }
+        });
+        input::Input {
+            discount_node: discount_node.unwrap_or(default_input.discount_node),
+        }
     }
 
     #[test]

--- a/discounts/rust/order-discounts/default/src/main.rs
+++ b/discounts/rust/order-discounts/default/src/main.rs
@@ -8,8 +8,8 @@ use api::*;
 pub struct Configuration {}
 
 impl Configuration {
-    fn from_str(str: &str) -> Self {
-        serde_json::from_str(str).expect("Unable to parse configuration value from metafield")
+    fn from_str(value: &str) -> Self {
+        serde_json::from_str(value).expect("Unable to parse configuration value from metafield")
     }
 }
 

--- a/discounts/rust/order-discounts/fixed-amount/.gitignore
+++ b/discounts/rust/order-discounts/fixed-amount/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/discounts/rust/order-discounts/fixed-amount/Cargo.toml
+++ b/discounts/rust/order-discounts/fixed-amount/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fixed-amount"
+version = "1.0.0"
+edition = "2021"
+include = ["*.graphql"]
+
+[dependencies]
+serde = { version = "1.0.13", features = ["derive"] }
+serde_with = "1.13.0"
+serde_json = "1.0"
+
+[profile.release]
+lto = true
+opt-level = 'z'
+strip = true

--- a/discounts/rust/order-discounts/fixed-amount/Cargo.toml
+++ b/discounts/rust/order-discounts/fixed-amount/Cargo.toml
@@ -2,7 +2,6 @@
 name = "fixed-amount"
 version = "1.0.0"
 edition = "2021"
-include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/order-discounts/fixed-amount/Cargo.toml
+++ b/discounts/rust/order-discounts/fixed-amount/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fixed-amount"
 version = "1.0.0"
 edition = "2021"
-include = ["*.graphql"]
+include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/order-discounts/fixed-amount/README.md
+++ b/discounts/rust/order-discounts/fixed-amount/README.md
@@ -1,0 +1,21 @@
+# Shopify Function development with Rust
+
+## Dependencies
+
+- [Install Rust](https://www.rust-lang.org/tools/install)
+  - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
+- Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
+  - `cargo install cargo-wasi`
+- On Macs with Apple Silicon, you'll also need to install the Binaryen toolchain and set the `WASM_OPT` environment variable. ([related issue](https://github.com/bytecodealliance/cargo-wasi/issues/112))
+  - `brew install binaryen`
+  - Add `export WASM_OPT=/opt/homebrew/bin/wasm-opt` to your `.bashrc` or `.zshrc`
+
+## Building the function
+
+You can build this individual function using `cargo wasi`.
+
+```shell
+cargo wasi build --release
+```
+
+The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.function.extension.toml`.

--- a/discounts/rust/order-discounts/fixed-amount/input.graphql
+++ b/discounts/rust/order-discounts/fixed-amount/input.graphql
@@ -1,0 +1,7 @@
+query Input {
+  discountNode {
+    metafield(namespace: "fixed-amount", key: "function-configuration") {
+      value
+    }
+  }
+}

--- a/discounts/rust/order-discounts/fixed-amount/input.graphql
+++ b/discounts/rust/order-discounts/fixed-amount/input.graphql
@@ -4,4 +4,5 @@ query Input {
       value
     }
   }
+  presentmentCurrencyRate
 }

--- a/discounts/rust/order-discounts/fixed-amount/metadata.json
+++ b/discounts/rust/order-discounts/fixed-amount/metadata.json
@@ -1,0 +1,1 @@
+{"schemaVersions":{"order_discounts":{"major":1,"minor":0}}}

--- a/discounts/rust/order-discounts/fixed-amount/schema.graphql
+++ b/discounts/rust/order-discounts/fixed-amount/schema.graphql
@@ -224,9 +224,14 @@ type CartLineCost {
 }
 
 """
-The condition for when to apply the discount.
+The condition to apply the discount.
 """
 input Condition @oneOf {
+  """
+  The condition for checking the minimum subtotal amount of the order.
+  """
+  orderMinimumSubtotal: OrderMinimumSubtotal
+
   """
   The condition for checking the minimum quantity of a product.
   """
@@ -2410,7 +2415,7 @@ The discount to be applied.
 """
 input Discount {
   """
-  The condition for when the discount is applied.
+  The condition to apply the discount.
   """
   conditions: [Condition!]
 
@@ -2421,6 +2426,9 @@ input Discount {
 
   """
   The targets of the discount.
+
+  The value is validated against: targets should contain only one type of `Target`.
+  For example, targets that contain a list of `ProductVariantTarget` targets are valid.
   """
   targets: [Target!]!
 
@@ -2475,14 +2483,6 @@ input FixedAmount {
   The amount must be greater than or equal to 0.
   """
   amount: Decimal!
-
-  """
-  Whether to apply the value to each entitled item.
-
-  The default value is `false`, which causes the value to be applied once across the entitled items.
-  When the value is `true`, the value will be applied to each of the entitled items.
-  """
-  appliesToEachItem: Boolean
 }
 
 """
@@ -2671,6 +2671,38 @@ type MutationRoot {
 }
 
 """
+The condition for checking the minimum subtotal amount of the order.
+"""
+input OrderMinimumSubtotal {
+  """
+  Variant IDs with a merchandise line price that's excluded to calculate the minimum subtotal amount of the order.
+  """
+  excludedVariantIds: [ID!]!
+
+  """
+  The minimum subtotal amount of the order.
+  """
+  minimumAmount: Decimal!
+
+  """
+  The target type of the condition.
+
+   The value is validated against: = "ORDER_SUBTOTAL".
+  """
+  targetType: TargetType!
+}
+
+"""
+The subtotal of the target order.
+"""
+input OrderSubtotalTarget {
+  """
+  Variant IDs with a merchandise line price that's excluded for the minimum subtotal condition of the order.
+  """
+  excludedVariantIds: [ID!]!
+}
+
+"""
 A percentage value.
 """
 input Percentage {
@@ -2679,7 +2711,7 @@ input Percentage {
 
   The value is validated against: >= 0.
   """
-  value: Float!
+  value: Decimal!
 }
 
 """
@@ -2781,7 +2813,7 @@ input ProductMinimumSubtotal {
   """
   The minimum subtotal amount of the product.
   """
-  minimumAmount: Float!
+  minimumAmount: Decimal!
 
   """
   The target type of the condition.
@@ -2864,6 +2896,11 @@ The target of the discount.
 """
 input Target @oneOf {
   """
+  The subtotal of the target order.
+  """
+  orderSubtotal: OrderSubtotalTarget
+
+  """
   The target product variant.
   """
   productVariant: ProductVariantTarget
@@ -2885,7 +2922,7 @@ enum TargetType {
 }
 
 """
-The value of the discount.
+The discount value.
 """
 input Value @oneOf {
   """

--- a/discounts/rust/order-discounts/fixed-amount/schema.graphql
+++ b/discounts/rust/order-discounts/fixed-amount/schema.graphql
@@ -1,0 +1,2930 @@
+schema {
+  query: Input
+  mutation: MutationRoot
+}
+
+"""
+Exactly one field of input must be provided, and all others omitted.
+"""
+directive @oneOf on INPUT_OBJECT
+
+"""
+Represents a generic custom attribute.
+"""
+type Attribute {
+  """
+  Key or name of the attribute.
+  """
+  key: String!
+
+  """
+  Value of the attribute.
+  """
+  value: String
+}
+
+"""
+Represents information about the buyer that is interacting with the cart.
+"""
+type BuyerIdentity {
+  """
+  The customer associated with the cart.
+  """
+  customer: Customer
+
+  """
+  The email address of the buyer that is interacting with the cart.
+  """
+  email: String
+
+  """
+  The phone number of the buyer that is interacting with the cart.
+  """
+  phone: String
+}
+
+"""
+A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+"""
+type Cart {
+  """
+  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  """
+  attribute(
+    """
+    The key of the attribute to retrieve.
+    """
+    key: String
+  ): Attribute
+
+  """
+  Information about the buyer that is interacting with the cart.
+  """
+  buyerIdentity: BuyerIdentity
+
+  """
+  The costs that the buyer will pay at checkout.
+  """
+  cost: CartCost!
+
+  """
+  The delivery groups available for the cart based on the buyer's shipping address.
+  """
+  deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  A list of lines containing information about the items the customer intends to purchase.
+  """
+  lines: [CartLine!]!
+}
+
+"""
+The cost that the buyer will pay at checkout.
+"""
+type CartCost {
+  """
+  The amount, before taxes and discounts, for the customer to pay.
+  """
+  subtotalAmount: MoneyV2!
+
+  """
+  The total amount for the customer to pay.
+  """
+  totalAmount: MoneyV2!
+
+  """
+  The duty amount for the customer to pay at checkout.
+  """
+  totalDutyAmount: MoneyV2
+
+  """
+  The tax amount for the customer to pay at checkout.
+  """
+  totalTaxAmount: MoneyV2
+}
+
+"""
+Information about the options available for one or more line items to be delivered to a specific address.
+"""
+type CartDeliveryGroup {
+  """
+  A list of cart lines for the delivery group.
+  """
+  cartLines: [CartLine!]!
+
+  """
+  The destination address for the delivery group.
+  """
+  deliveryAddress: MailingAddress
+
+  """
+  The delivery options available for the delivery group.
+  """
+  deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  Unique identifier for the delivery group.
+  """
+  id: ID!
+
+  """
+  Information about the delivery option the buyer has selected.
+  """
+  selectedDeliveryOption: CartDeliveryOption
+}
+
+"""
+Information about a delivery option.
+"""
+type CartDeliveryOption {
+  """
+  The code of the delivery option.
+  """
+  code: String
+
+  """
+  The cost for the delivery option.
+  """
+  cost: MoneyV2!
+
+  """
+  The method for the delivery option.
+  """
+  deliveryMethodType: DeliveryMethod!
+
+  """
+  The description of the delivery option.
+  """
+  description: String
+
+  """
+  The title of the delivery option.
+  """
+  title: String
+}
+
+"""
+Represents information about the merchandise in the cart.
+"""
+type CartLine {
+  """
+  Retrieve a cart line attribute by key.
+  """
+  attribute(
+    """
+    The key of the attribute to retrieve.
+    """
+    key: String
+  ): Attribute
+
+  """
+  The cost of the merchandise line that the buyer will pay at checkout.
+  """
+  cost: CartLineCost!
+
+  """
+  The ID of the cart line.
+  """
+  id: ID!
+
+  """
+  The merchandise that the buyer intends to purchase.
+  """
+  merchandise: Merchandise!
+
+  """
+  The quantity of the merchandise that the customer intends to purchase.
+  """
+  quantity: Int!
+}
+
+"""
+The estimated cost of the merchandise line that the buyer will pay at checkout.
+"""
+type CartLineCost {
+  """
+  The amount of the merchandise line.
+  """
+  amount: MoneyV2!
+
+  """
+  The compare at amount of the merchandise line.
+  """
+  compareAtAmount: MoneyV2
+
+  """
+  The cost of the merchandise line before discounts.
+  """
+  subtotalAmount: MoneyV2!
+
+  """
+  The total cost of the merchandise line.
+  """
+  totalAmount: MoneyV2!
+}
+
+"""
+The condition for when to apply the discount.
+"""
+input Condition @oneOf {
+  """
+  The condition for checking the minimum quantity of a product.
+  """
+  productMinimumQuantity: ProductMinimumQuantity
+
+  """
+  The condition for checking the minimum subtotal amount of the product.
+  """
+  productMinimumSubtotal: ProductMinimumSubtotal
+}
+
+"""
+The code designating a country/region, which generally follows ISO 3166-1 alpha-2 guidelines.
+If a territory doesn't have a country code value in the `CountryCode` enum, it might be considered a subdivision
+of another country. For example, the territories associated with Spain are represented by the country code `ES`,
+and the territories associated with the United States of America are represented by the country code `US`.
+"""
+enum CountryCode {
+  """
+  Ascension Island.
+  """
+  AC
+
+  """
+  Andorra.
+  """
+  AD
+
+  """
+  United Arab Emirates.
+  """
+  AE
+
+  """
+  Afghanistan.
+  """
+  AF
+
+  """
+  Antigua & Barbuda.
+  """
+  AG
+
+  """
+  Anguilla.
+  """
+  AI
+
+  """
+  Albania.
+  """
+  AL
+
+  """
+  Armenia.
+  """
+  AM
+
+  """
+  Netherlands Antilles.
+  """
+  AN
+
+  """
+  Angola.
+  """
+  AO
+
+  """
+  Argentina.
+  """
+  AR
+
+  """
+  Austria.
+  """
+  AT
+
+  """
+  Australia.
+  """
+  AU
+
+  """
+  Aruba.
+  """
+  AW
+
+  """
+  Åland Islands.
+  """
+  AX
+
+  """
+  Azerbaijan.
+  """
+  AZ
+
+  """
+  Bosnia & Herzegovina.
+  """
+  BA
+
+  """
+  Barbados.
+  """
+  BB
+
+  """
+  Bangladesh.
+  """
+  BD
+
+  """
+  Belgium.
+  """
+  BE
+
+  """
+  Burkina Faso.
+  """
+  BF
+
+  """
+  Bulgaria.
+  """
+  BG
+
+  """
+  Bahrain.
+  """
+  BH
+
+  """
+  Burundi.
+  """
+  BI
+
+  """
+  Benin.
+  """
+  BJ
+
+  """
+  St. Barthélemy.
+  """
+  BL
+
+  """
+  Bermuda.
+  """
+  BM
+
+  """
+  Brunei.
+  """
+  BN
+
+  """
+  Bolivia.
+  """
+  BO
+
+  """
+  Caribbean Netherlands.
+  """
+  BQ
+
+  """
+  Brazil.
+  """
+  BR
+
+  """
+  Bahamas.
+  """
+  BS
+
+  """
+  Bhutan.
+  """
+  BT
+
+  """
+  Bouvet Island.
+  """
+  BV
+
+  """
+  Botswana.
+  """
+  BW
+
+  """
+  Belarus.
+  """
+  BY
+
+  """
+  Belize.
+  """
+  BZ
+
+  """
+  Canada.
+  """
+  CA
+
+  """
+  Cocos (Keeling) Islands.
+  """
+  CC
+
+  """
+  Congo - Kinshasa.
+  """
+  CD
+
+  """
+  Central African Republic.
+  """
+  CF
+
+  """
+  Congo - Brazzaville.
+  """
+  CG
+
+  """
+  Switzerland.
+  """
+  CH
+
+  """
+  Côte d’Ivoire.
+  """
+  CI
+
+  """
+  Cook Islands.
+  """
+  CK
+
+  """
+  Chile.
+  """
+  CL
+
+  """
+  Cameroon.
+  """
+  CM
+
+  """
+  China.
+  """
+  CN
+
+  """
+  Colombia.
+  """
+  CO
+
+  """
+  Costa Rica.
+  """
+  CR
+
+  """
+  Cuba.
+  """
+  CU
+
+  """
+  Cape Verde.
+  """
+  CV
+
+  """
+  Curaçao.
+  """
+  CW
+
+  """
+  Christmas Island.
+  """
+  CX
+
+  """
+  Cyprus.
+  """
+  CY
+
+  """
+  Czechia.
+  """
+  CZ
+
+  """
+  Germany.
+  """
+  DE
+
+  """
+  Djibouti.
+  """
+  DJ
+
+  """
+  Denmark.
+  """
+  DK
+
+  """
+  Dominica.
+  """
+  DM
+
+  """
+  Dominican Republic.
+  """
+  DO
+
+  """
+  Algeria.
+  """
+  DZ
+
+  """
+  Ecuador.
+  """
+  EC
+
+  """
+  Estonia.
+  """
+  EE
+
+  """
+  Egypt.
+  """
+  EG
+
+  """
+  Western Sahara.
+  """
+  EH
+
+  """
+  Eritrea.
+  """
+  ER
+
+  """
+  Spain.
+  """
+  ES
+
+  """
+  Ethiopia.
+  """
+  ET
+
+  """
+  Finland.
+  """
+  FI
+
+  """
+  Fiji.
+  """
+  FJ
+
+  """
+  Falkland Islands.
+  """
+  FK
+
+  """
+  Faroe Islands.
+  """
+  FO
+
+  """
+  France.
+  """
+  FR
+
+  """
+  Gabon.
+  """
+  GA
+
+  """
+  United Kingdom.
+  """
+  GB
+
+  """
+  Grenada.
+  """
+  GD
+
+  """
+  Georgia.
+  """
+  GE
+
+  """
+  French Guiana.
+  """
+  GF
+
+  """
+  Guernsey.
+  """
+  GG
+
+  """
+  Ghana.
+  """
+  GH
+
+  """
+  Gibraltar.
+  """
+  GI
+
+  """
+  Greenland.
+  """
+  GL
+
+  """
+  Gambia.
+  """
+  GM
+
+  """
+  Guinea.
+  """
+  GN
+
+  """
+  Guadeloupe.
+  """
+  GP
+
+  """
+  Equatorial Guinea.
+  """
+  GQ
+
+  """
+  Greece.
+  """
+  GR
+
+  """
+  South Georgia & South Sandwich Islands.
+  """
+  GS
+
+  """
+  Guatemala.
+  """
+  GT
+
+  """
+  Guinea-Bissau.
+  """
+  GW
+
+  """
+  Guyana.
+  """
+  GY
+
+  """
+  Hong Kong SAR.
+  """
+  HK
+
+  """
+  Heard & McDonald Islands.
+  """
+  HM
+
+  """
+  Honduras.
+  """
+  HN
+
+  """
+  Croatia.
+  """
+  HR
+
+  """
+  Haiti.
+  """
+  HT
+
+  """
+  Hungary.
+  """
+  HU
+
+  """
+  Indonesia.
+  """
+  ID
+
+  """
+  Ireland.
+  """
+  IE
+
+  """
+  Israel.
+  """
+  IL
+
+  """
+  Isle of Man.
+  """
+  IM
+
+  """
+  India.
+  """
+  IN
+
+  """
+  British Indian Ocean Territory.
+  """
+  IO
+
+  """
+  Iraq.
+  """
+  IQ
+
+  """
+  Iran.
+  """
+  IR
+
+  """
+  Iceland.
+  """
+  IS
+
+  """
+  Italy.
+  """
+  IT
+
+  """
+  Jersey.
+  """
+  JE
+
+  """
+  Jamaica.
+  """
+  JM
+
+  """
+  Jordan.
+  """
+  JO
+
+  """
+  Japan.
+  """
+  JP
+
+  """
+  Kenya.
+  """
+  KE
+
+  """
+  Kyrgyzstan.
+  """
+  KG
+
+  """
+  Cambodia.
+  """
+  KH
+
+  """
+  Kiribati.
+  """
+  KI
+
+  """
+  Comoros.
+  """
+  KM
+
+  """
+  St. Kitts & Nevis.
+  """
+  KN
+
+  """
+  North Korea.
+  """
+  KP
+
+  """
+  South Korea.
+  """
+  KR
+
+  """
+  Kuwait.
+  """
+  KW
+
+  """
+  Cayman Islands.
+  """
+  KY
+
+  """
+  Kazakhstan.
+  """
+  KZ
+
+  """
+  Laos.
+  """
+  LA
+
+  """
+  Lebanon.
+  """
+  LB
+
+  """
+  St. Lucia.
+  """
+  LC
+
+  """
+  Liechtenstein.
+  """
+  LI
+
+  """
+  Sri Lanka.
+  """
+  LK
+
+  """
+  Liberia.
+  """
+  LR
+
+  """
+  Lesotho.
+  """
+  LS
+
+  """
+  Lithuania.
+  """
+  LT
+
+  """
+  Luxembourg.
+  """
+  LU
+
+  """
+  Latvia.
+  """
+  LV
+
+  """
+  Libya.
+  """
+  LY
+
+  """
+  Morocco.
+  """
+  MA
+
+  """
+  Monaco.
+  """
+  MC
+
+  """
+  Moldova.
+  """
+  MD
+
+  """
+  Montenegro.
+  """
+  ME
+
+  """
+  St. Martin.
+  """
+  MF
+
+  """
+  Madagascar.
+  """
+  MG
+
+  """
+  North Macedonia.
+  """
+  MK
+
+  """
+  Mali.
+  """
+  ML
+
+  """
+  Myanmar (Burma).
+  """
+  MM
+
+  """
+  Mongolia.
+  """
+  MN
+
+  """
+  Macao SAR.
+  """
+  MO
+
+  """
+  Martinique.
+  """
+  MQ
+
+  """
+  Mauritania.
+  """
+  MR
+
+  """
+  Montserrat.
+  """
+  MS
+
+  """
+  Malta.
+  """
+  MT
+
+  """
+  Mauritius.
+  """
+  MU
+
+  """
+  Maldives.
+  """
+  MV
+
+  """
+  Malawi.
+  """
+  MW
+
+  """
+  Mexico.
+  """
+  MX
+
+  """
+  Malaysia.
+  """
+  MY
+
+  """
+  Mozambique.
+  """
+  MZ
+
+  """
+  Namibia.
+  """
+  NA
+
+  """
+  New Caledonia.
+  """
+  NC
+
+  """
+  Niger.
+  """
+  NE
+
+  """
+  Norfolk Island.
+  """
+  NF
+
+  """
+  Nigeria.
+  """
+  NG
+
+  """
+  Nicaragua.
+  """
+  NI
+
+  """
+  Netherlands.
+  """
+  NL
+
+  """
+  Norway.
+  """
+  NO
+
+  """
+  Nepal.
+  """
+  NP
+
+  """
+  Nauru.
+  """
+  NR
+
+  """
+  Niue.
+  """
+  NU
+
+  """
+  New Zealand.
+  """
+  NZ
+
+  """
+  Oman.
+  """
+  OM
+
+  """
+  Panama.
+  """
+  PA
+
+  """
+  Peru.
+  """
+  PE
+
+  """
+  French Polynesia.
+  """
+  PF
+
+  """
+  Papua New Guinea.
+  """
+  PG
+
+  """
+  Philippines.
+  """
+  PH
+
+  """
+  Pakistan.
+  """
+  PK
+
+  """
+  Poland.
+  """
+  PL
+
+  """
+  St. Pierre & Miquelon.
+  """
+  PM
+
+  """
+  Pitcairn Islands.
+  """
+  PN
+
+  """
+  Palestinian Territories.
+  """
+  PS
+
+  """
+  Portugal.
+  """
+  PT
+
+  """
+  Paraguay.
+  """
+  PY
+
+  """
+  Qatar.
+  """
+  QA
+
+  """
+  Réunion.
+  """
+  RE
+
+  """
+  Romania.
+  """
+  RO
+
+  """
+  Serbia.
+  """
+  RS
+
+  """
+  Russia.
+  """
+  RU
+
+  """
+  Rwanda.
+  """
+  RW
+
+  """
+  Saudi Arabia.
+  """
+  SA
+
+  """
+  Solomon Islands.
+  """
+  SB
+
+  """
+  Seychelles.
+  """
+  SC
+
+  """
+  Sudan.
+  """
+  SD
+
+  """
+  Sweden.
+  """
+  SE
+
+  """
+  Singapore.
+  """
+  SG
+
+  """
+  St. Helena.
+  """
+  SH
+
+  """
+  Slovenia.
+  """
+  SI
+
+  """
+  Svalbard & Jan Mayen.
+  """
+  SJ
+
+  """
+  Slovakia.
+  """
+  SK
+
+  """
+  Sierra Leone.
+  """
+  SL
+
+  """
+  San Marino.
+  """
+  SM
+
+  """
+  Senegal.
+  """
+  SN
+
+  """
+  Somalia.
+  """
+  SO
+
+  """
+  Suriname.
+  """
+  SR
+
+  """
+  South Sudan.
+  """
+  SS
+
+  """
+  São Tomé & Príncipe.
+  """
+  ST
+
+  """
+  El Salvador.
+  """
+  SV
+
+  """
+  Sint Maarten.
+  """
+  SX
+
+  """
+  Syria.
+  """
+  SY
+
+  """
+  Eswatini.
+  """
+  SZ
+
+  """
+  Tristan da Cunha.
+  """
+  TA
+
+  """
+  Turks & Caicos Islands.
+  """
+  TC
+
+  """
+  Chad.
+  """
+  TD
+
+  """
+  French Southern Territories.
+  """
+  TF
+
+  """
+  Togo.
+  """
+  TG
+
+  """
+  Thailand.
+  """
+  TH
+
+  """
+  Tajikistan.
+  """
+  TJ
+
+  """
+  Tokelau.
+  """
+  TK
+
+  """
+  Timor-Leste.
+  """
+  TL
+
+  """
+  Turkmenistan.
+  """
+  TM
+
+  """
+  Tunisia.
+  """
+  TN
+
+  """
+  Tonga.
+  """
+  TO
+
+  """
+  Turkey.
+  """
+  TR
+
+  """
+  Trinidad & Tobago.
+  """
+  TT
+
+  """
+  Tuvalu.
+  """
+  TV
+
+  """
+  Taiwan.
+  """
+  TW
+
+  """
+  Tanzania.
+  """
+  TZ
+
+  """
+  Ukraine.
+  """
+  UA
+
+  """
+  Uganda.
+  """
+  UG
+
+  """
+  U.S. Outlying Islands.
+  """
+  UM
+
+  """
+  United States.
+  """
+  US
+
+  """
+  Uruguay.
+  """
+  UY
+
+  """
+  Uzbekistan.
+  """
+  UZ
+
+  """
+  Vatican City.
+  """
+  VA
+
+  """
+  St. Vincent & Grenadines.
+  """
+  VC
+
+  """
+  Venezuela.
+  """
+  VE
+
+  """
+  British Virgin Islands.
+  """
+  VG
+
+  """
+  Vietnam.
+  """
+  VN
+
+  """
+  Vanuatu.
+  """
+  VU
+
+  """
+  Wallis & Futuna.
+  """
+  WF
+
+  """
+  Samoa.
+  """
+  WS
+
+  """
+  Kosovo.
+  """
+  XK
+
+  """
+  Yemen.
+  """
+  YE
+
+  """
+  Mayotte.
+  """
+  YT
+
+  """
+  South Africa.
+  """
+  ZA
+
+  """
+  Zambia.
+  """
+  ZM
+
+  """
+  Zimbabwe.
+  """
+  ZW
+
+  """
+  Unknown Region.
+  """
+  ZZ
+}
+
+"""
+The three-letter currency codes that represent the world currencies used in
+stores. These include standard ISO 4217 codes, legacy codes,
+and non-standard codes.
+"""
+enum CurrencyCode {
+  """
+  United Arab Emirates Dirham (AED).
+  """
+  AED
+
+  """
+  Afghan Afghani (AFN).
+  """
+  AFN
+
+  """
+  Albanian Lek (ALL).
+  """
+  ALL
+
+  """
+  Armenian Dram (AMD).
+  """
+  AMD
+
+  """
+  Netherlands Antillean Guilder.
+  """
+  ANG
+
+  """
+  Angolan Kwanza (AOA).
+  """
+  AOA
+
+  """
+  Argentine Pesos (ARS).
+  """
+  ARS
+
+  """
+  Australian Dollars (AUD).
+  """
+  AUD
+
+  """
+  Aruban Florin (AWG).
+  """
+  AWG
+
+  """
+  Azerbaijani Manat (AZN).
+  """
+  AZN
+
+  """
+  Bosnia and Herzegovina Convertible Mark (BAM).
+  """
+  BAM
+
+  """
+  Barbadian Dollar (BBD).
+  """
+  BBD
+
+  """
+  Bangladesh Taka (BDT).
+  """
+  BDT
+
+  """
+  Bulgarian Lev (BGN).
+  """
+  BGN
+
+  """
+  Bahraini Dinar (BHD).
+  """
+  BHD
+
+  """
+  Burundian Franc (BIF).
+  """
+  BIF
+
+  """
+  Bermudian Dollar (BMD).
+  """
+  BMD
+
+  """
+  Brunei Dollar (BND).
+  """
+  BND
+
+  """
+  Bolivian Boliviano (BOB).
+  """
+  BOB
+
+  """
+  Brazilian Real (BRL).
+  """
+  BRL
+
+  """
+  Bahamian Dollar (BSD).
+  """
+  BSD
+
+  """
+  Bhutanese Ngultrum (BTN).
+  """
+  BTN
+
+  """
+  Botswana Pula (BWP).
+  """
+  BWP
+
+  """
+  Belarusian Ruble (BYN).
+  """
+  BYN
+
+  """
+  Belarusian Ruble (BYR).
+  """
+  BYR @deprecated(reason: "`BYR` is deprecated. Use `BYN` available from version `2021-01` onwards instead.")
+
+  """
+  Belize Dollar (BZD).
+  """
+  BZD
+
+  """
+  Canadian Dollars (CAD).
+  """
+  CAD
+
+  """
+  Congolese franc (CDF).
+  """
+  CDF
+
+  """
+  Swiss Francs (CHF).
+  """
+  CHF
+
+  """
+  Chilean Peso (CLP).
+  """
+  CLP
+
+  """
+  Chinese Yuan Renminbi (CNY).
+  """
+  CNY
+
+  """
+  Colombian Peso (COP).
+  """
+  COP
+
+  """
+  Costa Rican Colones (CRC).
+  """
+  CRC
+
+  """
+  Cape Verdean escudo (CVE).
+  """
+  CVE
+
+  """
+  Czech Koruny (CZK).
+  """
+  CZK
+
+  """
+  Djiboutian Franc (DJF).
+  """
+  DJF
+
+  """
+  Danish Kroner (DKK).
+  """
+  DKK
+
+  """
+  Dominican Peso (DOP).
+  """
+  DOP
+
+  """
+  Algerian Dinar (DZD).
+  """
+  DZD
+
+  """
+  Egyptian Pound (EGP).
+  """
+  EGP
+
+  """
+  Eritrean Nakfa (ERN).
+  """
+  ERN
+
+  """
+  Ethiopian Birr (ETB).
+  """
+  ETB
+
+  """
+  Euro (EUR).
+  """
+  EUR
+
+  """
+  Fijian Dollars (FJD).
+  """
+  FJD
+
+  """
+  Falkland Islands Pounds (FKP).
+  """
+  FKP
+
+  """
+  United Kingdom Pounds (GBP).
+  """
+  GBP
+
+  """
+  Georgian Lari (GEL).
+  """
+  GEL
+
+  """
+  Ghanaian Cedi (GHS).
+  """
+  GHS
+
+  """
+  Gibraltar Pounds (GIP).
+  """
+  GIP
+
+  """
+  Gambian Dalasi (GMD).
+  """
+  GMD
+
+  """
+  Guinean Franc (GNF).
+  """
+  GNF
+
+  """
+  Guatemalan Quetzal (GTQ).
+  """
+  GTQ
+
+  """
+  Guyanese Dollar (GYD).
+  """
+  GYD
+
+  """
+  Hong Kong Dollars (HKD).
+  """
+  HKD
+
+  """
+  Honduran Lempira (HNL).
+  """
+  HNL
+
+  """
+  Croatian Kuna (HRK).
+  """
+  HRK
+
+  """
+  Haitian Gourde (HTG).
+  """
+  HTG
+
+  """
+  Hungarian Forint (HUF).
+  """
+  HUF
+
+  """
+  Indonesian Rupiah (IDR).
+  """
+  IDR
+
+  """
+  Israeli New Shekel (NIS).
+  """
+  ILS
+
+  """
+  Indian Rupees (INR).
+  """
+  INR
+
+  """
+  Iraqi Dinar (IQD).
+  """
+  IQD
+
+  """
+  Iranian Rial (IRR).
+  """
+  IRR
+
+  """
+  Icelandic Kronur (ISK).
+  """
+  ISK
+
+  """
+  Jersey Pound.
+  """
+  JEP
+
+  """
+  Jamaican Dollars (JMD).
+  """
+  JMD
+
+  """
+  Jordanian Dinar (JOD).
+  """
+  JOD
+
+  """
+  Japanese Yen (JPY).
+  """
+  JPY
+
+  """
+  Kenyan Shilling (KES).
+  """
+  KES
+
+  """
+  Kyrgyzstani Som (KGS).
+  """
+  KGS
+
+  """
+  Cambodian Riel.
+  """
+  KHR
+
+  """
+  Kiribati Dollar (KID).
+  """
+  KID
+
+  """
+  Comorian Franc (KMF).
+  """
+  KMF
+
+  """
+  South Korean Won (KRW).
+  """
+  KRW
+
+  """
+  Kuwaiti Dinar (KWD).
+  """
+  KWD
+
+  """
+  Cayman Dollars (KYD).
+  """
+  KYD
+
+  """
+  Kazakhstani Tenge (KZT).
+  """
+  KZT
+
+  """
+  Laotian Kip (LAK).
+  """
+  LAK
+
+  """
+  Lebanese Pounds (LBP).
+  """
+  LBP
+
+  """
+  Sri Lankan Rupees (LKR).
+  """
+  LKR
+
+  """
+  Liberian Dollar (LRD).
+  """
+  LRD
+
+  """
+  Lesotho Loti (LSL).
+  """
+  LSL
+
+  """
+  Lithuanian Litai (LTL).
+  """
+  LTL
+
+  """
+  Latvian Lati (LVL).
+  """
+  LVL
+
+  """
+  Libyan Dinar (LYD).
+  """
+  LYD
+
+  """
+  Moroccan Dirham.
+  """
+  MAD
+
+  """
+  Moldovan Leu (MDL).
+  """
+  MDL
+
+  """
+  Malagasy Ariary (MGA).
+  """
+  MGA
+
+  """
+  Macedonia Denar (MKD).
+  """
+  MKD
+
+  """
+  Burmese Kyat (MMK).
+  """
+  MMK
+
+  """
+  Mongolian Tugrik.
+  """
+  MNT
+
+  """
+  Macanese Pataca (MOP).
+  """
+  MOP
+
+  """
+  Mauritanian Ouguiya (MRU).
+  """
+  MRU
+
+  """
+  Mauritian Rupee (MUR).
+  """
+  MUR
+
+  """
+  Maldivian Rufiyaa (MVR).
+  """
+  MVR
+
+  """
+  Malawian Kwacha (MWK).
+  """
+  MWK
+
+  """
+  Mexican Pesos (MXN).
+  """
+  MXN
+
+  """
+  Malaysian Ringgits (MYR).
+  """
+  MYR
+
+  """
+  Mozambican Metical.
+  """
+  MZN
+
+  """
+  Namibian Dollar.
+  """
+  NAD
+
+  """
+  Nigerian Naira (NGN).
+  """
+  NGN
+
+  """
+  Nicaraguan Córdoba (NIO).
+  """
+  NIO
+
+  """
+  Norwegian Kroner (NOK).
+  """
+  NOK
+
+  """
+  Nepalese Rupee (NPR).
+  """
+  NPR
+
+  """
+  New Zealand Dollars (NZD).
+  """
+  NZD
+
+  """
+  Omani Rial (OMR).
+  """
+  OMR
+
+  """
+  Panamian Balboa (PAB).
+  """
+  PAB
+
+  """
+  Peruvian Nuevo Sol (PEN).
+  """
+  PEN
+
+  """
+  Papua New Guinean Kina (PGK).
+  """
+  PGK
+
+  """
+  Philippine Peso (PHP).
+  """
+  PHP
+
+  """
+  Pakistani Rupee (PKR).
+  """
+  PKR
+
+  """
+  Polish Zlotych (PLN).
+  """
+  PLN
+
+  """
+  Paraguayan Guarani (PYG).
+  """
+  PYG
+
+  """
+  Qatari Rial (QAR).
+  """
+  QAR
+
+  """
+  Romanian Lei (RON).
+  """
+  RON
+
+  """
+  Serbian dinar (RSD).
+  """
+  RSD
+
+  """
+  Russian Rubles (RUB).
+  """
+  RUB
+
+  """
+  Rwandan Franc (RWF).
+  """
+  RWF
+
+  """
+  Saudi Riyal (SAR).
+  """
+  SAR
+
+  """
+  Solomon Islands Dollar (SBD).
+  """
+  SBD
+
+  """
+  Seychellois Rupee (SCR).
+  """
+  SCR
+
+  """
+  Sudanese Pound (SDG).
+  """
+  SDG
+
+  """
+  Swedish Kronor (SEK).
+  """
+  SEK
+
+  """
+  Singapore Dollars (SGD).
+  """
+  SGD
+
+  """
+  Saint Helena Pounds (SHP).
+  """
+  SHP
+
+  """
+  Sierra Leonean Leone (SLL).
+  """
+  SLL
+
+  """
+  Somali Shilling (SOS).
+  """
+  SOS
+
+  """
+  Surinamese Dollar (SRD).
+  """
+  SRD
+
+  """
+  South Sudanese Pound (SSP).
+  """
+  SSP
+
+  """
+  Sao Tome And Principe Dobra (STD).
+  """
+  STD @deprecated(reason: "`STD` is deprecated. Use `STN` available from version `2022-07` onwards instead.")
+
+  """
+  Sao Tome And Principe Dobra (STN).
+  """
+  STN
+
+  """
+  Syrian Pound (SYP).
+  """
+  SYP
+
+  """
+  Swazi Lilangeni (SZL).
+  """
+  SZL
+
+  """
+  Thai baht (THB).
+  """
+  THB
+
+  """
+  Tajikistani Somoni (TJS).
+  """
+  TJS
+
+  """
+  Turkmenistani Manat (TMT).
+  """
+  TMT
+
+  """
+  Tunisian Dinar (TND).
+  """
+  TND
+
+  """
+  Tongan Pa'anga (TOP).
+  """
+  TOP
+
+  """
+  Turkish Lira (TRY).
+  """
+  TRY
+
+  """
+  Trinidad and Tobago Dollars (TTD).
+  """
+  TTD
+
+  """
+  Taiwan Dollars (TWD).
+  """
+  TWD
+
+  """
+  Tanzanian Shilling (TZS).
+  """
+  TZS
+
+  """
+  Ukrainian Hryvnia (UAH).
+  """
+  UAH
+
+  """
+  Ugandan Shilling (UGX).
+  """
+  UGX
+
+  """
+  United States Dollars (USD).
+  """
+  USD
+
+  """
+  Uruguayan Pesos (UYU).
+  """
+  UYU
+
+  """
+  Uzbekistan som (UZS).
+  """
+  UZS
+
+  """
+  Venezuelan Bolivares (VED).
+  """
+  VED
+
+  """
+  Venezuelan Bolivares (VEF).
+  """
+  VEF @deprecated(reason: "`VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead.")
+
+  """
+  Venezuelan Bolivares (VES).
+  """
+  VES
+
+  """
+  Vietnamese đồng (VND).
+  """
+  VND
+
+  """
+  Vanuatu Vatu (VUV).
+  """
+  VUV
+
+  """
+  Samoan Tala (WST).
+  """
+  WST
+
+  """
+  Central African CFA Franc (XAF).
+  """
+  XAF
+
+  """
+  East Caribbean Dollar (XCD).
+  """
+  XCD
+
+  """
+  West African CFA franc (XOF).
+  """
+  XOF
+
+  """
+  CFP Franc (XPF).
+  """
+  XPF
+
+  """
+  Unrecognized currency.
+  """
+  XXX
+
+  """
+  Yemeni Rial (YER).
+  """
+  YER
+
+  """
+  South African Rand (ZAR).
+  """
+  ZAR
+
+  """
+  Zambian Kwacha (ZMW).
+  """
+  ZMW
+}
+
+"""
+A custom product.
+"""
+type CustomProduct {
+  """
+  Whether the merchandise is a gift card.
+  """
+  isGiftCard: Boolean!
+
+  """
+  Whether the merchandise requires shipping.
+  """
+  requiresShipping: Boolean!
+
+  """
+  The weight of the product variant in the unit system specified with `weight_unit`.
+  """
+  weight: Float
+
+  """
+  Unit of measurement for weight.
+  """
+  weightUnit: WeightUnit!
+}
+
+"""
+Represents a customer with the shop.
+"""
+type Customer implements HasMetafields {
+  """
+  The total amount of money spent by the customer.
+  """
+  amountSpent: MoneyV2!
+
+  """
+  The customer’s name, email or phone number.
+  """
+  displayName: String!
+
+  """
+  The customer’s email address.
+  """
+  email: String
+
+  """
+  Whether the customer has any of the given tags.
+  """
+  hasAnyTag(
+    """
+    The tags to search for.
+    """
+    tags: [String!]! = []
+  ): Boolean!
+
+  """
+  A unique identifier for the customer.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  The number of orders made by the customer.
+  """
+  numberOfOrders: Int!
+}
+
+"""
+A signed decimal number, which supports arbitrary precision and is serialized as a string.
+
+Example values: `"29.99"`, `"29.999"`.
+"""
+scalar Decimal
+
+"""
+List of different delivery method types.
+"""
+enum DeliveryMethod {
+  """
+  Local Delivery.
+  """
+  LOCAL
+
+  """
+  None.
+  """
+  NONE
+
+  """
+  Shipping to a Pickup Point.
+  """
+  PICKUP_POINT
+
+  """
+  Local Pickup.
+  """
+  PICK_UP
+
+  """
+  Retail.
+  """
+  RETAIL
+
+  """
+  Shipping.
+  """
+  SHIPPING
+}
+
+"""
+The discount to be applied.
+"""
+input Discount {
+  """
+  The condition for when the discount is applied.
+  """
+  conditions: [Condition!]
+
+  """
+  The discount message.
+  """
+  message: String
+
+  """
+  The targets of the discount.
+  """
+  targets: [Target!]!
+
+  """
+  The value of the discount.
+  """
+  value: Value!
+}
+
+"""
+The strategy that's applied to the list of discounts.
+"""
+enum DiscountApplicationStrategy {
+  """
+  Only apply the first discount with conditions that are satisfied.
+  """
+  FIRST
+
+  """
+  Only apply the discount that offers the maximum reduction.
+  """
+  MAXIMUM
+}
+
+"""
+A discount wrapper node.
+"""
+type DiscountNode implements HasMetafields {
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+}
+
+"""
+A fixed amount value.
+"""
+input FixedAmount {
+  """
+  The fixed amount value of the discount, in the currency of the cart.
+
+  The amount must be greater than or equal to 0.
+  """
+  amount: Decimal!
+
+  """
+  Whether to apply the value to each entitled item.
+
+  The default value is `false`, which causes the value to be applied once across the entitled items.
+  When the value is `true`, the value will be applied to each of the entitled items.
+  """
+  appliesToEachItem: Boolean
+}
+
+"""
+The result of the function.
+"""
+input FunctionResult {
+  """
+  The strategy to apply the list of discounts.
+  """
+  discountApplicationStrategy: DiscountApplicationStrategy!
+
+  """
+  The list of discounts to be applied.
+  """
+  discounts: [Discount!]!
+}
+
+"""
+Represents information about the metafields associated to the specified resource.
+"""
+interface HasMetafields {
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+}
+
+"""
+Represents a unique identifier that is Base64 obfuscated. It is often used to
+refetch an object or as key for a cache. The ID type appears in a JSON response
+as a String; however, it is not intended to be human-readable. When expected as
+an input type, any string (such as `"VXNlci0xMA=="`) or integer (such as `4`)
+input value will be accepted as an ID.
+"""
+scalar ID
+
+"""
+The input object for the function.
+"""
+type Input {
+  """
+  The cart to discount.
+  """
+  cart: Cart!
+
+  """
+  The discount node executing the function.
+  """
+  discountNode: DiscountNode!
+
+  """
+  The localization of the function execution context.
+  """
+  localization: Cart!
+
+  """
+  The conversion rate between the shop's currency and the currency of the cart.
+  """
+  presentmentCurrencyRate: Decimal
+}
+
+"""
+Represents a mailing address.
+"""
+type MailingAddress {
+  """
+  The first line of the address. Typically the street address or PO Box number.
+  """
+  address1: String
+
+  """
+  The second line of the address. Typically the number of the apartment, suite, or unit.
+  """
+  address2: String
+
+  """
+  The name of the city, district, village, or town.
+  """
+  city: String
+
+  """
+  The name of the customer's company or organization.
+  """
+  company: String
+
+  """
+  The two-letter code for the country of the address. For example, US.
+  """
+  countryCode: CountryCode
+
+  """
+  The first name of the customer.
+  """
+  firstName: String
+
+  """
+  The last name of the customer.
+  """
+  lastName: String
+
+  """
+  The full name of the customer, based on firstName and lastName.
+  """
+  name: String
+
+  """
+  A unique phone number for the customer. Formatted using E.164 standard. For example, +16135551111.
+  """
+  phone: String
+
+  """
+  The two-letter code for the region. For example, ON.
+  """
+  provinceCode: String
+
+  """
+  The zip or postal code of the address.
+  """
+  zip: String
+}
+
+"""
+The merchandise to be purchased at checkout.
+"""
+union Merchandise = CustomProduct | ProductVariant
+
+"""
+[Metafields](https://shopify.dev/apps/metafields)
+enable you to attach additional information to a
+Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
+or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
+For more information about the Shopify resources that you can attach metafields to, refer to
+[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+"""
+type Metafield {
+  """
+  The type of data that the metafield stores in the `value` field.
+  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  """
+  type: String!
+
+  """
+  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  """
+  value: String!
+}
+
+"""
+A monetary value with currency.
+"""
+type MoneyV2 {
+  """
+  Decimal money amount.
+  """
+  amount: Decimal!
+
+  """
+  Currency of the money.
+  """
+  currencyCode: CurrencyCode!
+}
+
+"""
+The root mutation for the API.
+"""
+type MutationRoot {
+  """
+  Handles the function result.
+  """
+  handleResult(
+    """
+    The result of the function.
+    """
+    result: FunctionResult!
+  ): Void!
+}
+
+"""
+A percentage value.
+"""
+input Percentage {
+  """
+  The percentage value.
+
+  The value is validated against: >= 0.
+  """
+  value: Float!
+}
+
+"""
+Represents a product.
+"""
+type Product implements HasMetafields {
+  """
+  A unique human-friendly string of the product's title.
+  """
+  handle: String!
+
+  """
+  Whether the product has any of the given tags.
+  """
+  hasAnyTag(
+    """
+    The tags to search for.
+    """
+    tags: [String!]! = []
+  ): Boolean!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Whether the product has any of the given collection.
+  """
+  inAnyCollection(
+    """
+    The collections to search for.
+    """
+    ids: [ID!]! = []
+  ): Boolean!
+
+  """
+  Whether the product is a gift card.
+  """
+  isGiftCard: Boolean!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  The product type specified by the merchant.
+  """
+  productType: String
+
+  """
+  The name of the product's vendor.
+  """
+  vendor: String
+}
+
+"""
+The condition for checking the minimum quantity of a product.
+"""
+input ProductMinimumQuantity {
+  """
+  Variant IDs with a merchandise line price that's included to calculate the minimum quantity of the product.
+  """
+  ids: [ID!]!
+
+  """
+  The minimum quantity of a product.
+  """
+  minimumQuantity: Int!
+
+  """
+  The target type of the condition.
+
+  The value is validated against: = "PRODUCT_VARIANT".
+  """
+  targetType: TargetType!
+}
+
+"""
+The condition for checking the minimum subtotal amount of the product.
+"""
+input ProductMinimumSubtotal {
+  """
+  Variant IDs with a merchandise line price that's included to calculate the minimum subtotal amount of a product.
+  """
+  ids: [ID!]!
+
+  """
+  The minimum subtotal amount of the product.
+  """
+  minimumAmount: Float!
+
+  """
+  The target type of the condition.
+
+  The value is validated against: = "PRODUCT_VARIANT".
+  """
+  targetType: TargetType!
+}
+
+"""
+Represents a product variant.
+"""
+type ProductVariant implements HasMetafields {
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  The product that this variant belongs to.
+  """
+  product: Product!
+
+  """
+  Whether the merchandise requires shipping.
+  """
+  requiresShipping: Boolean!
+
+  """
+  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  """
+  sku: String
+
+  """
+  The weight of the product variant in the unit system specified with `weight_unit`.
+  """
+  weight: Float
+
+  """
+  Unit of measurement for weight.
+  """
+  weightUnit: WeightUnit!
+}
+
+"""
+The target product variant.
+"""
+input ProductVariantTarget {
+  """
+  The ID of the target product variant.
+  """
+  id: ID!
+
+  """
+  The number of line items that are being discounted.
+  The default value is `null`, which represents the quantity of the matching line items.
+
+  The value is validated against: > 0.
+  """
+  quantity: Int
+}
+
+"""
+The target of the discount.
+"""
+input Target @oneOf {
+  """
+  The target product variant.
+  """
+  productVariant: ProductVariantTarget
+}
+
+"""
+The target type of a condition.
+"""
+enum TargetType {
+  """
+  The target is the subtotal of the order.
+  """
+  ORDER_SUBTOTAL
+
+  """
+  The target is a product variant.
+  """
+  PRODUCT_VARIANT
+}
+
+"""
+The value of the discount.
+"""
+input Value @oneOf {
+  """
+  A fixed amount value.
+  """
+  fixedAmount: FixedAmount
+
+  """
+  A percentage value.
+  """
+  percentage: Percentage
+}
+
+"""
+A void type that can be used to return a null value from a mutation.
+"""
+scalar Void
+
+"""
+Units of measurement for weight.
+"""
+enum WeightUnit {
+  """
+  Metric system unit of mass.
+  """
+  GRAMS
+
+  """
+  1 kilogram equals 1000 grams.
+  """
+  KILOGRAMS
+
+  """
+  Imperial system unit of mass.
+  """
+  OUNCES
+
+  """
+  1 pound equals 16 ounces.
+  """
+  POUNDS
+}

--- a/discounts/rust/order-discounts/fixed-amount/shopify.function.extension.toml
+++ b/discounts/rust/order-discounts/fixed-amount/shopify.function.extension.toml
@@ -1,0 +1,7 @@
+name = "Fixed Amount Off Order"
+type = "order_discounts"
+api_version = "2022-07"
+
+[build]
+command = "cargo wasi build --release"
+path = "target/wasm32-wasi/release/fixed-amount.wasm"

--- a/discounts/rust/order-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/order-discounts/fixed-amount/src/api.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use serde_with::{serde_as, DisplayFromStr};
-
 pub type Boolean = bool;
 pub type Decimal = f64;
 pub type Int = i32;
@@ -16,22 +14,23 @@ pub mod input {
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
+        #[serde_as(as = "DisplayFromStr")]
         pub presentment_currency_rate: Decimal,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct Metafield {
         pub value: String,
     }
 }
 
 use serde::Serialize;
-use serde_with::skip_serializing_none;
+use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
@@ -85,12 +84,14 @@ pub enum Target {
     },
 }
 
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     OrderMinimumSubtotal {
         excluded_variant_ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
@@ -103,6 +104,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },

--- a/discounts/rust/order-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/order-discounts/fixed-amount/src/api.rs
@@ -13,7 +13,6 @@ pub mod input {
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
-        pub cart: Cart,
         pub presentment_currency_rate: Decimal,
     }
 
@@ -25,22 +24,6 @@ pub mod input {
     #[derive(Clone, Debug, Deserialize, Default)]
     pub struct Metafield {
         pub value: String,
-    }
-
-    #[derive(Clone, Debug, Deserialize)]
-    pub struct Cart {
-        pub lines: Vec<CartLine>,
-    }
-
-    #[derive(Clone, Debug, Deserialize)]
-    pub struct CartLine {
-        pub id: ID,
-        pub merchandise: Merchandise,
-    }
-
-    #[derive(Clone, Debug, Deserialize)]
-    pub struct Merchandise {
-        pub id: Option<ID>,
     }
 }
 

--- a/discounts/rust/order-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/order-discounts/fixed-amount/src/api.rs
@@ -13,6 +13,8 @@ pub mod input {
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
+        pub cart: Cart,
+        pub presentment_currency_rate: Decimal,
     }
 
     #[derive(Clone, Debug, Deserialize, Default)]
@@ -23,6 +25,22 @@ pub mod input {
     #[derive(Clone, Debug, Deserialize, Default)]
     pub struct Metafield {
         pub value: String,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct Cart {
+        pub lines: Vec<CartLine>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct CartLine {
+        pub id: ID,
+        pub merchandise: Merchandise,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct Merchandise {
+        pub id: Option<ID>,
     }
 }
 
@@ -73,7 +91,14 @@ pub struct Percentage {
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Target {
-    DeliveryGroup { id: ID },
+    #[serde(rename_all(serialize = "camelCase"))]
+    OrderSubtotal {
+        excluded_variant_ids: Vec<ID>,
+    },
+    ProductVariant {
+        id: ID,
+        quantity: Option<Int>,
+    },
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/discounts/rust/order-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/order-discounts/fixed-amount/src/api.rs
@@ -10,7 +10,7 @@ pub mod input {
     use serde::Deserialize;
 
     #[serde_as]
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
@@ -18,12 +18,12 @@ pub mod input {
         pub presentment_currency_rate: Decimal,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct Metafield {
         pub value: String,
     }

--- a/discounts/rust/order-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/order-discounts/fixed-amount/src/api.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
+use serde_with::{serde_as, DisplayFromStr};
+
 pub type Boolean = bool;
-pub type Decimal = String;
+pub type Decimal = f64;
 pub type Int = i32;
 pub type ID = String;
 
@@ -9,6 +11,7 @@ pub mod input {
     use super::*;
     use serde::Deserialize;
 
+    #[serde_as]
     #[derive(Clone, Debug, Deserialize)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
@@ -53,21 +56,19 @@ pub struct Discount {
     pub conditions: Option<Vec<Condition>>,
 }
 
+#[skip_serializing_none]
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Value {
-    FixedAmount(FixedAmount),
-    Percentage(Percentage),
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct FixedAmount {
-    pub amount: Decimal,
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct Percentage {
-    pub value: Decimal,
+    FixedAmount {
+        #[serde_as(as = "DisplayFromStr")]
+        amount: Decimal,
+    },
+    Percentage {
+        #[serde_as(as = "DisplayFromStr")]
+        value: Decimal,
+    },
 }
 
 #[skip_serializing_none]

--- a/discounts/rust/order-discounts/fixed-amount/src/main.rs
+++ b/discounts/rust/order-discounts/fixed-amount/src/main.rs
@@ -156,4 +156,15 @@ mod tests {
         });
         assert_eq!(handle_result, expected_handle_result);
     }
+
+    #[test]
+    fn test_input_deserialization() {
+        let input = r#"
+        {
+            "discountNode": { "metafield": null },
+            "presentmentCurrencyRate": "1.00"
+        }
+        "#;
+        assert!(serde_json::from_str::<input::Input>(input).is_ok());
+    }
 }

--- a/discounts/rust/order-discounts/fixed-amount/src/main.rs
+++ b/discounts/rust/order-discounts/fixed-amount/src/main.rs
@@ -43,21 +43,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::Error>> {
-    let config: Configuration = input.configuration();
-
-    let converted_value = convert_to_cart_currency(config.value, &input);
+    let config = input.configuration();
+    let converted_value = convert_to_cart_currency(config.value, input.presentment_currency_rate);
     let targets = vec![Target::OrderSubtotal {
         excluded_variant_ids: vec![],
     }];
     Ok(build_result(converted_value, targets))
 }
 
-fn convert_to_cart_currency(value: f64, input: &input::Input) -> f64 {
-    let rate = &input.presentment_currency_rate;
-    value
-        * rate
-            .parse::<f64>()
-            .expect("presentment_currency_rate is malformed.")
+fn convert_to_cart_currency(value: f64, presentment_currency_rate: f64) -> f64 {
+    value * presentment_currency_rate
 }
 
 fn build_result(amount: f64, targets: Vec<Target>) -> FunctionResult {
@@ -68,9 +63,7 @@ fn build_result(amount: f64, targets: Vec<Target>) -> FunctionResult {
             message: None,
             conditions: None,
             targets,
-            value: Value::FixedAmount(FixedAmount {
-                amount: format!("{}", amount),
-            }),
+            value: Value::FixedAmount { amount },
         }]
     };
     FunctionResult {
@@ -84,17 +77,16 @@ mod tests {
     use super::*;
 
     fn input(
-        configuration: Option<Configuration>,
+        config: Option<Configuration>,
         presentment_currency_rate: Option<Decimal>,
     ) -> input::Input {
         let discount_node = input::DiscountNode {
-            metafield: configuration.map(|value| {
+            metafield: config.map(|value| {
                 let value = serde_json::to_string(&value).unwrap();
                 input::Metafield { value }
             }),
         };
-        let presentment_currency_rate =
-            presentment_currency_rate.unwrap_or_else(|| "1.00".to_string());
+        let presentment_currency_rate = presentment_currency_rate.unwrap_or(1.00);
         input::Input {
             discount_node,
             presentment_currency_rate,
@@ -137,10 +129,7 @@ mod tests {
 
     #[test]
     fn test_discount_with_presentment_currency_rate() {
-        let input = input(
-            Some(Configuration { value: 10.0 }),
-            Some("2.00".to_string()),
-        );
+        let input = input(Some(Configuration { value: 10.00 }), Some(2.00));
         let handle_result = serde_json::json!(function(input).unwrap());
 
         let expected_handle_result = serde_json::json!({

--- a/discounts/rust/order-discounts/fixed-amount/src/main.rs
+++ b/discounts/rust/order-discounts/fixed-amount/src/main.rs
@@ -1,0 +1,157 @@
+use serde::{Deserialize, Serialize};
+
+mod api;
+use api::*;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Configuration {
+    pub value: f64,
+}
+
+impl Configuration {
+    const DEFAULT_VALUE: f64 = 50.00;
+
+    fn from_str(str: &str) -> Self {
+        serde_json::from_str(str).expect("Unable to parse configuration value from metafield")
+    }
+}
+
+impl Default for Configuration {
+    fn default() -> Self {
+        Configuration {
+            value: Self::DEFAULT_VALUE,
+        }
+    }
+}
+
+impl input::Input {
+    pub fn configuration(&self) -> Configuration {
+        match &self.discount_node.metafield {
+            Some(input::Metafield { value }) => Configuration::from_str(value),
+            None => Configuration::default(),
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let input: input::Input = serde_json::from_reader(std::io::BufReader::new(std::io::stdin()))?;
+    let mut out = std::io::stdout();
+    let mut serializer = serde_json::Serializer::new(&mut out);
+    function(input)?.serialize(&mut serializer)?;
+    Ok(())
+}
+
+fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::Error>> {
+    let config: Configuration = input.configuration();
+
+    let converted_value = convert_to_cart_currency(config.value, &input);
+    let targets = vec![Target::OrderSubtotal {
+        excluded_variant_ids: vec![],
+    }];
+    Ok(build_result(converted_value, targets))
+}
+
+fn convert_to_cart_currency(value: f64, input: &input::Input) -> f64 {
+    let rate = &input.presentment_currency_rate;
+    value
+        * rate
+            .parse::<f64>()
+            .expect("presentment_currency_rate is malformed.")
+}
+
+fn build_result(amount: f64, targets: Vec<Target>) -> FunctionResult {
+    let discounts = if targets.is_empty() {
+        vec![]
+    } else {
+        vec![Discount {
+            message: None,
+            conditions: None,
+            targets,
+            value: Value::FixedAmount(FixedAmount {
+                amount: format!("{}", amount),
+            }),
+        }]
+    };
+    FunctionResult {
+        discounts,
+        discount_application_strategy: DiscountApplicationStrategy::First,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(
+        configuration: Option<Configuration>,
+        presentment_currency_rate: Option<Decimal>,
+    ) -> input::Input {
+        let discount_node = input::DiscountNode {
+            metafield: configuration.map(|value| {
+                let value = serde_json::to_string(&value).unwrap();
+                input::Metafield { value }
+            }),
+        };
+        let presentment_currency_rate =
+            presentment_currency_rate.unwrap_or_else(|| "1.00".to_string());
+        input::Input {
+            discount_node,
+            presentment_currency_rate,
+        }
+    }
+
+    #[test]
+    fn test_discount_with_no_configuration() {
+        let input = input(None, None);
+        let handle_result = serde_json::json!(function(input).unwrap());
+
+        let expected_handle_result = serde_json::json!({
+            "discounts": [
+                {
+                    "targets": [{ "orderSubtotal": { "excludedVariantIds": [] } }],
+                    "value": { "fixedAmount": { "amount": "50" } },
+                }
+            ],
+            "discountApplicationStrategy": "FIRST",
+        });
+        assert_eq!(handle_result, expected_handle_result);
+    }
+
+    #[test]
+    fn test_discount_with_value() {
+        let input = input(Some(Configuration { value: 12.34 }), None);
+        let handle_result = serde_json::json!(function(input).unwrap());
+
+        let expected_handle_result = serde_json::json!({
+            "discounts": [
+                {
+                    "targets": [{ "orderSubtotal": { "excludedVariantIds": [] } }],
+                    "value": { "fixedAmount": { "amount": "12.34" } },
+                }
+            ],
+            "discountApplicationStrategy": "FIRST",
+        });
+        assert_eq!(handle_result, expected_handle_result);
+    }
+
+    #[test]
+    fn test_discount_with_presentment_currency_rate() {
+        let input = input(
+            Some(Configuration { value: 10.0 }),
+            Some("2.00".to_string()),
+        );
+        let handle_result = serde_json::json!(function(input).unwrap());
+
+        let expected_handle_result = serde_json::json!({
+            "discounts": [
+                {
+                    "targets": [{ "orderSubtotal": { "excludedVariantIds": [] } }],
+                    "value": { "fixedAmount": { "amount": "20" } },
+                }
+            ],
+            "discountApplicationStrategy": "FIRST",
+        });
+        assert_eq!(handle_result, expected_handle_result);
+    }
+}

--- a/discounts/rust/order-discounts/fixed-amount/src/main.rs
+++ b/discounts/rust/order-discounts/fixed-amount/src/main.rs
@@ -12,8 +12,8 @@ pub struct Configuration {
 impl Configuration {
     const DEFAULT_VALUE: f64 = 50.00;
 
-    fn from_str(str: &str) -> Self {
-        serde_json::from_str(str).expect("Unable to parse configuration value from metafield")
+    fn from_str(value: &str) -> Self {
+        serde_json::from_str(value).expect("Unable to parse configuration value from metafield")
     }
 }
 

--- a/discounts/rust/order-discounts/fixed-amount/src/main.rs
+++ b/discounts/rust/order-discounts/fixed-amount/src/main.rs
@@ -76,20 +76,33 @@ fn build_result(amount: f64, targets: Vec<Target>) -> FunctionResult {
 mod tests {
     use super::*;
 
+    impl Default for input::Input {
+        fn default() -> Self {
+            let json = r#"
+            {
+                "discountNode": { "metafield": null },
+                "presentmentCurrencyRate": "1.00"
+            }
+            "#;
+            serde_json::from_str(json).unwrap()
+        }
+    }
+
     fn input(
         config: Option<Configuration>,
         presentment_currency_rate: Option<Decimal>,
     ) -> input::Input {
-        let discount_node = input::DiscountNode {
-            metafield: config.map(|value| {
-                let value = serde_json::to_string(&value).unwrap();
-                input::Metafield { value }
-            }),
-        };
-        let presentment_currency_rate = presentment_currency_rate.unwrap_or(1.00);
+        let default_input = input::Input::default();
+        let discount_node = config.map(|value| {
+            let value = serde_json::to_string(&value).unwrap();
+            input::DiscountNode {
+                metafield: Some(input::Metafield { value }),
+            }
+        });
         input::Input {
-            discount_node,
-            presentment_currency_rate,
+            discount_node: discount_node.unwrap_or(default_input.discount_node),
+            presentment_currency_rate: presentment_currency_rate
+                .unwrap_or(default_input.presentment_currency_rate),
         }
     }
 

--- a/discounts/rust/product-discounts/default/Cargo.toml.liquid
+++ b/discounts/rust/product-discounts/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{name | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/product-discounts/default/Cargo.toml.liquid
+++ b/discounts/rust/product-discounts/default/Cargo.toml.liquid
@@ -2,7 +2,7 @@
 name = "{{name | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-include = ["*.graphql"]
+include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/product-discounts/default/schema.graphql
+++ b/discounts/rust/product-discounts/default/schema.graphql
@@ -3404,7 +3404,7 @@ input Percentage {
 
   The value is validated against: >= 0.
   """
-  value: Float!
+  value: Decimal!
 }
 
 """
@@ -3506,7 +3506,7 @@ input ProductMinimumSubtotal {
   """
   The minimum subtotal amount of the product.
   """
-  minimumAmount: Float!
+  minimumAmount: Decimal!
 
   """
   The target type of the condition.

--- a/discounts/rust/product-discounts/default/src/api.rs
+++ b/discounts/rust/product-discounts/default/src/api.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
+use serde_with::{serde_as, DisplayFromStr};
+
 pub type Boolean = bool;
-pub type Decimal = String;
+pub type Decimal = f64;
 pub type Int = i32;
 pub type ID = String;
 
@@ -52,24 +54,21 @@ pub struct Discount {
     pub conditions: Option<Vec<Condition>>,
 }
 
+#[skip_serializing_none]
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Value {
-    FixedAmount(FixedAmount),
-    Percentage(Percentage),
-}
-
-#[skip_serializing_none]
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all(serialize = "camelCase"))]
-pub struct FixedAmount {
-    pub amount: Decimal,
-    pub applies_to_each_item: Option<Boolean>,
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct Percentage {
-    pub value: String,
+    #[serde(rename_all(serialize = "camelCase"))]
+    FixedAmount {
+        #[serde_as(as = "DisplayFromStr")]
+        amount: Decimal,
+        applies_to_each_item: Option<Boolean>,
+    },
+    Percentage {
+        #[serde_as(as = "DisplayFromStr")]
+        value: Decimal,
+    },
 }
 
 #[skip_serializing_none]
@@ -91,7 +90,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
-        minimum_amount: String,
+        minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
 }

--- a/discounts/rust/product-discounts/default/src/api.rs
+++ b/discounts/rust/product-discounts/default/src/api.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use serde_with::{serde_as, DisplayFromStr};
-
 pub type Boolean = bool;
 pub type Decimal = f64;
 pub type Int = i32;
@@ -17,19 +15,19 @@ pub mod input {
         pub discount_node: DiscountNode,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct Metafield {
         pub value: String,
     }
 }
 
 use serde::Serialize;
-use serde_with::skip_serializing_none;
+use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]

--- a/discounts/rust/product-discounts/default/src/api.rs
+++ b/discounts/rust/product-discounts/default/src/api.rs
@@ -1,11 +1,12 @@
 #![allow(dead_code)]
 
 pub type Boolean = bool;
-pub type Float = f64;
+pub type Decimal = String;
 pub type Int = i32;
 pub type ID = String;
 
 pub mod input {
+    use super::*;
     use serde::Deserialize;
 
     #[derive(Clone, Debug, Deserialize)]
@@ -58,16 +59,17 @@ pub enum Value {
     Percentage(Percentage),
 }
 
+#[skip_serializing_none]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct FixedAmount {
+    pub amount: Decimal,
     pub applies_to_each_item: Option<Boolean>,
-    pub value: Float,
 }
 
 #[derive(Clone, Debug, Serialize)]
 pub struct Percentage {
-    pub value: Float,
+    pub value: String,
 }
 
 #[skip_serializing_none]
@@ -89,7 +91,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
-        minimum_amount: Float,
+        minimum_amount: String,
         target_type: ConditionTargetType,
     },
 }

--- a/discounts/rust/product-discounts/default/src/api.rs
+++ b/discounts/rust/product-discounts/default/src/api.rs
@@ -9,18 +9,18 @@ pub mod input {
     use super::*;
     use serde::Deserialize;
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct Metafield {
         pub value: String,
     }
@@ -76,6 +76,7 @@ pub enum Target {
     ProductVariant { id: ID, quantity: Option<Int> },
 }
 
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Condition {
@@ -88,6 +89,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },

--- a/discounts/rust/product-discounts/default/src/api.rs
+++ b/discounts/rust/product-discounts/default/src/api.rs
@@ -61,7 +61,7 @@ pub enum Value {
     FixedAmount {
         #[serde_as(as = "DisplayFromStr")]
         amount: Decimal,
-        applies_to_each_item: Option<Boolean>,
+        applies_to_each_item: Boolean,
     },
     Percentage {
         #[serde_as(as = "DisplayFromStr")]

--- a/discounts/rust/product-discounts/default/src/main.rs
+++ b/discounts/rust/product-discounts/default/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::Error>> {
-    let _config: Configuration = input.configuration();
+    let _config = input.configuration();
     Ok(FunctionResult {
         discounts: vec![],
         discount_application_strategy: DiscountApplicationStrategy::First,
@@ -42,9 +42,9 @@ fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::E
 mod tests {
     use super::*;
 
-    fn input(configuration: Option<Configuration>) -> input::Input {
+    fn input(config: Option<Configuration>) -> input::Input {
         let discount_node = input::DiscountNode {
-            metafield: configuration.map(|value| {
+            metafield: config.map(|value| {
                 let value = serde_json::to_string(&value).unwrap();
                 input::Metafield { value }
             }),

--- a/discounts/rust/product-discounts/default/src/main.rs
+++ b/discounts/rust/product-discounts/default/src/main.rs
@@ -42,14 +42,28 @@ fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::E
 mod tests {
     use super::*;
 
+    impl Default for input::Input {
+        fn default() -> Self {
+            let json = r#"
+            {
+                "discountNode": { "metafield": null }
+            }
+            "#;
+            serde_json::from_str(json).unwrap()
+        }
+    }
+
     fn input(config: Option<Configuration>) -> input::Input {
-        let discount_node = input::DiscountNode {
-            metafield: config.map(|value| {
-                let value = serde_json::to_string(&value).unwrap();
-                input::Metafield { value }
-            }),
-        };
-        input::Input { discount_node }
+        let default_input = input::Input::default();
+        let discount_node = config.map(|value| {
+            let value = serde_json::to_string(&value).unwrap();
+            input::DiscountNode {
+                metafield: Some(input::Metafield { value }),
+            }
+        });
+        input::Input {
+            discount_node: discount_node.unwrap_or(default_input.discount_node),
+        }
     }
 
     #[test]

--- a/discounts/rust/product-discounts/default/src/main.rs
+++ b/discounts/rust/product-discounts/default/src/main.rs
@@ -8,8 +8,8 @@ use api::*;
 pub struct Configuration {}
 
 impl Configuration {
-    fn from_str(str: &str) -> Self {
-        serde_json::from_str(str).expect("Unable to parse configuration value from metafield")
+    fn from_str(value: &str) -> Self {
+        serde_json::from_str(value).expect("Unable to parse configuration value from metafield")
     }
 }
 

--- a/discounts/rust/product-discounts/fixed-amount/.gitignore
+++ b/discounts/rust/product-discounts/fixed-amount/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/discounts/rust/product-discounts/fixed-amount/Cargo.toml
+++ b/discounts/rust/product-discounts/fixed-amount/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fixed-amount"
+version = "1.0.0"
+edition = "2021"
+include = ["*.graphql"]
+
+[dependencies]
+serde = { version = "1.0.13", features = ["derive"] }
+serde_with = "1.13.0"
+serde_json = "1.0"
+
+[profile.release]
+lto = true
+opt-level = 'z'
+strip = true

--- a/discounts/rust/product-discounts/fixed-amount/Cargo.toml
+++ b/discounts/rust/product-discounts/fixed-amount/Cargo.toml
@@ -2,7 +2,6 @@
 name = "fixed-amount"
 version = "1.0.0"
 edition = "2021"
-include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/product-discounts/fixed-amount/Cargo.toml
+++ b/discounts/rust/product-discounts/fixed-amount/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fixed-amount"
 version = "1.0.0"
 edition = "2021"
-include = ["*.graphql"]
+include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/product-discounts/fixed-amount/README.md
+++ b/discounts/rust/product-discounts/fixed-amount/README.md
@@ -1,0 +1,21 @@
+# Shopify Function development with Rust
+
+## Dependencies
+
+- [Install Rust](https://www.rust-lang.org/tools/install)
+  - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
+- Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
+  - `cargo install cargo-wasi`
+- On Macs with Apple Silicon, you'll also need to install the Binaryen toolchain and set the `WASM_OPT` environment variable. ([related issue](https://github.com/bytecodealliance/cargo-wasi/issues/112))
+  - `brew install binaryen`
+  - Add `export WASM_OPT=/opt/homebrew/bin/wasm-opt` to your `.bashrc` or `.zshrc`
+
+## Building the function
+
+You can build this individual function using `cargo wasi`.
+
+```shell
+cargo wasi build --release
+```
+
+The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.function.extension.toml`.

--- a/discounts/rust/product-discounts/fixed-amount/input.graphql
+++ b/discounts/rust/product-discounts/fixed-amount/input.graphql
@@ -1,0 +1,17 @@
+query Input {
+  cart {
+    lines {
+      id
+      merchandise {
+        ... on ProductVariant {
+          id
+        }
+      }
+    }
+  }
+  discountNode {
+    metafield(namespace: "fixed-amount", key: "function-configuration") {
+      value
+    }
+  }
+}

--- a/discounts/rust/product-discounts/fixed-amount/input.graphql
+++ b/discounts/rust/product-discounts/fixed-amount/input.graphql
@@ -14,4 +14,5 @@ query Input {
       value
     }
   }
+  presentmentCurrencyRate
 }

--- a/discounts/rust/product-discounts/fixed-amount/metadata.json
+++ b/discounts/rust/product-discounts/fixed-amount/metadata.json
@@ -1,0 +1,1 @@
+{"schemaVersions":{"product_discounts":{"major":1,"minor":0}}}

--- a/discounts/rust/product-discounts/fixed-amount/schema.graphql
+++ b/discounts/rust/product-discounts/fixed-amount/schema.graphql
@@ -2679,7 +2679,7 @@ input Percentage {
 
   The value is validated against: >= 0.
   """
-  value: Float!
+  value: Decimal!
 }
 
 """
@@ -2781,7 +2781,7 @@ input ProductMinimumSubtotal {
   """
   The minimum subtotal amount of the product.
   """
-  minimumAmount: Float!
+  minimumAmount: Decimal!
 
   """
   The target type of the condition.

--- a/discounts/rust/product-discounts/fixed-amount/schema.graphql
+++ b/discounts/rust/product-discounts/fixed-amount/schema.graphql
@@ -1,0 +1,2930 @@
+schema {
+  query: Input
+  mutation: MutationRoot
+}
+
+"""
+Exactly one field of input must be provided, and all others omitted.
+"""
+directive @oneOf on INPUT_OBJECT
+
+"""
+Represents a generic custom attribute.
+"""
+type Attribute {
+  """
+  Key or name of the attribute.
+  """
+  key: String!
+
+  """
+  Value of the attribute.
+  """
+  value: String
+}
+
+"""
+Represents information about the buyer that is interacting with the cart.
+"""
+type BuyerIdentity {
+  """
+  The customer associated with the cart.
+  """
+  customer: Customer
+
+  """
+  The email address of the buyer that is interacting with the cart.
+  """
+  email: String
+
+  """
+  The phone number of the buyer that is interacting with the cart.
+  """
+  phone: String
+}
+
+"""
+A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+"""
+type Cart {
+  """
+  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  """
+  attribute(
+    """
+    The key of the attribute to retrieve.
+    """
+    key: String
+  ): Attribute
+
+  """
+  Information about the buyer that is interacting with the cart.
+  """
+  buyerIdentity: BuyerIdentity
+
+  """
+  The costs that the buyer will pay at checkout.
+  """
+  cost: CartCost!
+
+  """
+  The delivery groups available for the cart based on the buyer's shipping address.
+  """
+  deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  A list of lines containing information about the items the customer intends to purchase.
+  """
+  lines: [CartLine!]!
+}
+
+"""
+The cost that the buyer will pay at checkout.
+"""
+type CartCost {
+  """
+  The amount, before taxes and discounts, for the customer to pay.
+  """
+  subtotalAmount: MoneyV2!
+
+  """
+  The total amount for the customer to pay.
+  """
+  totalAmount: MoneyV2!
+
+  """
+  The duty amount for the customer to pay at checkout.
+  """
+  totalDutyAmount: MoneyV2
+
+  """
+  The tax amount for the customer to pay at checkout.
+  """
+  totalTaxAmount: MoneyV2
+}
+
+"""
+Information about the options available for one or more line items to be delivered to a specific address.
+"""
+type CartDeliveryGroup {
+  """
+  A list of cart lines for the delivery group.
+  """
+  cartLines: [CartLine!]!
+
+  """
+  The destination address for the delivery group.
+  """
+  deliveryAddress: MailingAddress
+
+  """
+  The delivery options available for the delivery group.
+  """
+  deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  Unique identifier for the delivery group.
+  """
+  id: ID!
+
+  """
+  Information about the delivery option the buyer has selected.
+  """
+  selectedDeliveryOption: CartDeliveryOption
+}
+
+"""
+Information about a delivery option.
+"""
+type CartDeliveryOption {
+  """
+  The code of the delivery option.
+  """
+  code: String
+
+  """
+  The cost for the delivery option.
+  """
+  cost: MoneyV2!
+
+  """
+  The method for the delivery option.
+  """
+  deliveryMethodType: DeliveryMethod!
+
+  """
+  The description of the delivery option.
+  """
+  description: String
+
+  """
+  The title of the delivery option.
+  """
+  title: String
+}
+
+"""
+Represents information about the merchandise in the cart.
+"""
+type CartLine {
+  """
+  Retrieve a cart line attribute by key.
+  """
+  attribute(
+    """
+    The key of the attribute to retrieve.
+    """
+    key: String
+  ): Attribute
+
+  """
+  The cost of the merchandise line that the buyer will pay at checkout.
+  """
+  cost: CartLineCost!
+
+  """
+  The ID of the cart line.
+  """
+  id: ID!
+
+  """
+  The merchandise that the buyer intends to purchase.
+  """
+  merchandise: Merchandise!
+
+  """
+  The quantity of the merchandise that the customer intends to purchase.
+  """
+  quantity: Int!
+}
+
+"""
+The estimated cost of the merchandise line that the buyer will pay at checkout.
+"""
+type CartLineCost {
+  """
+  The amount of the merchandise line.
+  """
+  amount: MoneyV2!
+
+  """
+  The compare at amount of the merchandise line.
+  """
+  compareAtAmount: MoneyV2
+
+  """
+  The cost of the merchandise line before discounts.
+  """
+  subtotalAmount: MoneyV2!
+
+  """
+  The total cost of the merchandise line.
+  """
+  totalAmount: MoneyV2!
+}
+
+"""
+The condition for when to apply the discount.
+"""
+input Condition @oneOf {
+  """
+  The condition for checking the minimum quantity of a product.
+  """
+  productMinimumQuantity: ProductMinimumQuantity
+
+  """
+  The condition for checking the minimum subtotal amount of the product.
+  """
+  productMinimumSubtotal: ProductMinimumSubtotal
+}
+
+"""
+The code designating a country/region, which generally follows ISO 3166-1 alpha-2 guidelines.
+If a territory doesn't have a country code value in the `CountryCode` enum, it might be considered a subdivision
+of another country. For example, the territories associated with Spain are represented by the country code `ES`,
+and the territories associated with the United States of America are represented by the country code `US`.
+"""
+enum CountryCode {
+  """
+  Ascension Island.
+  """
+  AC
+
+  """
+  Andorra.
+  """
+  AD
+
+  """
+  United Arab Emirates.
+  """
+  AE
+
+  """
+  Afghanistan.
+  """
+  AF
+
+  """
+  Antigua & Barbuda.
+  """
+  AG
+
+  """
+  Anguilla.
+  """
+  AI
+
+  """
+  Albania.
+  """
+  AL
+
+  """
+  Armenia.
+  """
+  AM
+
+  """
+  Netherlands Antilles.
+  """
+  AN
+
+  """
+  Angola.
+  """
+  AO
+
+  """
+  Argentina.
+  """
+  AR
+
+  """
+  Austria.
+  """
+  AT
+
+  """
+  Australia.
+  """
+  AU
+
+  """
+  Aruba.
+  """
+  AW
+
+  """
+  Åland Islands.
+  """
+  AX
+
+  """
+  Azerbaijan.
+  """
+  AZ
+
+  """
+  Bosnia & Herzegovina.
+  """
+  BA
+
+  """
+  Barbados.
+  """
+  BB
+
+  """
+  Bangladesh.
+  """
+  BD
+
+  """
+  Belgium.
+  """
+  BE
+
+  """
+  Burkina Faso.
+  """
+  BF
+
+  """
+  Bulgaria.
+  """
+  BG
+
+  """
+  Bahrain.
+  """
+  BH
+
+  """
+  Burundi.
+  """
+  BI
+
+  """
+  Benin.
+  """
+  BJ
+
+  """
+  St. Barthélemy.
+  """
+  BL
+
+  """
+  Bermuda.
+  """
+  BM
+
+  """
+  Brunei.
+  """
+  BN
+
+  """
+  Bolivia.
+  """
+  BO
+
+  """
+  Caribbean Netherlands.
+  """
+  BQ
+
+  """
+  Brazil.
+  """
+  BR
+
+  """
+  Bahamas.
+  """
+  BS
+
+  """
+  Bhutan.
+  """
+  BT
+
+  """
+  Bouvet Island.
+  """
+  BV
+
+  """
+  Botswana.
+  """
+  BW
+
+  """
+  Belarus.
+  """
+  BY
+
+  """
+  Belize.
+  """
+  BZ
+
+  """
+  Canada.
+  """
+  CA
+
+  """
+  Cocos (Keeling) Islands.
+  """
+  CC
+
+  """
+  Congo - Kinshasa.
+  """
+  CD
+
+  """
+  Central African Republic.
+  """
+  CF
+
+  """
+  Congo - Brazzaville.
+  """
+  CG
+
+  """
+  Switzerland.
+  """
+  CH
+
+  """
+  Côte d’Ivoire.
+  """
+  CI
+
+  """
+  Cook Islands.
+  """
+  CK
+
+  """
+  Chile.
+  """
+  CL
+
+  """
+  Cameroon.
+  """
+  CM
+
+  """
+  China.
+  """
+  CN
+
+  """
+  Colombia.
+  """
+  CO
+
+  """
+  Costa Rica.
+  """
+  CR
+
+  """
+  Cuba.
+  """
+  CU
+
+  """
+  Cape Verde.
+  """
+  CV
+
+  """
+  Curaçao.
+  """
+  CW
+
+  """
+  Christmas Island.
+  """
+  CX
+
+  """
+  Cyprus.
+  """
+  CY
+
+  """
+  Czechia.
+  """
+  CZ
+
+  """
+  Germany.
+  """
+  DE
+
+  """
+  Djibouti.
+  """
+  DJ
+
+  """
+  Denmark.
+  """
+  DK
+
+  """
+  Dominica.
+  """
+  DM
+
+  """
+  Dominican Republic.
+  """
+  DO
+
+  """
+  Algeria.
+  """
+  DZ
+
+  """
+  Ecuador.
+  """
+  EC
+
+  """
+  Estonia.
+  """
+  EE
+
+  """
+  Egypt.
+  """
+  EG
+
+  """
+  Western Sahara.
+  """
+  EH
+
+  """
+  Eritrea.
+  """
+  ER
+
+  """
+  Spain.
+  """
+  ES
+
+  """
+  Ethiopia.
+  """
+  ET
+
+  """
+  Finland.
+  """
+  FI
+
+  """
+  Fiji.
+  """
+  FJ
+
+  """
+  Falkland Islands.
+  """
+  FK
+
+  """
+  Faroe Islands.
+  """
+  FO
+
+  """
+  France.
+  """
+  FR
+
+  """
+  Gabon.
+  """
+  GA
+
+  """
+  United Kingdom.
+  """
+  GB
+
+  """
+  Grenada.
+  """
+  GD
+
+  """
+  Georgia.
+  """
+  GE
+
+  """
+  French Guiana.
+  """
+  GF
+
+  """
+  Guernsey.
+  """
+  GG
+
+  """
+  Ghana.
+  """
+  GH
+
+  """
+  Gibraltar.
+  """
+  GI
+
+  """
+  Greenland.
+  """
+  GL
+
+  """
+  Gambia.
+  """
+  GM
+
+  """
+  Guinea.
+  """
+  GN
+
+  """
+  Guadeloupe.
+  """
+  GP
+
+  """
+  Equatorial Guinea.
+  """
+  GQ
+
+  """
+  Greece.
+  """
+  GR
+
+  """
+  South Georgia & South Sandwich Islands.
+  """
+  GS
+
+  """
+  Guatemala.
+  """
+  GT
+
+  """
+  Guinea-Bissau.
+  """
+  GW
+
+  """
+  Guyana.
+  """
+  GY
+
+  """
+  Hong Kong SAR.
+  """
+  HK
+
+  """
+  Heard & McDonald Islands.
+  """
+  HM
+
+  """
+  Honduras.
+  """
+  HN
+
+  """
+  Croatia.
+  """
+  HR
+
+  """
+  Haiti.
+  """
+  HT
+
+  """
+  Hungary.
+  """
+  HU
+
+  """
+  Indonesia.
+  """
+  ID
+
+  """
+  Ireland.
+  """
+  IE
+
+  """
+  Israel.
+  """
+  IL
+
+  """
+  Isle of Man.
+  """
+  IM
+
+  """
+  India.
+  """
+  IN
+
+  """
+  British Indian Ocean Territory.
+  """
+  IO
+
+  """
+  Iraq.
+  """
+  IQ
+
+  """
+  Iran.
+  """
+  IR
+
+  """
+  Iceland.
+  """
+  IS
+
+  """
+  Italy.
+  """
+  IT
+
+  """
+  Jersey.
+  """
+  JE
+
+  """
+  Jamaica.
+  """
+  JM
+
+  """
+  Jordan.
+  """
+  JO
+
+  """
+  Japan.
+  """
+  JP
+
+  """
+  Kenya.
+  """
+  KE
+
+  """
+  Kyrgyzstan.
+  """
+  KG
+
+  """
+  Cambodia.
+  """
+  KH
+
+  """
+  Kiribati.
+  """
+  KI
+
+  """
+  Comoros.
+  """
+  KM
+
+  """
+  St. Kitts & Nevis.
+  """
+  KN
+
+  """
+  North Korea.
+  """
+  KP
+
+  """
+  South Korea.
+  """
+  KR
+
+  """
+  Kuwait.
+  """
+  KW
+
+  """
+  Cayman Islands.
+  """
+  KY
+
+  """
+  Kazakhstan.
+  """
+  KZ
+
+  """
+  Laos.
+  """
+  LA
+
+  """
+  Lebanon.
+  """
+  LB
+
+  """
+  St. Lucia.
+  """
+  LC
+
+  """
+  Liechtenstein.
+  """
+  LI
+
+  """
+  Sri Lanka.
+  """
+  LK
+
+  """
+  Liberia.
+  """
+  LR
+
+  """
+  Lesotho.
+  """
+  LS
+
+  """
+  Lithuania.
+  """
+  LT
+
+  """
+  Luxembourg.
+  """
+  LU
+
+  """
+  Latvia.
+  """
+  LV
+
+  """
+  Libya.
+  """
+  LY
+
+  """
+  Morocco.
+  """
+  MA
+
+  """
+  Monaco.
+  """
+  MC
+
+  """
+  Moldova.
+  """
+  MD
+
+  """
+  Montenegro.
+  """
+  ME
+
+  """
+  St. Martin.
+  """
+  MF
+
+  """
+  Madagascar.
+  """
+  MG
+
+  """
+  North Macedonia.
+  """
+  MK
+
+  """
+  Mali.
+  """
+  ML
+
+  """
+  Myanmar (Burma).
+  """
+  MM
+
+  """
+  Mongolia.
+  """
+  MN
+
+  """
+  Macao SAR.
+  """
+  MO
+
+  """
+  Martinique.
+  """
+  MQ
+
+  """
+  Mauritania.
+  """
+  MR
+
+  """
+  Montserrat.
+  """
+  MS
+
+  """
+  Malta.
+  """
+  MT
+
+  """
+  Mauritius.
+  """
+  MU
+
+  """
+  Maldives.
+  """
+  MV
+
+  """
+  Malawi.
+  """
+  MW
+
+  """
+  Mexico.
+  """
+  MX
+
+  """
+  Malaysia.
+  """
+  MY
+
+  """
+  Mozambique.
+  """
+  MZ
+
+  """
+  Namibia.
+  """
+  NA
+
+  """
+  New Caledonia.
+  """
+  NC
+
+  """
+  Niger.
+  """
+  NE
+
+  """
+  Norfolk Island.
+  """
+  NF
+
+  """
+  Nigeria.
+  """
+  NG
+
+  """
+  Nicaragua.
+  """
+  NI
+
+  """
+  Netherlands.
+  """
+  NL
+
+  """
+  Norway.
+  """
+  NO
+
+  """
+  Nepal.
+  """
+  NP
+
+  """
+  Nauru.
+  """
+  NR
+
+  """
+  Niue.
+  """
+  NU
+
+  """
+  New Zealand.
+  """
+  NZ
+
+  """
+  Oman.
+  """
+  OM
+
+  """
+  Panama.
+  """
+  PA
+
+  """
+  Peru.
+  """
+  PE
+
+  """
+  French Polynesia.
+  """
+  PF
+
+  """
+  Papua New Guinea.
+  """
+  PG
+
+  """
+  Philippines.
+  """
+  PH
+
+  """
+  Pakistan.
+  """
+  PK
+
+  """
+  Poland.
+  """
+  PL
+
+  """
+  St. Pierre & Miquelon.
+  """
+  PM
+
+  """
+  Pitcairn Islands.
+  """
+  PN
+
+  """
+  Palestinian Territories.
+  """
+  PS
+
+  """
+  Portugal.
+  """
+  PT
+
+  """
+  Paraguay.
+  """
+  PY
+
+  """
+  Qatar.
+  """
+  QA
+
+  """
+  Réunion.
+  """
+  RE
+
+  """
+  Romania.
+  """
+  RO
+
+  """
+  Serbia.
+  """
+  RS
+
+  """
+  Russia.
+  """
+  RU
+
+  """
+  Rwanda.
+  """
+  RW
+
+  """
+  Saudi Arabia.
+  """
+  SA
+
+  """
+  Solomon Islands.
+  """
+  SB
+
+  """
+  Seychelles.
+  """
+  SC
+
+  """
+  Sudan.
+  """
+  SD
+
+  """
+  Sweden.
+  """
+  SE
+
+  """
+  Singapore.
+  """
+  SG
+
+  """
+  St. Helena.
+  """
+  SH
+
+  """
+  Slovenia.
+  """
+  SI
+
+  """
+  Svalbard & Jan Mayen.
+  """
+  SJ
+
+  """
+  Slovakia.
+  """
+  SK
+
+  """
+  Sierra Leone.
+  """
+  SL
+
+  """
+  San Marino.
+  """
+  SM
+
+  """
+  Senegal.
+  """
+  SN
+
+  """
+  Somalia.
+  """
+  SO
+
+  """
+  Suriname.
+  """
+  SR
+
+  """
+  South Sudan.
+  """
+  SS
+
+  """
+  São Tomé & Príncipe.
+  """
+  ST
+
+  """
+  El Salvador.
+  """
+  SV
+
+  """
+  Sint Maarten.
+  """
+  SX
+
+  """
+  Syria.
+  """
+  SY
+
+  """
+  Eswatini.
+  """
+  SZ
+
+  """
+  Tristan da Cunha.
+  """
+  TA
+
+  """
+  Turks & Caicos Islands.
+  """
+  TC
+
+  """
+  Chad.
+  """
+  TD
+
+  """
+  French Southern Territories.
+  """
+  TF
+
+  """
+  Togo.
+  """
+  TG
+
+  """
+  Thailand.
+  """
+  TH
+
+  """
+  Tajikistan.
+  """
+  TJ
+
+  """
+  Tokelau.
+  """
+  TK
+
+  """
+  Timor-Leste.
+  """
+  TL
+
+  """
+  Turkmenistan.
+  """
+  TM
+
+  """
+  Tunisia.
+  """
+  TN
+
+  """
+  Tonga.
+  """
+  TO
+
+  """
+  Turkey.
+  """
+  TR
+
+  """
+  Trinidad & Tobago.
+  """
+  TT
+
+  """
+  Tuvalu.
+  """
+  TV
+
+  """
+  Taiwan.
+  """
+  TW
+
+  """
+  Tanzania.
+  """
+  TZ
+
+  """
+  Ukraine.
+  """
+  UA
+
+  """
+  Uganda.
+  """
+  UG
+
+  """
+  U.S. Outlying Islands.
+  """
+  UM
+
+  """
+  United States.
+  """
+  US
+
+  """
+  Uruguay.
+  """
+  UY
+
+  """
+  Uzbekistan.
+  """
+  UZ
+
+  """
+  Vatican City.
+  """
+  VA
+
+  """
+  St. Vincent & Grenadines.
+  """
+  VC
+
+  """
+  Venezuela.
+  """
+  VE
+
+  """
+  British Virgin Islands.
+  """
+  VG
+
+  """
+  Vietnam.
+  """
+  VN
+
+  """
+  Vanuatu.
+  """
+  VU
+
+  """
+  Wallis & Futuna.
+  """
+  WF
+
+  """
+  Samoa.
+  """
+  WS
+
+  """
+  Kosovo.
+  """
+  XK
+
+  """
+  Yemen.
+  """
+  YE
+
+  """
+  Mayotte.
+  """
+  YT
+
+  """
+  South Africa.
+  """
+  ZA
+
+  """
+  Zambia.
+  """
+  ZM
+
+  """
+  Zimbabwe.
+  """
+  ZW
+
+  """
+  Unknown Region.
+  """
+  ZZ
+}
+
+"""
+The three-letter currency codes that represent the world currencies used in
+stores. These include standard ISO 4217 codes, legacy codes,
+and non-standard codes.
+"""
+enum CurrencyCode {
+  """
+  United Arab Emirates Dirham (AED).
+  """
+  AED
+
+  """
+  Afghan Afghani (AFN).
+  """
+  AFN
+
+  """
+  Albanian Lek (ALL).
+  """
+  ALL
+
+  """
+  Armenian Dram (AMD).
+  """
+  AMD
+
+  """
+  Netherlands Antillean Guilder.
+  """
+  ANG
+
+  """
+  Angolan Kwanza (AOA).
+  """
+  AOA
+
+  """
+  Argentine Pesos (ARS).
+  """
+  ARS
+
+  """
+  Australian Dollars (AUD).
+  """
+  AUD
+
+  """
+  Aruban Florin (AWG).
+  """
+  AWG
+
+  """
+  Azerbaijani Manat (AZN).
+  """
+  AZN
+
+  """
+  Bosnia and Herzegovina Convertible Mark (BAM).
+  """
+  BAM
+
+  """
+  Barbadian Dollar (BBD).
+  """
+  BBD
+
+  """
+  Bangladesh Taka (BDT).
+  """
+  BDT
+
+  """
+  Bulgarian Lev (BGN).
+  """
+  BGN
+
+  """
+  Bahraini Dinar (BHD).
+  """
+  BHD
+
+  """
+  Burundian Franc (BIF).
+  """
+  BIF
+
+  """
+  Bermudian Dollar (BMD).
+  """
+  BMD
+
+  """
+  Brunei Dollar (BND).
+  """
+  BND
+
+  """
+  Bolivian Boliviano (BOB).
+  """
+  BOB
+
+  """
+  Brazilian Real (BRL).
+  """
+  BRL
+
+  """
+  Bahamian Dollar (BSD).
+  """
+  BSD
+
+  """
+  Bhutanese Ngultrum (BTN).
+  """
+  BTN
+
+  """
+  Botswana Pula (BWP).
+  """
+  BWP
+
+  """
+  Belarusian Ruble (BYN).
+  """
+  BYN
+
+  """
+  Belarusian Ruble (BYR).
+  """
+  BYR @deprecated(reason: "`BYR` is deprecated. Use `BYN` available from version `2021-01` onwards instead.")
+
+  """
+  Belize Dollar (BZD).
+  """
+  BZD
+
+  """
+  Canadian Dollars (CAD).
+  """
+  CAD
+
+  """
+  Congolese franc (CDF).
+  """
+  CDF
+
+  """
+  Swiss Francs (CHF).
+  """
+  CHF
+
+  """
+  Chilean Peso (CLP).
+  """
+  CLP
+
+  """
+  Chinese Yuan Renminbi (CNY).
+  """
+  CNY
+
+  """
+  Colombian Peso (COP).
+  """
+  COP
+
+  """
+  Costa Rican Colones (CRC).
+  """
+  CRC
+
+  """
+  Cape Verdean escudo (CVE).
+  """
+  CVE
+
+  """
+  Czech Koruny (CZK).
+  """
+  CZK
+
+  """
+  Djiboutian Franc (DJF).
+  """
+  DJF
+
+  """
+  Danish Kroner (DKK).
+  """
+  DKK
+
+  """
+  Dominican Peso (DOP).
+  """
+  DOP
+
+  """
+  Algerian Dinar (DZD).
+  """
+  DZD
+
+  """
+  Egyptian Pound (EGP).
+  """
+  EGP
+
+  """
+  Eritrean Nakfa (ERN).
+  """
+  ERN
+
+  """
+  Ethiopian Birr (ETB).
+  """
+  ETB
+
+  """
+  Euro (EUR).
+  """
+  EUR
+
+  """
+  Fijian Dollars (FJD).
+  """
+  FJD
+
+  """
+  Falkland Islands Pounds (FKP).
+  """
+  FKP
+
+  """
+  United Kingdom Pounds (GBP).
+  """
+  GBP
+
+  """
+  Georgian Lari (GEL).
+  """
+  GEL
+
+  """
+  Ghanaian Cedi (GHS).
+  """
+  GHS
+
+  """
+  Gibraltar Pounds (GIP).
+  """
+  GIP
+
+  """
+  Gambian Dalasi (GMD).
+  """
+  GMD
+
+  """
+  Guinean Franc (GNF).
+  """
+  GNF
+
+  """
+  Guatemalan Quetzal (GTQ).
+  """
+  GTQ
+
+  """
+  Guyanese Dollar (GYD).
+  """
+  GYD
+
+  """
+  Hong Kong Dollars (HKD).
+  """
+  HKD
+
+  """
+  Honduran Lempira (HNL).
+  """
+  HNL
+
+  """
+  Croatian Kuna (HRK).
+  """
+  HRK
+
+  """
+  Haitian Gourde (HTG).
+  """
+  HTG
+
+  """
+  Hungarian Forint (HUF).
+  """
+  HUF
+
+  """
+  Indonesian Rupiah (IDR).
+  """
+  IDR
+
+  """
+  Israeli New Shekel (NIS).
+  """
+  ILS
+
+  """
+  Indian Rupees (INR).
+  """
+  INR
+
+  """
+  Iraqi Dinar (IQD).
+  """
+  IQD
+
+  """
+  Iranian Rial (IRR).
+  """
+  IRR
+
+  """
+  Icelandic Kronur (ISK).
+  """
+  ISK
+
+  """
+  Jersey Pound.
+  """
+  JEP
+
+  """
+  Jamaican Dollars (JMD).
+  """
+  JMD
+
+  """
+  Jordanian Dinar (JOD).
+  """
+  JOD
+
+  """
+  Japanese Yen (JPY).
+  """
+  JPY
+
+  """
+  Kenyan Shilling (KES).
+  """
+  KES
+
+  """
+  Kyrgyzstani Som (KGS).
+  """
+  KGS
+
+  """
+  Cambodian Riel.
+  """
+  KHR
+
+  """
+  Kiribati Dollar (KID).
+  """
+  KID
+
+  """
+  Comorian Franc (KMF).
+  """
+  KMF
+
+  """
+  South Korean Won (KRW).
+  """
+  KRW
+
+  """
+  Kuwaiti Dinar (KWD).
+  """
+  KWD
+
+  """
+  Cayman Dollars (KYD).
+  """
+  KYD
+
+  """
+  Kazakhstani Tenge (KZT).
+  """
+  KZT
+
+  """
+  Laotian Kip (LAK).
+  """
+  LAK
+
+  """
+  Lebanese Pounds (LBP).
+  """
+  LBP
+
+  """
+  Sri Lankan Rupees (LKR).
+  """
+  LKR
+
+  """
+  Liberian Dollar (LRD).
+  """
+  LRD
+
+  """
+  Lesotho Loti (LSL).
+  """
+  LSL
+
+  """
+  Lithuanian Litai (LTL).
+  """
+  LTL
+
+  """
+  Latvian Lati (LVL).
+  """
+  LVL
+
+  """
+  Libyan Dinar (LYD).
+  """
+  LYD
+
+  """
+  Moroccan Dirham.
+  """
+  MAD
+
+  """
+  Moldovan Leu (MDL).
+  """
+  MDL
+
+  """
+  Malagasy Ariary (MGA).
+  """
+  MGA
+
+  """
+  Macedonia Denar (MKD).
+  """
+  MKD
+
+  """
+  Burmese Kyat (MMK).
+  """
+  MMK
+
+  """
+  Mongolian Tugrik.
+  """
+  MNT
+
+  """
+  Macanese Pataca (MOP).
+  """
+  MOP
+
+  """
+  Mauritanian Ouguiya (MRU).
+  """
+  MRU
+
+  """
+  Mauritian Rupee (MUR).
+  """
+  MUR
+
+  """
+  Maldivian Rufiyaa (MVR).
+  """
+  MVR
+
+  """
+  Malawian Kwacha (MWK).
+  """
+  MWK
+
+  """
+  Mexican Pesos (MXN).
+  """
+  MXN
+
+  """
+  Malaysian Ringgits (MYR).
+  """
+  MYR
+
+  """
+  Mozambican Metical.
+  """
+  MZN
+
+  """
+  Namibian Dollar.
+  """
+  NAD
+
+  """
+  Nigerian Naira (NGN).
+  """
+  NGN
+
+  """
+  Nicaraguan Córdoba (NIO).
+  """
+  NIO
+
+  """
+  Norwegian Kroner (NOK).
+  """
+  NOK
+
+  """
+  Nepalese Rupee (NPR).
+  """
+  NPR
+
+  """
+  New Zealand Dollars (NZD).
+  """
+  NZD
+
+  """
+  Omani Rial (OMR).
+  """
+  OMR
+
+  """
+  Panamian Balboa (PAB).
+  """
+  PAB
+
+  """
+  Peruvian Nuevo Sol (PEN).
+  """
+  PEN
+
+  """
+  Papua New Guinean Kina (PGK).
+  """
+  PGK
+
+  """
+  Philippine Peso (PHP).
+  """
+  PHP
+
+  """
+  Pakistani Rupee (PKR).
+  """
+  PKR
+
+  """
+  Polish Zlotych (PLN).
+  """
+  PLN
+
+  """
+  Paraguayan Guarani (PYG).
+  """
+  PYG
+
+  """
+  Qatari Rial (QAR).
+  """
+  QAR
+
+  """
+  Romanian Lei (RON).
+  """
+  RON
+
+  """
+  Serbian dinar (RSD).
+  """
+  RSD
+
+  """
+  Russian Rubles (RUB).
+  """
+  RUB
+
+  """
+  Rwandan Franc (RWF).
+  """
+  RWF
+
+  """
+  Saudi Riyal (SAR).
+  """
+  SAR
+
+  """
+  Solomon Islands Dollar (SBD).
+  """
+  SBD
+
+  """
+  Seychellois Rupee (SCR).
+  """
+  SCR
+
+  """
+  Sudanese Pound (SDG).
+  """
+  SDG
+
+  """
+  Swedish Kronor (SEK).
+  """
+  SEK
+
+  """
+  Singapore Dollars (SGD).
+  """
+  SGD
+
+  """
+  Saint Helena Pounds (SHP).
+  """
+  SHP
+
+  """
+  Sierra Leonean Leone (SLL).
+  """
+  SLL
+
+  """
+  Somali Shilling (SOS).
+  """
+  SOS
+
+  """
+  Surinamese Dollar (SRD).
+  """
+  SRD
+
+  """
+  South Sudanese Pound (SSP).
+  """
+  SSP
+
+  """
+  Sao Tome And Principe Dobra (STD).
+  """
+  STD @deprecated(reason: "`STD` is deprecated. Use `STN` available from version `2022-07` onwards instead.")
+
+  """
+  Sao Tome And Principe Dobra (STN).
+  """
+  STN
+
+  """
+  Syrian Pound (SYP).
+  """
+  SYP
+
+  """
+  Swazi Lilangeni (SZL).
+  """
+  SZL
+
+  """
+  Thai baht (THB).
+  """
+  THB
+
+  """
+  Tajikistani Somoni (TJS).
+  """
+  TJS
+
+  """
+  Turkmenistani Manat (TMT).
+  """
+  TMT
+
+  """
+  Tunisian Dinar (TND).
+  """
+  TND
+
+  """
+  Tongan Pa'anga (TOP).
+  """
+  TOP
+
+  """
+  Turkish Lira (TRY).
+  """
+  TRY
+
+  """
+  Trinidad and Tobago Dollars (TTD).
+  """
+  TTD
+
+  """
+  Taiwan Dollars (TWD).
+  """
+  TWD
+
+  """
+  Tanzanian Shilling (TZS).
+  """
+  TZS
+
+  """
+  Ukrainian Hryvnia (UAH).
+  """
+  UAH
+
+  """
+  Ugandan Shilling (UGX).
+  """
+  UGX
+
+  """
+  United States Dollars (USD).
+  """
+  USD
+
+  """
+  Uruguayan Pesos (UYU).
+  """
+  UYU
+
+  """
+  Uzbekistan som (UZS).
+  """
+  UZS
+
+  """
+  Venezuelan Bolivares (VED).
+  """
+  VED
+
+  """
+  Venezuelan Bolivares (VEF).
+  """
+  VEF @deprecated(reason: "`VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead.")
+
+  """
+  Venezuelan Bolivares (VES).
+  """
+  VES
+
+  """
+  Vietnamese đồng (VND).
+  """
+  VND
+
+  """
+  Vanuatu Vatu (VUV).
+  """
+  VUV
+
+  """
+  Samoan Tala (WST).
+  """
+  WST
+
+  """
+  Central African CFA Franc (XAF).
+  """
+  XAF
+
+  """
+  East Caribbean Dollar (XCD).
+  """
+  XCD
+
+  """
+  West African CFA franc (XOF).
+  """
+  XOF
+
+  """
+  CFP Franc (XPF).
+  """
+  XPF
+
+  """
+  Unrecognized currency.
+  """
+  XXX
+
+  """
+  Yemeni Rial (YER).
+  """
+  YER
+
+  """
+  South African Rand (ZAR).
+  """
+  ZAR
+
+  """
+  Zambian Kwacha (ZMW).
+  """
+  ZMW
+}
+
+"""
+A custom product.
+"""
+type CustomProduct {
+  """
+  Whether the merchandise is a gift card.
+  """
+  isGiftCard: Boolean!
+
+  """
+  Whether the merchandise requires shipping.
+  """
+  requiresShipping: Boolean!
+
+  """
+  The weight of the product variant in the unit system specified with `weight_unit`.
+  """
+  weight: Float
+
+  """
+  Unit of measurement for weight.
+  """
+  weightUnit: WeightUnit!
+}
+
+"""
+Represents a customer with the shop.
+"""
+type Customer implements HasMetafields {
+  """
+  The total amount of money spent by the customer.
+  """
+  amountSpent: MoneyV2!
+
+  """
+  The customer’s name, email or phone number.
+  """
+  displayName: String!
+
+  """
+  The customer’s email address.
+  """
+  email: String
+
+  """
+  Whether the customer has any of the given tags.
+  """
+  hasAnyTag(
+    """
+    The tags to search for.
+    """
+    tags: [String!]! = []
+  ): Boolean!
+
+  """
+  A unique identifier for the customer.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  The number of orders made by the customer.
+  """
+  numberOfOrders: Int!
+}
+
+"""
+A signed decimal number, which supports arbitrary precision and is serialized as a string.
+
+Example values: `"29.99"`, `"29.999"`.
+"""
+scalar Decimal
+
+"""
+List of different delivery method types.
+"""
+enum DeliveryMethod {
+  """
+  Local Delivery.
+  """
+  LOCAL
+
+  """
+  None.
+  """
+  NONE
+
+  """
+  Shipping to a Pickup Point.
+  """
+  PICKUP_POINT
+
+  """
+  Local Pickup.
+  """
+  PICK_UP
+
+  """
+  Retail.
+  """
+  RETAIL
+
+  """
+  Shipping.
+  """
+  SHIPPING
+}
+
+"""
+The discount to be applied.
+"""
+input Discount {
+  """
+  The condition for when the discount is applied.
+  """
+  conditions: [Condition!]
+
+  """
+  The discount message.
+  """
+  message: String
+
+  """
+  The targets of the discount.
+  """
+  targets: [Target!]!
+
+  """
+  The value of the discount.
+  """
+  value: Value!
+}
+
+"""
+The strategy that's applied to the list of discounts.
+"""
+enum DiscountApplicationStrategy {
+  """
+  Only apply the first discount with conditions that are satisfied.
+  """
+  FIRST
+
+  """
+  Only apply the discount that offers the maximum reduction.
+  """
+  MAXIMUM
+}
+
+"""
+A discount wrapper node.
+"""
+type DiscountNode implements HasMetafields {
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+}
+
+"""
+A fixed amount value.
+"""
+input FixedAmount {
+  """
+  The fixed amount value of the discount, in the currency of the cart.
+
+  The amount must be greater than or equal to 0.
+  """
+  amount: Decimal!
+
+  """
+  Whether to apply the value to each entitled item.
+
+  The default value is `false`, which causes the value to be applied once across the entitled items.
+  When the value is `true`, the value will be applied to each of the entitled items.
+  """
+  appliesToEachItem: Boolean
+}
+
+"""
+The result of the function.
+"""
+input FunctionResult {
+  """
+  The strategy to apply the list of discounts.
+  """
+  discountApplicationStrategy: DiscountApplicationStrategy!
+
+  """
+  The list of discounts to be applied.
+  """
+  discounts: [Discount!]!
+}
+
+"""
+Represents information about the metafields associated to the specified resource.
+"""
+interface HasMetafields {
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+}
+
+"""
+Represents a unique identifier that is Base64 obfuscated. It is often used to
+refetch an object or as key for a cache. The ID type appears in a JSON response
+as a String; however, it is not intended to be human-readable. When expected as
+an input type, any string (such as `"VXNlci0xMA=="`) or integer (such as `4`)
+input value will be accepted as an ID.
+"""
+scalar ID
+
+"""
+The input object for the function.
+"""
+type Input {
+  """
+  The cart to discount.
+  """
+  cart: Cart!
+
+  """
+  The discount node executing the function.
+  """
+  discountNode: DiscountNode!
+
+  """
+  The localization of the function execution context.
+  """
+  localization: Cart!
+
+  """
+  The conversion rate between the shop's currency and the currency of the cart.
+  """
+  presentmentCurrencyRate: Decimal
+}
+
+"""
+Represents a mailing address.
+"""
+type MailingAddress {
+  """
+  The first line of the address. Typically the street address or PO Box number.
+  """
+  address1: String
+
+  """
+  The second line of the address. Typically the number of the apartment, suite, or unit.
+  """
+  address2: String
+
+  """
+  The name of the city, district, village, or town.
+  """
+  city: String
+
+  """
+  The name of the customer's company or organization.
+  """
+  company: String
+
+  """
+  The two-letter code for the country of the address. For example, US.
+  """
+  countryCode: CountryCode
+
+  """
+  The first name of the customer.
+  """
+  firstName: String
+
+  """
+  The last name of the customer.
+  """
+  lastName: String
+
+  """
+  The full name of the customer, based on firstName and lastName.
+  """
+  name: String
+
+  """
+  A unique phone number for the customer. Formatted using E.164 standard. For example, +16135551111.
+  """
+  phone: String
+
+  """
+  The two-letter code for the region. For example, ON.
+  """
+  provinceCode: String
+
+  """
+  The zip or postal code of the address.
+  """
+  zip: String
+}
+
+"""
+The merchandise to be purchased at checkout.
+"""
+union Merchandise = CustomProduct | ProductVariant
+
+"""
+[Metafields](https://shopify.dev/apps/metafields)
+enable you to attach additional information to a
+Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
+or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
+For more information about the Shopify resources that you can attach metafields to, refer to
+[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+"""
+type Metafield {
+  """
+  The type of data that the metafield stores in the `value` field.
+  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  """
+  type: String!
+
+  """
+  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  """
+  value: String!
+}
+
+"""
+A monetary value with currency.
+"""
+type MoneyV2 {
+  """
+  Decimal money amount.
+  """
+  amount: Decimal!
+
+  """
+  Currency of the money.
+  """
+  currencyCode: CurrencyCode!
+}
+
+"""
+The root mutation for the API.
+"""
+type MutationRoot {
+  """
+  Handles the function result.
+  """
+  handleResult(
+    """
+    The result of the function.
+    """
+    result: FunctionResult!
+  ): Void!
+}
+
+"""
+A percentage value.
+"""
+input Percentage {
+  """
+  The percentage value.
+
+  The value is validated against: >= 0.
+  """
+  value: Float!
+}
+
+"""
+Represents a product.
+"""
+type Product implements HasMetafields {
+  """
+  A unique human-friendly string of the product's title.
+  """
+  handle: String!
+
+  """
+  Whether the product has any of the given tags.
+  """
+  hasAnyTag(
+    """
+    The tags to search for.
+    """
+    tags: [String!]! = []
+  ): Boolean!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Whether the product has any of the given collection.
+  """
+  inAnyCollection(
+    """
+    The collections to search for.
+    """
+    ids: [ID!]! = []
+  ): Boolean!
+
+  """
+  Whether the product is a gift card.
+  """
+  isGiftCard: Boolean!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  The product type specified by the merchant.
+  """
+  productType: String
+
+  """
+  The name of the product's vendor.
+  """
+  vendor: String
+}
+
+"""
+The condition for checking the minimum quantity of a product.
+"""
+input ProductMinimumQuantity {
+  """
+  Variant IDs with a merchandise line price that's included to calculate the minimum quantity of the product.
+  """
+  ids: [ID!]!
+
+  """
+  The minimum quantity of a product.
+  """
+  minimumQuantity: Int!
+
+  """
+  The target type of the condition.
+
+  The value is validated against: = "PRODUCT_VARIANT".
+  """
+  targetType: TargetType!
+}
+
+"""
+The condition for checking the minimum subtotal amount of the product.
+"""
+input ProductMinimumSubtotal {
+  """
+  Variant IDs with a merchandise line price that's included to calculate the minimum subtotal amount of a product.
+  """
+  ids: [ID!]!
+
+  """
+  The minimum subtotal amount of the product.
+  """
+  minimumAmount: Float!
+
+  """
+  The target type of the condition.
+
+  The value is validated against: = "PRODUCT_VARIANT".
+  """
+  targetType: TargetType!
+}
+
+"""
+Represents a product variant.
+"""
+type ProductVariant implements HasMetafields {
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  The product that this variant belongs to.
+  """
+  product: Product!
+
+  """
+  Whether the merchandise requires shipping.
+  """
+  requiresShipping: Boolean!
+
+  """
+  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  """
+  sku: String
+
+  """
+  The weight of the product variant in the unit system specified with `weight_unit`.
+  """
+  weight: Float
+
+  """
+  Unit of measurement for weight.
+  """
+  weightUnit: WeightUnit!
+}
+
+"""
+The target product variant.
+"""
+input ProductVariantTarget {
+  """
+  The ID of the target product variant.
+  """
+  id: ID!
+
+  """
+  The number of line items that are being discounted.
+  The default value is `null`, which represents the quantity of the matching line items.
+
+  The value is validated against: > 0.
+  """
+  quantity: Int
+}
+
+"""
+The target of the discount.
+"""
+input Target @oneOf {
+  """
+  The target product variant.
+  """
+  productVariant: ProductVariantTarget
+}
+
+"""
+The target type of a condition.
+"""
+enum TargetType {
+  """
+  The target is the subtotal of the order.
+  """
+  ORDER_SUBTOTAL
+
+  """
+  The target is a product variant.
+  """
+  PRODUCT_VARIANT
+}
+
+"""
+The value of the discount.
+"""
+input Value @oneOf {
+  """
+  A fixed amount value.
+  """
+  fixedAmount: FixedAmount
+
+  """
+  A percentage value.
+  """
+  percentage: Percentage
+}
+
+"""
+A void type that can be used to return a null value from a mutation.
+"""
+scalar Void
+
+"""
+Units of measurement for weight.
+"""
+enum WeightUnit {
+  """
+  Metric system unit of mass.
+  """
+  GRAMS
+
+  """
+  1 kilogram equals 1000 grams.
+  """
+  KILOGRAMS
+
+  """
+  Imperial system unit of mass.
+  """
+  OUNCES
+
+  """
+  1 pound equals 16 ounces.
+  """
+  POUNDS
+}

--- a/discounts/rust/product-discounts/fixed-amount/shopify.function.extension.toml
+++ b/discounts/rust/product-discounts/fixed-amount/shopify.function.extension.toml
@@ -1,0 +1,7 @@
+name = "Fixed Amount"
+type = "product_discounts"
+api_version = "2022-07"
+
+[build]
+command = "cargo wasi build --release"
+path = "target/wasm32-wasi/release/fixed-amount.wasm"

--- a/discounts/rust/product-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/product-discounts/fixed-amount/src/api.rs
@@ -10,7 +10,7 @@ pub mod input {
     use serde::Deserialize;
 
     #[serde_as]
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
@@ -19,28 +19,28 @@ pub mod input {
         pub presentment_currency_rate: Decimal,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct Metafield {
         pub value: String,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct Cart {
         pub lines: Vec<CartLine>,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct CartLine {
         pub id: ID,
         pub merchandise: Merchandise,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct Merchandise {
         pub id: Option<ID>,
     }
@@ -96,6 +96,7 @@ pub enum Target {
     ProductVariant { id: ID, quantity: Option<Int> },
 }
 
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Condition {
@@ -108,6 +109,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },

--- a/discounts/rust/product-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/product-discounts/fixed-amount/src/api.rs
@@ -81,7 +81,7 @@ pub enum Value {
     FixedAmount {
         #[serde_as(as = "DisplayFromStr")]
         amount: Decimal,
-        applies_to_each_item: Option<Boolean>,
+        applies_to_each_item: Boolean,
     },
     Percentage {
         #[serde_as(as = "DisplayFromStr")]

--- a/discounts/rust/product-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/product-discounts/fixed-amount/src/api.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use serde_with::{serde_as, DisplayFromStr};
-
 pub type Boolean = bool;
 pub type Decimal = f64;
 pub type Int = i32;
@@ -11,20 +9,22 @@ pub mod input {
     use super::*;
     use serde::Deserialize;
 
+    #[serde_as]
     #[derive(Clone, Debug, Deserialize)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
         pub cart: Cart,
+        #[serde_as(as = "DisplayFromStr")]
         pub presentment_currency_rate: Decimal,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct Metafield {
         pub value: String,
     }
@@ -47,7 +47,7 @@ pub mod input {
 }
 
 use serde::Serialize;
-use serde_with::skip_serializing_none;
+use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]

--- a/discounts/rust/product-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/product-discounts/fixed-amount/src/api.rs
@@ -1,0 +1,121 @@
+#![allow(dead_code)]
+
+pub type Boolean = bool;
+pub type Decimal = String;
+pub type Int = i32;
+pub type ID = String;
+
+pub mod input {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Input {
+        pub discount_node: DiscountNode,
+        pub cart: Cart,
+        pub presentment_currency_rate: Decimal,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Default)]
+    pub struct DiscountNode {
+        pub metafield: Option<Metafield>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Default)]
+    pub struct Metafield {
+        pub value: String,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct Cart {
+        pub lines: Vec<CartLine>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct CartLine {
+        pub id: ID,
+        pub merchandise: Merchandise,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct Merchandise {
+        pub id: Option<ID>,
+    }
+}
+
+use serde::Serialize;
+use serde_with::skip_serializing_none;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct FunctionResult {
+    pub discount_application_strategy: DiscountApplicationStrategy,
+    pub discounts: Vec<Discount>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
+pub enum DiscountApplicationStrategy {
+    First,
+    Maximum,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Serialize)]
+pub struct Discount {
+    pub value: Value,
+    pub targets: Vec<Target>,
+    pub message: Option<String>,
+    pub conditions: Option<Vec<Condition>>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub enum Value {
+    FixedAmount(FixedAmount),
+    Percentage(Percentage),
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct FixedAmount {
+    pub amount: Decimal,
+    pub applies_to_each_item: Option<Boolean>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct Percentage {
+    pub value: Decimal,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub enum Target {
+    ProductVariant { id: ID, quantity: Option<Int> },
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub enum Condition {
+    #[serde(rename_all(serialize = "camelCase"))]
+    ProductMinimumQuantity {
+        ids: Vec<ID>,
+        minimum_quantity: Int,
+        target_type: ConditionTargetType,
+    },
+    #[serde(rename_all(serialize = "camelCase"))]
+    ProductMinimumSubtotal {
+        ids: Vec<ID>,
+        minimum_amount: Decimal,
+        target_type: ConditionTargetType,
+    },
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
+pub enum ConditionTargetType {
+    ProductVariant,
+}

--- a/discounts/rust/product-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/product-discounts/fixed-amount/src/api.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
+use serde_with::{serde_as, DisplayFromStr};
+
 pub type Boolean = bool;
-pub type Decimal = String;
+pub type Decimal = f64;
 pub type Int = i32;
 pub type ID = String;
 
@@ -70,24 +72,21 @@ pub struct Discount {
     pub conditions: Option<Vec<Condition>>,
 }
 
+#[skip_serializing_none]
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Value {
-    FixedAmount(FixedAmount),
-    Percentage(Percentage),
-}
-
-#[skip_serializing_none]
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all(serialize = "camelCase"))]
-pub struct FixedAmount {
-    pub amount: Decimal,
-    pub applies_to_each_item: Option<Boolean>,
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct Percentage {
-    pub value: Decimal,
+    #[serde(rename_all(serialize = "camelCase"))]
+    FixedAmount {
+        #[serde_as(as = "DisplayFromStr")]
+        amount: Decimal,
+        applies_to_each_item: Option<Boolean>,
+    },
+    Percentage {
+        #[serde_as(as = "DisplayFromStr")]
+        value: Decimal,
+    },
 }
 
 #[skip_serializing_none]

--- a/discounts/rust/product-discounts/fixed-amount/src/main.rs
+++ b/discounts/rust/product-discounts/fixed-amount/src/main.rs
@@ -1,0 +1,214 @@
+use serde::{Deserialize, Serialize};
+
+mod api;
+use api::*;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Configuration {
+    pub value: f64,
+}
+
+impl Configuration {
+    const DEFAULT_VALUE: f64 = 50.00;
+
+    fn from_str(str: &str) -> Self {
+        serde_json::from_str(str).expect("Unable to parse configuration value from metafield")
+    }
+}
+
+impl Default for Configuration {
+    fn default() -> Self {
+        Configuration {
+            value: Self::DEFAULT_VALUE,
+        }
+    }
+}
+
+impl input::Input {
+    pub fn configuration(&self) -> Configuration {
+        match &self.discount_node.metafield {
+            Some(input::Metafield { value }) => Configuration::from_str(value),
+            None => Configuration::default(),
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let input: input::Input = serde_json::from_reader(std::io::BufReader::new(std::io::stdin()))?;
+    let mut out = std::io::stdout();
+    let mut serializer = serde_json::Serializer::new(&mut out);
+    function(input)?.serialize(&mut serializer)?;
+    Ok(())
+}
+
+fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::Error>> {
+    let cart_lines = &input.cart.lines;
+    let config: Configuration = input.configuration();
+
+    let converted_value = convert_to_cart_currency(config.value, &input);
+    let targets = targets(cart_lines);
+    Ok(build_result(converted_value, targets))
+}
+
+fn convert_to_cart_currency(value: f64, input: &input::Input) -> f64 {
+    let rate = &input.presentment_currency_rate;
+    value
+        * rate
+            .parse::<f64>()
+            .expect("presentment_currency_rate is malformed.")
+}
+
+fn targets(cart_lines: &[input::CartLine]) -> Vec<Target> {
+    cart_lines
+        .iter()
+        .filter_map(|line| {
+            line.merchandise
+                .id
+                .as_ref()
+                .map(|id| Target::ProductVariant {
+                    id: id.to_string(),
+                    quantity: None,
+                })
+        })
+        .collect()
+}
+
+fn build_result(amount: f64, targets: Vec<Target>) -> FunctionResult {
+    let discounts = if targets.is_empty() {
+        vec![]
+    } else {
+        vec![Discount {
+            message: None,
+            conditions: None,
+            targets,
+            value: Value::FixedAmount(FixedAmount {
+                amount: format!("{}", amount),
+                applies_to_each_item: Some(false),
+            }),
+        }]
+    };
+    FunctionResult {
+        discounts,
+        discount_application_strategy: DiscountApplicationStrategy::First,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(
+        configuration: Option<Configuration>,
+        presentment_currency_rate: Option<Decimal>,
+    ) -> input::Input {
+        let cart = input::Cart {
+            lines: vec![
+                input::CartLine {
+                    id: "gid://shopify/CartLine/0".to_string(),
+                    merchandise: input::Merchandise {
+                        id: Some("gid://shopify/ProductVariant/0".to_string()),
+                    },
+                },
+                input::CartLine {
+                    id: "gid://shopify/CartLine/1".to_string(),
+                    merchandise: input::Merchandise {
+                        id: Some("gid://shopify/ProductVariant/1".to_string()),
+                    },
+                },
+            ],
+        };
+        let discount_node = input::DiscountNode {
+            metafield: configuration.map(|value| {
+                let value = serde_json::to_string(&value).unwrap();
+                input::Metafield { value }
+            }),
+        };
+        let presentment_currency_rate =
+            presentment_currency_rate.unwrap_or_else(|| "1.00".to_string());
+        input::Input {
+            cart,
+            discount_node,
+            presentment_currency_rate,
+        }
+    }
+
+    #[test]
+    fn test_discount_with_no_configuration() {
+        let input = input(None, None);
+        let handle_result = serde_json::json!(function(input).unwrap());
+
+        let expected_handle_result = serde_json::json!({
+            "discounts": [
+                {
+                    "targets": [
+                        { "productVariant": { "id": "gid://shopify/ProductVariant/0" } },
+                        { "productVariant": { "id": "gid://shopify/ProductVariant/1" } },
+                    ],
+                    "value": { "fixedAmount": { "amount": "50", "appliesToEachItem": false } },
+                }
+            ],
+            "discountApplicationStrategy": "FIRST",
+        });
+        assert_eq!(handle_result, expected_handle_result);
+    }
+
+    #[test]
+    fn test_discount_with_value() {
+        let input = input(Some(Configuration { value: 12.34 }), None);
+        let handle_result = serde_json::json!(function(input).unwrap());
+
+        let expected_handle_result = serde_json::json!({
+            "discounts": [
+                {
+                    "targets": [
+                        { "productVariant": { "id": "gid://shopify/ProductVariant/0" } },
+                        { "productVariant": { "id": "gid://shopify/ProductVariant/1" } },
+                    ],
+                    "value": { "fixedAmount": { "amount": "12.34", "appliesToEachItem": false } },
+                }
+            ],
+            "discountApplicationStrategy": "FIRST",
+        });
+        assert_eq!(handle_result, expected_handle_result);
+    }
+
+    #[test]
+    fn test_discount_with_presentment_currency_rate() {
+        let input = input(
+            Some(Configuration { value: 10.0 }),
+            Some("2.00".to_string()),
+        );
+        let handle_result = serde_json::json!(function(input).unwrap());
+
+        let expected_handle_result = serde_json::json!({
+            "discounts": [
+                {
+                    "targets": [
+                        { "productVariant": { "id": "gid://shopify/ProductVariant/0" } },
+                        { "productVariant": { "id": "gid://shopify/ProductVariant/1" } },
+                    ],
+                    "value": { "fixedAmount": { "amount": "20", "appliesToEachItem": false } },
+                }
+            ],
+            "discountApplicationStrategy": "FIRST",
+        });
+        assert_eq!(handle_result, expected_handle_result);
+    }
+
+    #[test]
+    fn test_discount_with_empty_cart_lines() {
+        let input = input::Input {
+            cart: input::Cart { lines: vec![] },
+            discount_node: input::DiscountNode { metafield: None },
+            presentment_currency_rate: "1.00".to_string(),
+        };
+        let handle_result = serde_json::json!(function(input).unwrap());
+
+        let expected_handle_result = serde_json::json!({
+            "discounts": [],
+            "discountApplicationStrategy": "FIRST",
+        });
+        assert_eq!(handle_result, expected_handle_result);
+    }
+}

--- a/discounts/rust/product-discounts/fixed-amount/src/main.rs
+++ b/discounts/rust/product-discounts/fixed-amount/src/main.rs
@@ -12,8 +12,8 @@ pub struct Configuration {
 impl Configuration {
     const DEFAULT_VALUE: f64 = 50.00;
 
-    fn from_str(str: &str) -> Self {
-        serde_json::from_str(str).expect("Unable to parse configuration value from metafield")
+    fn from_str(value: &str) -> Self {
+        serde_json::from_str(value).expect("Unable to parse configuration value from metafield")
     }
 }
 

--- a/discounts/rust/product-discounts/fixed-amount/src/main.rs
+++ b/discounts/rust/product-discounts/fixed-amount/src/main.rs
@@ -78,7 +78,7 @@ fn build_result(amount: f64, targets: Vec<Target>) -> FunctionResult {
             targets,
             value: Value::FixedAmount {
                 amount,
-                applies_to_each_item: Some(false),
+                applies_to_each_item: false,
             },
         }]
     };
@@ -210,7 +210,7 @@ mod tests {
         "#;
 
         let expected_input = input(
-            Some(Configuration { value: 10.00}),
+            Some(Configuration { value: 10.00 }),
             Some(2.00),
             Some(vec![
                 input::CartLine {

--- a/discounts/rust/product-discounts/fixed-amount/src/main.rs
+++ b/discounts/rust/product-discounts/fixed-amount/src/main.rs
@@ -91,44 +91,49 @@ fn build_result(amount: f64, targets: Vec<Target>) -> FunctionResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    impl Default for input::Input {
+        fn default() -> Self {
+            let json = r#"
+            {
+                "cart": {
+                    "lines": [
+                        { "id": "gid://shopify/CartLine/0", "merchandise": { "id": "gid://shopify/ProductVariant/0" } },
+                        { "id": "gid://shopify/CartLine/1", "merchandise": { "id": "gid://shopify/ProductVariant/1" } }
+                    ]
+                },
+                "discountNode": { "metafield": null },
+                "presentmentCurrencyRate": "1.00"
+            }
+            "#;
+            serde_json::from_str(json).unwrap()
+        }
+    }
 
     fn input(
         config: Option<Configuration>,
         presentment_currency_rate: Option<Decimal>,
+        cart_lines: Option<Vec<input::CartLine>>,
     ) -> input::Input {
-        let cart = input::Cart {
-            lines: vec![
-                input::CartLine {
-                    id: "gid://shopify/CartLine/0".to_string(),
-                    merchandise: input::Merchandise {
-                        id: Some("gid://shopify/ProductVariant/0".to_string()),
-                    },
-                },
-                input::CartLine {
-                    id: "gid://shopify/CartLine/1".to_string(),
-                    merchandise: input::Merchandise {
-                        id: Some("gid://shopify/ProductVariant/1".to_string()),
-                    },
-                },
-            ],
-        };
-        let discount_node = input::DiscountNode {
-            metafield: config.map(|value| {
-                let value = serde_json::to_string(&value).unwrap();
-                input::Metafield { value }
-            }),
-        };
-        let presentment_currency_rate = presentment_currency_rate.unwrap_or(1.00);
+        let default_input = input::Input::default();
+        let discount_node = config.map(|value| {
+            let value = serde_json::to_string(&value).unwrap();
+            input::DiscountNode {
+                metafield: Some(input::Metafield { value }),
+            }
+        });
         input::Input {
-            cart,
-            discount_node,
-            presentment_currency_rate,
+            discount_node: discount_node.unwrap_or(default_input.discount_node),
+            presentment_currency_rate: presentment_currency_rate
+                .unwrap_or(default_input.presentment_currency_rate),
+            cart: input::Cart {
+                lines: cart_lines.unwrap_or(default_input.cart.lines),
+            },
         }
     }
 
     #[test]
     fn test_discount_with_no_configuration() {
-        let input = input(None, None);
+        let input = input(None, None, None);
         let handle_result = serde_json::json!(function(input).unwrap());
 
         let expected_handle_result = serde_json::json!({
@@ -148,7 +153,7 @@ mod tests {
 
     #[test]
     fn test_discount_with_value() {
-        let input = input(Some(Configuration { value: 12.34 }), None);
+        let input = input(Some(Configuration { value: 12.34 }), None, None);
         let handle_result = serde_json::json!(function(input).unwrap());
 
         let expected_handle_result = serde_json::json!({
@@ -168,7 +173,7 @@ mod tests {
 
     #[test]
     fn test_discount_with_presentment_currency_rate() {
-        let input = input(Some(Configuration { value: 10.00 }), Some(2.00));
+        let input = input(Some(Configuration { value: 10.00 }), Some(2.00), None);
         let handle_result = serde_json::json!(function(input).unwrap());
 
         let expected_handle_result = serde_json::json!({
@@ -188,11 +193,7 @@ mod tests {
 
     #[test]
     fn test_discount_with_empty_cart_lines() {
-        let input = input::Input {
-            cart: input::Cart { lines: vec![] },
-            discount_node: input::DiscountNode { metafield: None },
-            presentment_currency_rate: 1.00,
-        };
+        let input = input(None, None, Some(vec![]));
         let handle_result = serde_json::json!(function(input).unwrap());
 
         let expected_handle_result = serde_json::json!({

--- a/discounts/rust/shipping-discounts/default/Cargo.toml.liquid
+++ b/discounts/rust/shipping-discounts/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{name | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/shipping-discounts/default/Cargo.toml.liquid
+++ b/discounts/rust/shipping-discounts/default/Cargo.toml.liquid
@@ -2,7 +2,7 @@
 name = "{{name | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-include = ["*.graphql"]
+include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/shipping-discounts/default/schema.graphql
+++ b/discounts/rust/shipping-discounts/default/schema.graphql
@@ -3386,7 +3386,7 @@ input Percentage {
 
   The value is validated against: >= 0.
   """
-  value: Float!
+  value: Decimal!
 }
 
 """

--- a/discounts/rust/shipping-discounts/default/src/api.rs
+++ b/discounts/rust/shipping-discounts/default/src/api.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use serde_with::{serde_as, DisplayFromStr};
-
 pub type Boolean = bool;
 pub type Decimal = f64;
 pub type Int = i32;
@@ -17,19 +15,19 @@ pub mod input {
         pub discount_node: DiscountNode,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct Metafield {
         pub value: String,
     }
 }
 
 use serde::Serialize;
-use serde_with::skip_serializing_none;
+use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]

--- a/discounts/rust/shipping-discounts/default/src/api.rs
+++ b/discounts/rust/shipping-discounts/default/src/api.rs
@@ -9,18 +9,18 @@ pub mod input {
     use super::*;
     use serde::Deserialize;
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct Metafield {
         pub value: String,
     }
@@ -74,12 +74,14 @@ pub enum Target {
     DeliveryGroup { id: ID },
 }
 
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     OrderMinimumSubtotal {
         excluded_variant_ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
@@ -92,6 +94,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },

--- a/discounts/rust/shipping-discounts/default/src/api.rs
+++ b/discounts/rust/shipping-discounts/default/src/api.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
+use serde_with::{serde_as, DisplayFromStr};
+
 pub type Boolean = bool;
-pub type Decimal = String;
+pub type Decimal = f64;
 pub type Int = i32;
 pub type ID = String;
 
@@ -52,21 +54,19 @@ pub struct Discount {
     pub conditions: Option<Vec<Condition>>,
 }
 
+#[skip_serializing_none]
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Value {
-    FixedAmount(FixedAmount),
-    Percentage(Percentage),
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct FixedAmount {
-    pub amount: Decimal,
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct Percentage {
-    pub value: Decimal,
+    FixedAmount {
+        #[serde_as(as = "DisplayFromStr")]
+        amount: Decimal,
+    },
+    Percentage {
+        #[serde_as(as = "DisplayFromStr")]
+        value: Decimal,
+    },
 }
 
 #[skip_serializing_none]

--- a/discounts/rust/shipping-discounts/default/src/main.rs
+++ b/discounts/rust/shipping-discounts/default/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::Error>> {
-    let _config: Configuration = input.configuration();
+    let _config = input.configuration();
     Ok(FunctionResult {
         discounts: vec![],
         discount_application_strategy: DiscountApplicationStrategy::First,
@@ -42,9 +42,9 @@ fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::E
 mod tests {
     use super::*;
 
-    fn input(configuration: Option<Configuration>) -> input::Input {
+    fn input(config: Option<Configuration>) -> input::Input {
         let discount_node = input::DiscountNode {
-            metafield: configuration.map(|value| {
+            metafield: config.map(|value| {
                 let value = serde_json::to_string(&value).unwrap();
                 input::Metafield { value }
             }),

--- a/discounts/rust/shipping-discounts/default/src/main.rs
+++ b/discounts/rust/shipping-discounts/default/src/main.rs
@@ -42,14 +42,28 @@ fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::E
 mod tests {
     use super::*;
 
+    impl Default for input::Input {
+        fn default() -> Self {
+            let json = r#"
+            {
+                "discountNode": { "metafield": null }
+            }
+            "#;
+            serde_json::from_str(json).unwrap()
+        }
+    }
+
     fn input(config: Option<Configuration>) -> input::Input {
-        let discount_node = input::DiscountNode {
-            metafield: config.map(|value| {
-                let value = serde_json::to_string(&value).unwrap();
-                input::Metafield { value }
-            }),
-        };
-        input::Input { discount_node }
+        let default_input = input::Input::default();
+        let discount_node = config.map(|value| {
+            let value = serde_json::to_string(&value).unwrap();
+            input::DiscountNode {
+                metafield: Some(input::Metafield { value }),
+            }
+        });
+        input::Input {
+            discount_node: discount_node.unwrap_or(default_input.discount_node),
+        }
     }
 
     #[test]

--- a/discounts/rust/shipping-discounts/default/src/main.rs
+++ b/discounts/rust/shipping-discounts/default/src/main.rs
@@ -8,8 +8,8 @@ use api::*;
 pub struct Configuration {}
 
 impl Configuration {
-    fn from_str(str: &str) -> Self {
-        serde_json::from_str(str).expect("Unable to parse configuration value from metafield")
+    fn from_str(value: &str) -> Self {
+        serde_json::from_str(value).expect("Unable to parse configuration value from metafield")
     }
 }
 

--- a/discounts/rust/shipping-discounts/fixed-amount/.gitignore
+++ b/discounts/rust/shipping-discounts/fixed-amount/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/discounts/rust/shipping-discounts/fixed-amount/Cargo.toml
+++ b/discounts/rust/shipping-discounts/fixed-amount/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fixed-amount"
+version = "1.0.0"
+edition = "2021"
+include = ["*.graphql"]
+
+[dependencies]
+serde = { version = "1.0.13", features = ["derive"] }
+serde_with = "1.13.0"
+serde_json = "1.0"
+
+[profile.release]
+lto = true
+opt-level = 'z'
+strip = true

--- a/discounts/rust/shipping-discounts/fixed-amount/Cargo.toml
+++ b/discounts/rust/shipping-discounts/fixed-amount/Cargo.toml
@@ -2,7 +2,6 @@
 name = "fixed-amount"
 version = "1.0.0"
 edition = "2021"
-include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/shipping-discounts/fixed-amount/Cargo.toml
+++ b/discounts/rust/shipping-discounts/fixed-amount/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fixed-amount"
 version = "1.0.0"
 edition = "2021"
-include = ["*.graphql"]
+include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/shipping-discounts/fixed-amount/README.md
+++ b/discounts/rust/shipping-discounts/fixed-amount/README.md
@@ -1,0 +1,21 @@
+# Shopify Function development with Rust
+
+## Dependencies
+
+- [Install Rust](https://www.rust-lang.org/tools/install)
+  - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
+- Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
+  - `cargo install cargo-wasi`
+- On Macs with Apple Silicon, you'll also need to install the Binaryen toolchain and set the `WASM_OPT` environment variable. ([related issue](https://github.com/bytecodealliance/cargo-wasi/issues/112))
+  - `brew install binaryen`
+  - Add `export WASM_OPT=/opt/homebrew/bin/wasm-opt` to your `.bashrc` or `.zshrc`
+
+## Building the function
+
+You can build this individual function using `cargo wasi`.
+
+```shell
+cargo wasi build --release
+```
+
+The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.function.extension.toml`.

--- a/discounts/rust/shipping-discounts/fixed-amount/input.graphql
+++ b/discounts/rust/shipping-discounts/fixed-amount/input.graphql
@@ -1,0 +1,12 @@
+query Input {
+  cart {
+    deliveryGroups {
+      id
+    }
+  }
+  discountNode {
+    metafield(namespace: "fixed-amount", key: "function-configuration") {
+      value
+    }
+  }
+}

--- a/discounts/rust/shipping-discounts/fixed-amount/input.graphql
+++ b/discounts/rust/shipping-discounts/fixed-amount/input.graphql
@@ -9,4 +9,5 @@ query Input {
       value
     }
   }
+  presentmentCurrencyRate
 }

--- a/discounts/rust/shipping-discounts/fixed-amount/metadata.json
+++ b/discounts/rust/shipping-discounts/fixed-amount/metadata.json
@@ -1,0 +1,1 @@
+{"schemaVersions":{"product_discounts":{"major":1,"minor":0}}}

--- a/discounts/rust/shipping-discounts/fixed-amount/schema.graphql
+++ b/discounts/rust/shipping-discounts/fixed-amount/schema.graphql
@@ -1,0 +1,2930 @@
+schema {
+  query: Input
+  mutation: MutationRoot
+}
+
+"""
+Exactly one field of input must be provided, and all others omitted.
+"""
+directive @oneOf on INPUT_OBJECT
+
+"""
+Represents a generic custom attribute.
+"""
+type Attribute {
+  """
+  Key or name of the attribute.
+  """
+  key: String!
+
+  """
+  Value of the attribute.
+  """
+  value: String
+}
+
+"""
+Represents information about the buyer that is interacting with the cart.
+"""
+type BuyerIdentity {
+  """
+  The customer associated with the cart.
+  """
+  customer: Customer
+
+  """
+  The email address of the buyer that is interacting with the cart.
+  """
+  email: String
+
+  """
+  The phone number of the buyer that is interacting with the cart.
+  """
+  phone: String
+}
+
+"""
+A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+"""
+type Cart {
+  """
+  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  """
+  attribute(
+    """
+    The key of the attribute to retrieve.
+    """
+    key: String
+  ): Attribute
+
+  """
+  Information about the buyer that is interacting with the cart.
+  """
+  buyerIdentity: BuyerIdentity
+
+  """
+  The costs that the buyer will pay at checkout.
+  """
+  cost: CartCost!
+
+  """
+  The delivery groups available for the cart based on the buyer's shipping address.
+  """
+  deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  A list of lines containing information about the items the customer intends to purchase.
+  """
+  lines: [CartLine!]!
+}
+
+"""
+The cost that the buyer will pay at checkout.
+"""
+type CartCost {
+  """
+  The amount, before taxes and discounts, for the customer to pay.
+  """
+  subtotalAmount: MoneyV2!
+
+  """
+  The total amount for the customer to pay.
+  """
+  totalAmount: MoneyV2!
+
+  """
+  The duty amount for the customer to pay at checkout.
+  """
+  totalDutyAmount: MoneyV2
+
+  """
+  The tax amount for the customer to pay at checkout.
+  """
+  totalTaxAmount: MoneyV2
+}
+
+"""
+Information about the options available for one or more line items to be delivered to a specific address.
+"""
+type CartDeliveryGroup {
+  """
+  A list of cart lines for the delivery group.
+  """
+  cartLines: [CartLine!]!
+
+  """
+  The destination address for the delivery group.
+  """
+  deliveryAddress: MailingAddress
+
+  """
+  The delivery options available for the delivery group.
+  """
+  deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  Unique identifier for the delivery group.
+  """
+  id: ID!
+
+  """
+  Information about the delivery option the buyer has selected.
+  """
+  selectedDeliveryOption: CartDeliveryOption
+}
+
+"""
+Information about a delivery option.
+"""
+type CartDeliveryOption {
+  """
+  The code of the delivery option.
+  """
+  code: String
+
+  """
+  The cost for the delivery option.
+  """
+  cost: MoneyV2!
+
+  """
+  The method for the delivery option.
+  """
+  deliveryMethodType: DeliveryMethod!
+
+  """
+  The description of the delivery option.
+  """
+  description: String
+
+  """
+  The title of the delivery option.
+  """
+  title: String
+}
+
+"""
+Represents information about the merchandise in the cart.
+"""
+type CartLine {
+  """
+  Retrieve a cart line attribute by key.
+  """
+  attribute(
+    """
+    The key of the attribute to retrieve.
+    """
+    key: String
+  ): Attribute
+
+  """
+  The cost of the merchandise line that the buyer will pay at checkout.
+  """
+  cost: CartLineCost!
+
+  """
+  The ID of the cart line.
+  """
+  id: ID!
+
+  """
+  The merchandise that the buyer intends to purchase.
+  """
+  merchandise: Merchandise!
+
+  """
+  The quantity of the merchandise that the customer intends to purchase.
+  """
+  quantity: Int!
+}
+
+"""
+The estimated cost of the merchandise line that the buyer will pay at checkout.
+"""
+type CartLineCost {
+  """
+  The amount of the merchandise line.
+  """
+  amount: MoneyV2!
+
+  """
+  The compare at amount of the merchandise line.
+  """
+  compareAtAmount: MoneyV2
+
+  """
+  The cost of the merchandise line before discounts.
+  """
+  subtotalAmount: MoneyV2!
+
+  """
+  The total cost of the merchandise line.
+  """
+  totalAmount: MoneyV2!
+}
+
+"""
+The condition for when to apply the discount.
+"""
+input Condition @oneOf {
+  """
+  The condition for checking the minimum quantity of a product.
+  """
+  productMinimumQuantity: ProductMinimumQuantity
+
+  """
+  The condition for checking the minimum subtotal amount of the product.
+  """
+  productMinimumSubtotal: ProductMinimumSubtotal
+}
+
+"""
+The code designating a country/region, which generally follows ISO 3166-1 alpha-2 guidelines.
+If a territory doesn't have a country code value in the `CountryCode` enum, it might be considered a subdivision
+of another country. For example, the territories associated with Spain are represented by the country code `ES`,
+and the territories associated with the United States of America are represented by the country code `US`.
+"""
+enum CountryCode {
+  """
+  Ascension Island.
+  """
+  AC
+
+  """
+  Andorra.
+  """
+  AD
+
+  """
+  United Arab Emirates.
+  """
+  AE
+
+  """
+  Afghanistan.
+  """
+  AF
+
+  """
+  Antigua & Barbuda.
+  """
+  AG
+
+  """
+  Anguilla.
+  """
+  AI
+
+  """
+  Albania.
+  """
+  AL
+
+  """
+  Armenia.
+  """
+  AM
+
+  """
+  Netherlands Antilles.
+  """
+  AN
+
+  """
+  Angola.
+  """
+  AO
+
+  """
+  Argentina.
+  """
+  AR
+
+  """
+  Austria.
+  """
+  AT
+
+  """
+  Australia.
+  """
+  AU
+
+  """
+  Aruba.
+  """
+  AW
+
+  """
+  Åland Islands.
+  """
+  AX
+
+  """
+  Azerbaijan.
+  """
+  AZ
+
+  """
+  Bosnia & Herzegovina.
+  """
+  BA
+
+  """
+  Barbados.
+  """
+  BB
+
+  """
+  Bangladesh.
+  """
+  BD
+
+  """
+  Belgium.
+  """
+  BE
+
+  """
+  Burkina Faso.
+  """
+  BF
+
+  """
+  Bulgaria.
+  """
+  BG
+
+  """
+  Bahrain.
+  """
+  BH
+
+  """
+  Burundi.
+  """
+  BI
+
+  """
+  Benin.
+  """
+  BJ
+
+  """
+  St. Barthélemy.
+  """
+  BL
+
+  """
+  Bermuda.
+  """
+  BM
+
+  """
+  Brunei.
+  """
+  BN
+
+  """
+  Bolivia.
+  """
+  BO
+
+  """
+  Caribbean Netherlands.
+  """
+  BQ
+
+  """
+  Brazil.
+  """
+  BR
+
+  """
+  Bahamas.
+  """
+  BS
+
+  """
+  Bhutan.
+  """
+  BT
+
+  """
+  Bouvet Island.
+  """
+  BV
+
+  """
+  Botswana.
+  """
+  BW
+
+  """
+  Belarus.
+  """
+  BY
+
+  """
+  Belize.
+  """
+  BZ
+
+  """
+  Canada.
+  """
+  CA
+
+  """
+  Cocos (Keeling) Islands.
+  """
+  CC
+
+  """
+  Congo - Kinshasa.
+  """
+  CD
+
+  """
+  Central African Republic.
+  """
+  CF
+
+  """
+  Congo - Brazzaville.
+  """
+  CG
+
+  """
+  Switzerland.
+  """
+  CH
+
+  """
+  Côte d’Ivoire.
+  """
+  CI
+
+  """
+  Cook Islands.
+  """
+  CK
+
+  """
+  Chile.
+  """
+  CL
+
+  """
+  Cameroon.
+  """
+  CM
+
+  """
+  China.
+  """
+  CN
+
+  """
+  Colombia.
+  """
+  CO
+
+  """
+  Costa Rica.
+  """
+  CR
+
+  """
+  Cuba.
+  """
+  CU
+
+  """
+  Cape Verde.
+  """
+  CV
+
+  """
+  Curaçao.
+  """
+  CW
+
+  """
+  Christmas Island.
+  """
+  CX
+
+  """
+  Cyprus.
+  """
+  CY
+
+  """
+  Czechia.
+  """
+  CZ
+
+  """
+  Germany.
+  """
+  DE
+
+  """
+  Djibouti.
+  """
+  DJ
+
+  """
+  Denmark.
+  """
+  DK
+
+  """
+  Dominica.
+  """
+  DM
+
+  """
+  Dominican Republic.
+  """
+  DO
+
+  """
+  Algeria.
+  """
+  DZ
+
+  """
+  Ecuador.
+  """
+  EC
+
+  """
+  Estonia.
+  """
+  EE
+
+  """
+  Egypt.
+  """
+  EG
+
+  """
+  Western Sahara.
+  """
+  EH
+
+  """
+  Eritrea.
+  """
+  ER
+
+  """
+  Spain.
+  """
+  ES
+
+  """
+  Ethiopia.
+  """
+  ET
+
+  """
+  Finland.
+  """
+  FI
+
+  """
+  Fiji.
+  """
+  FJ
+
+  """
+  Falkland Islands.
+  """
+  FK
+
+  """
+  Faroe Islands.
+  """
+  FO
+
+  """
+  France.
+  """
+  FR
+
+  """
+  Gabon.
+  """
+  GA
+
+  """
+  United Kingdom.
+  """
+  GB
+
+  """
+  Grenada.
+  """
+  GD
+
+  """
+  Georgia.
+  """
+  GE
+
+  """
+  French Guiana.
+  """
+  GF
+
+  """
+  Guernsey.
+  """
+  GG
+
+  """
+  Ghana.
+  """
+  GH
+
+  """
+  Gibraltar.
+  """
+  GI
+
+  """
+  Greenland.
+  """
+  GL
+
+  """
+  Gambia.
+  """
+  GM
+
+  """
+  Guinea.
+  """
+  GN
+
+  """
+  Guadeloupe.
+  """
+  GP
+
+  """
+  Equatorial Guinea.
+  """
+  GQ
+
+  """
+  Greece.
+  """
+  GR
+
+  """
+  South Georgia & South Sandwich Islands.
+  """
+  GS
+
+  """
+  Guatemala.
+  """
+  GT
+
+  """
+  Guinea-Bissau.
+  """
+  GW
+
+  """
+  Guyana.
+  """
+  GY
+
+  """
+  Hong Kong SAR.
+  """
+  HK
+
+  """
+  Heard & McDonald Islands.
+  """
+  HM
+
+  """
+  Honduras.
+  """
+  HN
+
+  """
+  Croatia.
+  """
+  HR
+
+  """
+  Haiti.
+  """
+  HT
+
+  """
+  Hungary.
+  """
+  HU
+
+  """
+  Indonesia.
+  """
+  ID
+
+  """
+  Ireland.
+  """
+  IE
+
+  """
+  Israel.
+  """
+  IL
+
+  """
+  Isle of Man.
+  """
+  IM
+
+  """
+  India.
+  """
+  IN
+
+  """
+  British Indian Ocean Territory.
+  """
+  IO
+
+  """
+  Iraq.
+  """
+  IQ
+
+  """
+  Iran.
+  """
+  IR
+
+  """
+  Iceland.
+  """
+  IS
+
+  """
+  Italy.
+  """
+  IT
+
+  """
+  Jersey.
+  """
+  JE
+
+  """
+  Jamaica.
+  """
+  JM
+
+  """
+  Jordan.
+  """
+  JO
+
+  """
+  Japan.
+  """
+  JP
+
+  """
+  Kenya.
+  """
+  KE
+
+  """
+  Kyrgyzstan.
+  """
+  KG
+
+  """
+  Cambodia.
+  """
+  KH
+
+  """
+  Kiribati.
+  """
+  KI
+
+  """
+  Comoros.
+  """
+  KM
+
+  """
+  St. Kitts & Nevis.
+  """
+  KN
+
+  """
+  North Korea.
+  """
+  KP
+
+  """
+  South Korea.
+  """
+  KR
+
+  """
+  Kuwait.
+  """
+  KW
+
+  """
+  Cayman Islands.
+  """
+  KY
+
+  """
+  Kazakhstan.
+  """
+  KZ
+
+  """
+  Laos.
+  """
+  LA
+
+  """
+  Lebanon.
+  """
+  LB
+
+  """
+  St. Lucia.
+  """
+  LC
+
+  """
+  Liechtenstein.
+  """
+  LI
+
+  """
+  Sri Lanka.
+  """
+  LK
+
+  """
+  Liberia.
+  """
+  LR
+
+  """
+  Lesotho.
+  """
+  LS
+
+  """
+  Lithuania.
+  """
+  LT
+
+  """
+  Luxembourg.
+  """
+  LU
+
+  """
+  Latvia.
+  """
+  LV
+
+  """
+  Libya.
+  """
+  LY
+
+  """
+  Morocco.
+  """
+  MA
+
+  """
+  Monaco.
+  """
+  MC
+
+  """
+  Moldova.
+  """
+  MD
+
+  """
+  Montenegro.
+  """
+  ME
+
+  """
+  St. Martin.
+  """
+  MF
+
+  """
+  Madagascar.
+  """
+  MG
+
+  """
+  North Macedonia.
+  """
+  MK
+
+  """
+  Mali.
+  """
+  ML
+
+  """
+  Myanmar (Burma).
+  """
+  MM
+
+  """
+  Mongolia.
+  """
+  MN
+
+  """
+  Macao SAR.
+  """
+  MO
+
+  """
+  Martinique.
+  """
+  MQ
+
+  """
+  Mauritania.
+  """
+  MR
+
+  """
+  Montserrat.
+  """
+  MS
+
+  """
+  Malta.
+  """
+  MT
+
+  """
+  Mauritius.
+  """
+  MU
+
+  """
+  Maldives.
+  """
+  MV
+
+  """
+  Malawi.
+  """
+  MW
+
+  """
+  Mexico.
+  """
+  MX
+
+  """
+  Malaysia.
+  """
+  MY
+
+  """
+  Mozambique.
+  """
+  MZ
+
+  """
+  Namibia.
+  """
+  NA
+
+  """
+  New Caledonia.
+  """
+  NC
+
+  """
+  Niger.
+  """
+  NE
+
+  """
+  Norfolk Island.
+  """
+  NF
+
+  """
+  Nigeria.
+  """
+  NG
+
+  """
+  Nicaragua.
+  """
+  NI
+
+  """
+  Netherlands.
+  """
+  NL
+
+  """
+  Norway.
+  """
+  NO
+
+  """
+  Nepal.
+  """
+  NP
+
+  """
+  Nauru.
+  """
+  NR
+
+  """
+  Niue.
+  """
+  NU
+
+  """
+  New Zealand.
+  """
+  NZ
+
+  """
+  Oman.
+  """
+  OM
+
+  """
+  Panama.
+  """
+  PA
+
+  """
+  Peru.
+  """
+  PE
+
+  """
+  French Polynesia.
+  """
+  PF
+
+  """
+  Papua New Guinea.
+  """
+  PG
+
+  """
+  Philippines.
+  """
+  PH
+
+  """
+  Pakistan.
+  """
+  PK
+
+  """
+  Poland.
+  """
+  PL
+
+  """
+  St. Pierre & Miquelon.
+  """
+  PM
+
+  """
+  Pitcairn Islands.
+  """
+  PN
+
+  """
+  Palestinian Territories.
+  """
+  PS
+
+  """
+  Portugal.
+  """
+  PT
+
+  """
+  Paraguay.
+  """
+  PY
+
+  """
+  Qatar.
+  """
+  QA
+
+  """
+  Réunion.
+  """
+  RE
+
+  """
+  Romania.
+  """
+  RO
+
+  """
+  Serbia.
+  """
+  RS
+
+  """
+  Russia.
+  """
+  RU
+
+  """
+  Rwanda.
+  """
+  RW
+
+  """
+  Saudi Arabia.
+  """
+  SA
+
+  """
+  Solomon Islands.
+  """
+  SB
+
+  """
+  Seychelles.
+  """
+  SC
+
+  """
+  Sudan.
+  """
+  SD
+
+  """
+  Sweden.
+  """
+  SE
+
+  """
+  Singapore.
+  """
+  SG
+
+  """
+  St. Helena.
+  """
+  SH
+
+  """
+  Slovenia.
+  """
+  SI
+
+  """
+  Svalbard & Jan Mayen.
+  """
+  SJ
+
+  """
+  Slovakia.
+  """
+  SK
+
+  """
+  Sierra Leone.
+  """
+  SL
+
+  """
+  San Marino.
+  """
+  SM
+
+  """
+  Senegal.
+  """
+  SN
+
+  """
+  Somalia.
+  """
+  SO
+
+  """
+  Suriname.
+  """
+  SR
+
+  """
+  South Sudan.
+  """
+  SS
+
+  """
+  São Tomé & Príncipe.
+  """
+  ST
+
+  """
+  El Salvador.
+  """
+  SV
+
+  """
+  Sint Maarten.
+  """
+  SX
+
+  """
+  Syria.
+  """
+  SY
+
+  """
+  Eswatini.
+  """
+  SZ
+
+  """
+  Tristan da Cunha.
+  """
+  TA
+
+  """
+  Turks & Caicos Islands.
+  """
+  TC
+
+  """
+  Chad.
+  """
+  TD
+
+  """
+  French Southern Territories.
+  """
+  TF
+
+  """
+  Togo.
+  """
+  TG
+
+  """
+  Thailand.
+  """
+  TH
+
+  """
+  Tajikistan.
+  """
+  TJ
+
+  """
+  Tokelau.
+  """
+  TK
+
+  """
+  Timor-Leste.
+  """
+  TL
+
+  """
+  Turkmenistan.
+  """
+  TM
+
+  """
+  Tunisia.
+  """
+  TN
+
+  """
+  Tonga.
+  """
+  TO
+
+  """
+  Turkey.
+  """
+  TR
+
+  """
+  Trinidad & Tobago.
+  """
+  TT
+
+  """
+  Tuvalu.
+  """
+  TV
+
+  """
+  Taiwan.
+  """
+  TW
+
+  """
+  Tanzania.
+  """
+  TZ
+
+  """
+  Ukraine.
+  """
+  UA
+
+  """
+  Uganda.
+  """
+  UG
+
+  """
+  U.S. Outlying Islands.
+  """
+  UM
+
+  """
+  United States.
+  """
+  US
+
+  """
+  Uruguay.
+  """
+  UY
+
+  """
+  Uzbekistan.
+  """
+  UZ
+
+  """
+  Vatican City.
+  """
+  VA
+
+  """
+  St. Vincent & Grenadines.
+  """
+  VC
+
+  """
+  Venezuela.
+  """
+  VE
+
+  """
+  British Virgin Islands.
+  """
+  VG
+
+  """
+  Vietnam.
+  """
+  VN
+
+  """
+  Vanuatu.
+  """
+  VU
+
+  """
+  Wallis & Futuna.
+  """
+  WF
+
+  """
+  Samoa.
+  """
+  WS
+
+  """
+  Kosovo.
+  """
+  XK
+
+  """
+  Yemen.
+  """
+  YE
+
+  """
+  Mayotte.
+  """
+  YT
+
+  """
+  South Africa.
+  """
+  ZA
+
+  """
+  Zambia.
+  """
+  ZM
+
+  """
+  Zimbabwe.
+  """
+  ZW
+
+  """
+  Unknown Region.
+  """
+  ZZ
+}
+
+"""
+The three-letter currency codes that represent the world currencies used in
+stores. These include standard ISO 4217 codes, legacy codes,
+and non-standard codes.
+"""
+enum CurrencyCode {
+  """
+  United Arab Emirates Dirham (AED).
+  """
+  AED
+
+  """
+  Afghan Afghani (AFN).
+  """
+  AFN
+
+  """
+  Albanian Lek (ALL).
+  """
+  ALL
+
+  """
+  Armenian Dram (AMD).
+  """
+  AMD
+
+  """
+  Netherlands Antillean Guilder.
+  """
+  ANG
+
+  """
+  Angolan Kwanza (AOA).
+  """
+  AOA
+
+  """
+  Argentine Pesos (ARS).
+  """
+  ARS
+
+  """
+  Australian Dollars (AUD).
+  """
+  AUD
+
+  """
+  Aruban Florin (AWG).
+  """
+  AWG
+
+  """
+  Azerbaijani Manat (AZN).
+  """
+  AZN
+
+  """
+  Bosnia and Herzegovina Convertible Mark (BAM).
+  """
+  BAM
+
+  """
+  Barbadian Dollar (BBD).
+  """
+  BBD
+
+  """
+  Bangladesh Taka (BDT).
+  """
+  BDT
+
+  """
+  Bulgarian Lev (BGN).
+  """
+  BGN
+
+  """
+  Bahraini Dinar (BHD).
+  """
+  BHD
+
+  """
+  Burundian Franc (BIF).
+  """
+  BIF
+
+  """
+  Bermudian Dollar (BMD).
+  """
+  BMD
+
+  """
+  Brunei Dollar (BND).
+  """
+  BND
+
+  """
+  Bolivian Boliviano (BOB).
+  """
+  BOB
+
+  """
+  Brazilian Real (BRL).
+  """
+  BRL
+
+  """
+  Bahamian Dollar (BSD).
+  """
+  BSD
+
+  """
+  Bhutanese Ngultrum (BTN).
+  """
+  BTN
+
+  """
+  Botswana Pula (BWP).
+  """
+  BWP
+
+  """
+  Belarusian Ruble (BYN).
+  """
+  BYN
+
+  """
+  Belarusian Ruble (BYR).
+  """
+  BYR @deprecated(reason: "`BYR` is deprecated. Use `BYN` available from version `2021-01` onwards instead.")
+
+  """
+  Belize Dollar (BZD).
+  """
+  BZD
+
+  """
+  Canadian Dollars (CAD).
+  """
+  CAD
+
+  """
+  Congolese franc (CDF).
+  """
+  CDF
+
+  """
+  Swiss Francs (CHF).
+  """
+  CHF
+
+  """
+  Chilean Peso (CLP).
+  """
+  CLP
+
+  """
+  Chinese Yuan Renminbi (CNY).
+  """
+  CNY
+
+  """
+  Colombian Peso (COP).
+  """
+  COP
+
+  """
+  Costa Rican Colones (CRC).
+  """
+  CRC
+
+  """
+  Cape Verdean escudo (CVE).
+  """
+  CVE
+
+  """
+  Czech Koruny (CZK).
+  """
+  CZK
+
+  """
+  Djiboutian Franc (DJF).
+  """
+  DJF
+
+  """
+  Danish Kroner (DKK).
+  """
+  DKK
+
+  """
+  Dominican Peso (DOP).
+  """
+  DOP
+
+  """
+  Algerian Dinar (DZD).
+  """
+  DZD
+
+  """
+  Egyptian Pound (EGP).
+  """
+  EGP
+
+  """
+  Eritrean Nakfa (ERN).
+  """
+  ERN
+
+  """
+  Ethiopian Birr (ETB).
+  """
+  ETB
+
+  """
+  Euro (EUR).
+  """
+  EUR
+
+  """
+  Fijian Dollars (FJD).
+  """
+  FJD
+
+  """
+  Falkland Islands Pounds (FKP).
+  """
+  FKP
+
+  """
+  United Kingdom Pounds (GBP).
+  """
+  GBP
+
+  """
+  Georgian Lari (GEL).
+  """
+  GEL
+
+  """
+  Ghanaian Cedi (GHS).
+  """
+  GHS
+
+  """
+  Gibraltar Pounds (GIP).
+  """
+  GIP
+
+  """
+  Gambian Dalasi (GMD).
+  """
+  GMD
+
+  """
+  Guinean Franc (GNF).
+  """
+  GNF
+
+  """
+  Guatemalan Quetzal (GTQ).
+  """
+  GTQ
+
+  """
+  Guyanese Dollar (GYD).
+  """
+  GYD
+
+  """
+  Hong Kong Dollars (HKD).
+  """
+  HKD
+
+  """
+  Honduran Lempira (HNL).
+  """
+  HNL
+
+  """
+  Croatian Kuna (HRK).
+  """
+  HRK
+
+  """
+  Haitian Gourde (HTG).
+  """
+  HTG
+
+  """
+  Hungarian Forint (HUF).
+  """
+  HUF
+
+  """
+  Indonesian Rupiah (IDR).
+  """
+  IDR
+
+  """
+  Israeli New Shekel (NIS).
+  """
+  ILS
+
+  """
+  Indian Rupees (INR).
+  """
+  INR
+
+  """
+  Iraqi Dinar (IQD).
+  """
+  IQD
+
+  """
+  Iranian Rial (IRR).
+  """
+  IRR
+
+  """
+  Icelandic Kronur (ISK).
+  """
+  ISK
+
+  """
+  Jersey Pound.
+  """
+  JEP
+
+  """
+  Jamaican Dollars (JMD).
+  """
+  JMD
+
+  """
+  Jordanian Dinar (JOD).
+  """
+  JOD
+
+  """
+  Japanese Yen (JPY).
+  """
+  JPY
+
+  """
+  Kenyan Shilling (KES).
+  """
+  KES
+
+  """
+  Kyrgyzstani Som (KGS).
+  """
+  KGS
+
+  """
+  Cambodian Riel.
+  """
+  KHR
+
+  """
+  Kiribati Dollar (KID).
+  """
+  KID
+
+  """
+  Comorian Franc (KMF).
+  """
+  KMF
+
+  """
+  South Korean Won (KRW).
+  """
+  KRW
+
+  """
+  Kuwaiti Dinar (KWD).
+  """
+  KWD
+
+  """
+  Cayman Dollars (KYD).
+  """
+  KYD
+
+  """
+  Kazakhstani Tenge (KZT).
+  """
+  KZT
+
+  """
+  Laotian Kip (LAK).
+  """
+  LAK
+
+  """
+  Lebanese Pounds (LBP).
+  """
+  LBP
+
+  """
+  Sri Lankan Rupees (LKR).
+  """
+  LKR
+
+  """
+  Liberian Dollar (LRD).
+  """
+  LRD
+
+  """
+  Lesotho Loti (LSL).
+  """
+  LSL
+
+  """
+  Lithuanian Litai (LTL).
+  """
+  LTL
+
+  """
+  Latvian Lati (LVL).
+  """
+  LVL
+
+  """
+  Libyan Dinar (LYD).
+  """
+  LYD
+
+  """
+  Moroccan Dirham.
+  """
+  MAD
+
+  """
+  Moldovan Leu (MDL).
+  """
+  MDL
+
+  """
+  Malagasy Ariary (MGA).
+  """
+  MGA
+
+  """
+  Macedonia Denar (MKD).
+  """
+  MKD
+
+  """
+  Burmese Kyat (MMK).
+  """
+  MMK
+
+  """
+  Mongolian Tugrik.
+  """
+  MNT
+
+  """
+  Macanese Pataca (MOP).
+  """
+  MOP
+
+  """
+  Mauritanian Ouguiya (MRU).
+  """
+  MRU
+
+  """
+  Mauritian Rupee (MUR).
+  """
+  MUR
+
+  """
+  Maldivian Rufiyaa (MVR).
+  """
+  MVR
+
+  """
+  Malawian Kwacha (MWK).
+  """
+  MWK
+
+  """
+  Mexican Pesos (MXN).
+  """
+  MXN
+
+  """
+  Malaysian Ringgits (MYR).
+  """
+  MYR
+
+  """
+  Mozambican Metical.
+  """
+  MZN
+
+  """
+  Namibian Dollar.
+  """
+  NAD
+
+  """
+  Nigerian Naira (NGN).
+  """
+  NGN
+
+  """
+  Nicaraguan Córdoba (NIO).
+  """
+  NIO
+
+  """
+  Norwegian Kroner (NOK).
+  """
+  NOK
+
+  """
+  Nepalese Rupee (NPR).
+  """
+  NPR
+
+  """
+  New Zealand Dollars (NZD).
+  """
+  NZD
+
+  """
+  Omani Rial (OMR).
+  """
+  OMR
+
+  """
+  Panamian Balboa (PAB).
+  """
+  PAB
+
+  """
+  Peruvian Nuevo Sol (PEN).
+  """
+  PEN
+
+  """
+  Papua New Guinean Kina (PGK).
+  """
+  PGK
+
+  """
+  Philippine Peso (PHP).
+  """
+  PHP
+
+  """
+  Pakistani Rupee (PKR).
+  """
+  PKR
+
+  """
+  Polish Zlotych (PLN).
+  """
+  PLN
+
+  """
+  Paraguayan Guarani (PYG).
+  """
+  PYG
+
+  """
+  Qatari Rial (QAR).
+  """
+  QAR
+
+  """
+  Romanian Lei (RON).
+  """
+  RON
+
+  """
+  Serbian dinar (RSD).
+  """
+  RSD
+
+  """
+  Russian Rubles (RUB).
+  """
+  RUB
+
+  """
+  Rwandan Franc (RWF).
+  """
+  RWF
+
+  """
+  Saudi Riyal (SAR).
+  """
+  SAR
+
+  """
+  Solomon Islands Dollar (SBD).
+  """
+  SBD
+
+  """
+  Seychellois Rupee (SCR).
+  """
+  SCR
+
+  """
+  Sudanese Pound (SDG).
+  """
+  SDG
+
+  """
+  Swedish Kronor (SEK).
+  """
+  SEK
+
+  """
+  Singapore Dollars (SGD).
+  """
+  SGD
+
+  """
+  Saint Helena Pounds (SHP).
+  """
+  SHP
+
+  """
+  Sierra Leonean Leone (SLL).
+  """
+  SLL
+
+  """
+  Somali Shilling (SOS).
+  """
+  SOS
+
+  """
+  Surinamese Dollar (SRD).
+  """
+  SRD
+
+  """
+  South Sudanese Pound (SSP).
+  """
+  SSP
+
+  """
+  Sao Tome And Principe Dobra (STD).
+  """
+  STD @deprecated(reason: "`STD` is deprecated. Use `STN` available from version `2022-07` onwards instead.")
+
+  """
+  Sao Tome And Principe Dobra (STN).
+  """
+  STN
+
+  """
+  Syrian Pound (SYP).
+  """
+  SYP
+
+  """
+  Swazi Lilangeni (SZL).
+  """
+  SZL
+
+  """
+  Thai baht (THB).
+  """
+  THB
+
+  """
+  Tajikistani Somoni (TJS).
+  """
+  TJS
+
+  """
+  Turkmenistani Manat (TMT).
+  """
+  TMT
+
+  """
+  Tunisian Dinar (TND).
+  """
+  TND
+
+  """
+  Tongan Pa'anga (TOP).
+  """
+  TOP
+
+  """
+  Turkish Lira (TRY).
+  """
+  TRY
+
+  """
+  Trinidad and Tobago Dollars (TTD).
+  """
+  TTD
+
+  """
+  Taiwan Dollars (TWD).
+  """
+  TWD
+
+  """
+  Tanzanian Shilling (TZS).
+  """
+  TZS
+
+  """
+  Ukrainian Hryvnia (UAH).
+  """
+  UAH
+
+  """
+  Ugandan Shilling (UGX).
+  """
+  UGX
+
+  """
+  United States Dollars (USD).
+  """
+  USD
+
+  """
+  Uruguayan Pesos (UYU).
+  """
+  UYU
+
+  """
+  Uzbekistan som (UZS).
+  """
+  UZS
+
+  """
+  Venezuelan Bolivares (VED).
+  """
+  VED
+
+  """
+  Venezuelan Bolivares (VEF).
+  """
+  VEF @deprecated(reason: "`VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead.")
+
+  """
+  Venezuelan Bolivares (VES).
+  """
+  VES
+
+  """
+  Vietnamese đồng (VND).
+  """
+  VND
+
+  """
+  Vanuatu Vatu (VUV).
+  """
+  VUV
+
+  """
+  Samoan Tala (WST).
+  """
+  WST
+
+  """
+  Central African CFA Franc (XAF).
+  """
+  XAF
+
+  """
+  East Caribbean Dollar (XCD).
+  """
+  XCD
+
+  """
+  West African CFA franc (XOF).
+  """
+  XOF
+
+  """
+  CFP Franc (XPF).
+  """
+  XPF
+
+  """
+  Unrecognized currency.
+  """
+  XXX
+
+  """
+  Yemeni Rial (YER).
+  """
+  YER
+
+  """
+  South African Rand (ZAR).
+  """
+  ZAR
+
+  """
+  Zambian Kwacha (ZMW).
+  """
+  ZMW
+}
+
+"""
+A custom product.
+"""
+type CustomProduct {
+  """
+  Whether the merchandise is a gift card.
+  """
+  isGiftCard: Boolean!
+
+  """
+  Whether the merchandise requires shipping.
+  """
+  requiresShipping: Boolean!
+
+  """
+  The weight of the product variant in the unit system specified with `weight_unit`.
+  """
+  weight: Float
+
+  """
+  Unit of measurement for weight.
+  """
+  weightUnit: WeightUnit!
+}
+
+"""
+Represents a customer with the shop.
+"""
+type Customer implements HasMetafields {
+  """
+  The total amount of money spent by the customer.
+  """
+  amountSpent: MoneyV2!
+
+  """
+  The customer’s name, email or phone number.
+  """
+  displayName: String!
+
+  """
+  The customer’s email address.
+  """
+  email: String
+
+  """
+  Whether the customer has any of the given tags.
+  """
+  hasAnyTag(
+    """
+    The tags to search for.
+    """
+    tags: [String!]! = []
+  ): Boolean!
+
+  """
+  A unique identifier for the customer.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  The number of orders made by the customer.
+  """
+  numberOfOrders: Int!
+}
+
+"""
+A signed decimal number, which supports arbitrary precision and is serialized as a string.
+
+Example values: `"29.99"`, `"29.999"`.
+"""
+scalar Decimal
+
+"""
+List of different delivery method types.
+"""
+enum DeliveryMethod {
+  """
+  Local Delivery.
+  """
+  LOCAL
+
+  """
+  None.
+  """
+  NONE
+
+  """
+  Shipping to a Pickup Point.
+  """
+  PICKUP_POINT
+
+  """
+  Local Pickup.
+  """
+  PICK_UP
+
+  """
+  Retail.
+  """
+  RETAIL
+
+  """
+  Shipping.
+  """
+  SHIPPING
+}
+
+"""
+The discount to be applied.
+"""
+input Discount {
+  """
+  The condition for when the discount is applied.
+  """
+  conditions: [Condition!]
+
+  """
+  The discount message.
+  """
+  message: String
+
+  """
+  The targets of the discount.
+  """
+  targets: [Target!]!
+
+  """
+  The value of the discount.
+  """
+  value: Value!
+}
+
+"""
+The strategy that's applied to the list of discounts.
+"""
+enum DiscountApplicationStrategy {
+  """
+  Only apply the first discount with conditions that are satisfied.
+  """
+  FIRST
+
+  """
+  Only apply the discount that offers the maximum reduction.
+  """
+  MAXIMUM
+}
+
+"""
+A discount wrapper node.
+"""
+type DiscountNode implements HasMetafields {
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+}
+
+"""
+A fixed amount value.
+"""
+input FixedAmount {
+  """
+  The fixed amount value of the discount, in the currency of the cart.
+
+  The amount must be greater than or equal to 0.
+  """
+  amount: Decimal!
+
+  """
+  Whether to apply the value to each entitled item.
+
+  The default value is `false`, which causes the value to be applied once across the entitled items.
+  When the value is `true`, the value will be applied to each of the entitled items.
+  """
+  appliesToEachItem: Boolean
+}
+
+"""
+The result of the function.
+"""
+input FunctionResult {
+  """
+  The strategy to apply the list of discounts.
+  """
+  discountApplicationStrategy: DiscountApplicationStrategy!
+
+  """
+  The list of discounts to be applied.
+  """
+  discounts: [Discount!]!
+}
+
+"""
+Represents information about the metafields associated to the specified resource.
+"""
+interface HasMetafields {
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+}
+
+"""
+Represents a unique identifier that is Base64 obfuscated. It is often used to
+refetch an object or as key for a cache. The ID type appears in a JSON response
+as a String; however, it is not intended to be human-readable. When expected as
+an input type, any string (such as `"VXNlci0xMA=="`) or integer (such as `4`)
+input value will be accepted as an ID.
+"""
+scalar ID
+
+"""
+The input object for the function.
+"""
+type Input {
+  """
+  The cart to discount.
+  """
+  cart: Cart!
+
+  """
+  The discount node executing the function.
+  """
+  discountNode: DiscountNode!
+
+  """
+  The localization of the function execution context.
+  """
+  localization: Cart!
+
+  """
+  The conversion rate between the shop's currency and the currency of the cart.
+  """
+  presentmentCurrencyRate: Decimal
+}
+
+"""
+Represents a mailing address.
+"""
+type MailingAddress {
+  """
+  The first line of the address. Typically the street address or PO Box number.
+  """
+  address1: String
+
+  """
+  The second line of the address. Typically the number of the apartment, suite, or unit.
+  """
+  address2: String
+
+  """
+  The name of the city, district, village, or town.
+  """
+  city: String
+
+  """
+  The name of the customer's company or organization.
+  """
+  company: String
+
+  """
+  The two-letter code for the country of the address. For example, US.
+  """
+  countryCode: CountryCode
+
+  """
+  The first name of the customer.
+  """
+  firstName: String
+
+  """
+  The last name of the customer.
+  """
+  lastName: String
+
+  """
+  The full name of the customer, based on firstName and lastName.
+  """
+  name: String
+
+  """
+  A unique phone number for the customer. Formatted using E.164 standard. For example, +16135551111.
+  """
+  phone: String
+
+  """
+  The two-letter code for the region. For example, ON.
+  """
+  provinceCode: String
+
+  """
+  The zip or postal code of the address.
+  """
+  zip: String
+}
+
+"""
+The merchandise to be purchased at checkout.
+"""
+union Merchandise = CustomProduct | ProductVariant
+
+"""
+[Metafields](https://shopify.dev/apps/metafields)
+enable you to attach additional information to a
+Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
+or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
+For more information about the Shopify resources that you can attach metafields to, refer to
+[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+"""
+type Metafield {
+  """
+  The type of data that the metafield stores in the `value` field.
+  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  """
+  type: String!
+
+  """
+  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  """
+  value: String!
+}
+
+"""
+A monetary value with currency.
+"""
+type MoneyV2 {
+  """
+  Decimal money amount.
+  """
+  amount: Decimal!
+
+  """
+  Currency of the money.
+  """
+  currencyCode: CurrencyCode!
+}
+
+"""
+The root mutation for the API.
+"""
+type MutationRoot {
+  """
+  Handles the function result.
+  """
+  handleResult(
+    """
+    The result of the function.
+    """
+    result: FunctionResult!
+  ): Void!
+}
+
+"""
+A percentage value.
+"""
+input Percentage {
+  """
+  The percentage value.
+
+  The value is validated against: >= 0.
+  """
+  value: Float!
+}
+
+"""
+Represents a product.
+"""
+type Product implements HasMetafields {
+  """
+  A unique human-friendly string of the product's title.
+  """
+  handle: String!
+
+  """
+  Whether the product has any of the given tags.
+  """
+  hasAnyTag(
+    """
+    The tags to search for.
+    """
+    tags: [String!]! = []
+  ): Boolean!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Whether the product has any of the given collection.
+  """
+  inAnyCollection(
+    """
+    The collections to search for.
+    """
+    ids: [ID!]! = []
+  ): Boolean!
+
+  """
+  Whether the product is a gift card.
+  """
+  isGiftCard: Boolean!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  The product type specified by the merchant.
+  """
+  productType: String
+
+  """
+  The name of the product's vendor.
+  """
+  vendor: String
+}
+
+"""
+The condition for checking the minimum quantity of a product.
+"""
+input ProductMinimumQuantity {
+  """
+  Variant IDs with a merchandise line price that's included to calculate the minimum quantity of the product.
+  """
+  ids: [ID!]!
+
+  """
+  The minimum quantity of a product.
+  """
+  minimumQuantity: Int!
+
+  """
+  The target type of the condition.
+
+  The value is validated against: = "PRODUCT_VARIANT".
+  """
+  targetType: TargetType!
+}
+
+"""
+The condition for checking the minimum subtotal amount of the product.
+"""
+input ProductMinimumSubtotal {
+  """
+  Variant IDs with a merchandise line price that's included to calculate the minimum subtotal amount of a product.
+  """
+  ids: [ID!]!
+
+  """
+  The minimum subtotal amount of the product.
+  """
+  minimumAmount: Float!
+
+  """
+  The target type of the condition.
+
+  The value is validated against: = "PRODUCT_VARIANT".
+  """
+  targetType: TargetType!
+}
+
+"""
+Represents a product variant.
+"""
+type ProductVariant implements HasMetafields {
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  The product that this variant belongs to.
+  """
+  product: Product!
+
+  """
+  Whether the merchandise requires shipping.
+  """
+  requiresShipping: Boolean!
+
+  """
+  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  """
+  sku: String
+
+  """
+  The weight of the product variant in the unit system specified with `weight_unit`.
+  """
+  weight: Float
+
+  """
+  Unit of measurement for weight.
+  """
+  weightUnit: WeightUnit!
+}
+
+"""
+The target product variant.
+"""
+input ProductVariantTarget {
+  """
+  The ID of the target product variant.
+  """
+  id: ID!
+
+  """
+  The number of line items that are being discounted.
+  The default value is `null`, which represents the quantity of the matching line items.
+
+  The value is validated against: > 0.
+  """
+  quantity: Int
+}
+
+"""
+The target of the discount.
+"""
+input Target @oneOf {
+  """
+  The target product variant.
+  """
+  productVariant: ProductVariantTarget
+}
+
+"""
+The target type of a condition.
+"""
+enum TargetType {
+  """
+  The target is the subtotal of the order.
+  """
+  ORDER_SUBTOTAL
+
+  """
+  The target is a product variant.
+  """
+  PRODUCT_VARIANT
+}
+
+"""
+The value of the discount.
+"""
+input Value @oneOf {
+  """
+  A fixed amount value.
+  """
+  fixedAmount: FixedAmount
+
+  """
+  A percentage value.
+  """
+  percentage: Percentage
+}
+
+"""
+A void type that can be used to return a null value from a mutation.
+"""
+scalar Void
+
+"""
+Units of measurement for weight.
+"""
+enum WeightUnit {
+  """
+  Metric system unit of mass.
+  """
+  GRAMS
+
+  """
+  1 kilogram equals 1000 grams.
+  """
+  KILOGRAMS
+
+  """
+  Imperial system unit of mass.
+  """
+  OUNCES
+
+  """
+  1 pound equals 16 ounces.
+  """
+  POUNDS
+}

--- a/discounts/rust/shipping-discounts/fixed-amount/schema.graphql
+++ b/discounts/rust/shipping-discounts/fixed-amount/schema.graphql
@@ -224,21 +224,6 @@ type CartLineCost {
 }
 
 """
-The condition for when to apply the discount.
-"""
-input Condition @oneOf {
-  """
-  The condition for checking the minimum quantity of a product.
-  """
-  productMinimumQuantity: ProductMinimumQuantity
-
-  """
-  The condition for checking the minimum subtotal amount of the product.
-  """
-  productMinimumSubtotal: ProductMinimumSubtotal
-}
-
-"""
 The code designating a country/region, which generally follows ISO 3166-1 alpha-2 guidelines.
 If a territory doesn't have a country code value in the `CountryCode` enum, it might be considered a subdivision
 of another country. For example, the territories associated with Spain are represented by the country code `ES`,
@@ -2371,6 +2356,16 @@ Example values: `"29.99"`, `"29.999"`.
 scalar Decimal
 
 """
+The target delivery group.
+"""
+input DeliveryGroupTarget {
+  """
+  The ID of the target delivery group.
+  """
+  id: ID!
+}
+
+"""
 List of different delivery method types.
 """
 enum DeliveryMethod {
@@ -2409,11 +2404,6 @@ enum DeliveryMethod {
 The discount to be applied.
 """
 input Discount {
-  """
-  The condition for when the discount is applied.
-  """
-  conditions: [Condition!]
-
   """
   The discount message.
   """
@@ -2475,14 +2465,6 @@ input FixedAmount {
   The amount must be greater than or equal to 0.
   """
   amount: Decimal!
-
-  """
-  Whether to apply the value to each entitled item.
-
-  The default value is `false`, which causes the value to be applied once across the entitled items.
-  When the value is `true`, the value will be applied to each of the entitled items.
-  """
-  appliesToEachItem: Boolean
 }
 
 """
@@ -2679,7 +2661,7 @@ input Percentage {
 
   The value is validated against: >= 0.
   """
-  value: Float!
+  value: Decimal!
 }
 
 """
@@ -2748,50 +2730,6 @@ type Product implements HasMetafields {
 }
 
 """
-The condition for checking the minimum quantity of a product.
-"""
-input ProductMinimumQuantity {
-  """
-  Variant IDs with a merchandise line price that's included to calculate the minimum quantity of the product.
-  """
-  ids: [ID!]!
-
-  """
-  The minimum quantity of a product.
-  """
-  minimumQuantity: Int!
-
-  """
-  The target type of the condition.
-
-  The value is validated against: = "PRODUCT_VARIANT".
-  """
-  targetType: TargetType!
-}
-
-"""
-The condition for checking the minimum subtotal amount of the product.
-"""
-input ProductMinimumSubtotal {
-  """
-  Variant IDs with a merchandise line price that's included to calculate the minimum subtotal amount of a product.
-  """
-  ids: [ID!]!
-
-  """
-  The minimum subtotal amount of the product.
-  """
-  minimumAmount: Float!
-
-  """
-  The target type of the condition.
-
-  The value is validated against: = "PRODUCT_VARIANT".
-  """
-  targetType: TargetType!
-}
-
-"""
 Represents a product variant.
 """
 type ProductVariant implements HasMetafields {
@@ -2842,50 +2780,17 @@ type ProductVariant implements HasMetafields {
 }
 
 """
-The target product variant.
-"""
-input ProductVariantTarget {
-  """
-  The ID of the target product variant.
-  """
-  id: ID!
-
-  """
-  The number of line items that are being discounted.
-  The default value is `null`, which represents the quantity of the matching line items.
-
-  The value is validated against: > 0.
-  """
-  quantity: Int
-}
-
-"""
 The target of the discount.
 """
 input Target @oneOf {
   """
-  The target product variant.
+  The target delivery group.
   """
-  productVariant: ProductVariantTarget
+  deliveryGroup: DeliveryGroupTarget
 }
 
 """
-The target type of a condition.
-"""
-enum TargetType {
-  """
-  The target is the subtotal of the order.
-  """
-  ORDER_SUBTOTAL
-
-  """
-  The target is a product variant.
-  """
-  PRODUCT_VARIANT
-}
-
-"""
-The value of the discount.
+The discount value.
 """
 input Value @oneOf {
   """

--- a/discounts/rust/shipping-discounts/fixed-amount/shopify.function.extension.toml
+++ b/discounts/rust/shipping-discounts/fixed-amount/shopify.function.extension.toml
@@ -1,0 +1,7 @@
+name = "Fixed Amount"
+type = "product_discounts"
+api_version = "2022-07"
+
+[build]
+command = "cargo wasi build --release"
+path = "target/wasm32-wasi/release/fixed-amount.wasm"

--- a/discounts/rust/shipping-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/shipping-discounts/fixed-amount/src/api.rs
@@ -1,0 +1,120 @@
+#![allow(dead_code)]
+
+pub type Boolean = bool;
+pub type Decimal = String;
+pub type Int = i32;
+pub type ID = String;
+
+pub mod input {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Input {
+        pub discount_node: DiscountNode,
+        pub cart: Cart,
+        pub presentment_currency_rate: String,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Default)]
+    pub struct DiscountNode {
+        pub metafield: Option<Metafield>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Default)]
+    pub struct Metafield {
+        pub value: String,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Cart {
+        pub delivery_groups: Vec<CartDeliveryGroup>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct CartDeliveryGroup {
+        pub id: ID,
+    }
+}
+
+use serde::Serialize;
+use serde_with::skip_serializing_none;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct FunctionResult {
+    pub discount_application_strategy: DiscountApplicationStrategy,
+    pub discounts: Vec<Discount>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
+pub enum DiscountApplicationStrategy {
+    First,
+    Maximum,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Serialize)]
+pub struct Discount {
+    pub value: Value,
+    pub targets: Vec<Target>,
+    pub message: Option<String>,
+    pub conditions: Option<Vec<Condition>>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub enum Value {
+    FixedAmount(FixedAmount),
+    Percentage(Percentage),
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct FixedAmount {
+    pub amount: Decimal,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct Percentage {
+    pub value: Decimal,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub enum Target {
+    DeliveryGroup { id: ID },
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub enum Condition {
+    #[serde(rename_all(serialize = "camelCase"))]
+    OrderMinimumSubtotal {
+        excluded_variant_ids: Vec<ID>,
+        minimum_amount: Decimal,
+        target_type: ConditionTargetType,
+    },
+    #[serde(rename_all(serialize = "camelCase"))]
+    ProductMinimumQuantity {
+        ids: Vec<ID>,
+        minimum_quantity: Int,
+        target_type: ConditionTargetType,
+    },
+    #[serde(rename_all(serialize = "camelCase"))]
+    ProductMinimumSubtotal {
+        ids: Vec<ID>,
+        minimum_amount: Decimal,
+        target_type: ConditionTargetType,
+    },
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
+pub enum ConditionTargetType {
+    OrderSubtotal,
+    ProductVariant,
+}

--- a/discounts/rust/shipping-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/shipping-discounts/fixed-amount/src/api.rs
@@ -10,7 +10,7 @@ pub mod input {
     use serde::Deserialize;
 
     #[serde_as]
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
@@ -19,23 +19,23 @@ pub mod input {
         pub presentment_currency_rate: Decimal,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct Metafield {
         pub value: String,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct Cart {
         pub delivery_groups: Vec<CartDeliveryGroup>,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct CartDeliveryGroup {
         pub id: ID,
     }
@@ -89,12 +89,14 @@ pub enum Target {
     DeliveryGroup { id: ID },
 }
 
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     OrderMinimumSubtotal {
         excluded_variant_ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
@@ -107,6 +109,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },

--- a/discounts/rust/shipping-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/shipping-discounts/fixed-amount/src/api.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use serde_with::{serde_as, DisplayFromStr};
-
 pub type Boolean = bool;
 pub type Decimal = f64;
 pub type Int = i32;
@@ -11,20 +9,22 @@ pub mod input {
     use super::*;
     use serde::Deserialize;
 
+    #[serde_as]
     #[derive(Clone, Debug, Deserialize)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
         pub cart: Cart,
+        #[serde_as(as = "DisplayFromStr")]
         pub presentment_currency_rate: Decimal,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct Metafield {
         pub value: String,
     }
@@ -42,7 +42,7 @@ pub mod input {
 }
 
 use serde::Serialize;
-use serde_with::skip_serializing_none;
+use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]

--- a/discounts/rust/shipping-discounts/fixed-amount/src/api.rs
+++ b/discounts/rust/shipping-discounts/fixed-amount/src/api.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
+use serde_with::{serde_as, DisplayFromStr};
+
 pub type Boolean = bool;
-pub type Decimal = String;
+pub type Decimal = f64;
 pub type Int = i32;
 pub type ID = String;
 
@@ -14,7 +16,7 @@ pub mod input {
     pub struct Input {
         pub discount_node: DiscountNode,
         pub cart: Cart,
-        pub presentment_currency_rate: String,
+        pub presentment_currency_rate: Decimal,
     }
 
     #[derive(Clone, Debug, Deserialize, Default)]
@@ -65,21 +67,19 @@ pub struct Discount {
     pub conditions: Option<Vec<Condition>>,
 }
 
+#[skip_serializing_none]
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Value {
-    FixedAmount(FixedAmount),
-    Percentage(Percentage),
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct FixedAmount {
-    pub amount: Decimal,
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct Percentage {
-    pub value: Decimal,
+    FixedAmount {
+        #[serde_as(as = "DisplayFromStr")]
+        amount: Decimal,
+    },
+    Percentage {
+        #[serde_as(as = "DisplayFromStr")]
+        value: Decimal,
+    },
 }
 
 #[skip_serializing_none]

--- a/discounts/rust/shipping-discounts/fixed-amount/src/main.rs
+++ b/discounts/rust/shipping-discounts/fixed-amount/src/main.rs
@@ -1,0 +1,203 @@
+use serde::{Deserialize, Serialize};
+
+mod api;
+use api::*;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Configuration {
+    pub value: f64,
+}
+
+impl Configuration {
+    const DEFAULT_VALUE: f64 = 50.00;
+
+    fn from_str(str: &str) -> Self {
+        serde_json::from_str(str).expect("Unable to parse configuration value from metafield")
+    }
+}
+
+impl Default for Configuration {
+    fn default() -> Self {
+        Configuration {
+            value: Self::DEFAULT_VALUE,
+        }
+    }
+}
+
+impl input::Input {
+    pub fn configuration(&self) -> Configuration {
+        match &self.discount_node.metafield {
+            Some(input::Metafield { value }) => Configuration::from_str(value),
+            None => Configuration::default(),
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let input: input::Input = serde_json::from_reader(std::io::BufReader::new(std::io::stdin()))?;
+    let mut out = std::io::stdout();
+    let mut serializer = serde_json::Serializer::new(&mut out);
+    function(input)?.serialize(&mut serializer)?;
+    Ok(())
+}
+
+fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::Error>> {
+    let delivery_groups = &input.cart.delivery_groups;
+    let config: Configuration = input.configuration();
+
+    let converted_value = convert_to_cart_currency(config.value, &input);
+    let targets = targets(delivery_groups);
+    Ok(build_result(converted_value, targets))
+}
+
+fn convert_to_cart_currency(value: f64, input: &input::Input) -> f64 {
+    let rate = &input.presentment_currency_rate;
+    value
+        * rate
+            .parse::<f64>()
+            .expect("presentment_currency_rate is malformed.")
+}
+
+fn targets(delivery_groups: &[input::CartDeliveryGroup]) -> Vec<Target> {
+    delivery_groups
+        .iter()
+        .map(|line| Target::DeliveryGroup {
+            id: line.id.to_string(),
+        })
+        .collect()
+}
+
+fn build_result(amount: f64, targets: Vec<Target>) -> FunctionResult {
+    let discounts = if targets.is_empty() {
+        vec![]
+    } else {
+        vec![Discount {
+            message: None,
+            conditions: None,
+            targets,
+            value: Value::FixedAmount(FixedAmount {
+                amount: format!("{}", amount),
+            }),
+        }]
+    };
+    FunctionResult {
+        discounts,
+        discount_application_strategy: DiscountApplicationStrategy::First,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(
+        configuration: Option<Configuration>,
+        presentment_currency_rate: Option<Decimal>,
+    ) -> input::Input {
+        let cart = input::Cart {
+            delivery_groups: vec![
+                input::CartDeliveryGroup {
+                    id: "gid://shopify/CartDeliveryGroup/0".to_string(),
+                },
+                input::CartDeliveryGroup {
+                    id: "gid://shopify/CartDeliveryGroup/1".to_string(),
+                },
+            ],
+        };
+        let discount_node = input::DiscountNode {
+            metafield: configuration.map(|value| {
+                let value = serde_json::to_string(&value).unwrap();
+                input::Metafield { value }
+            }),
+        };
+        let presentment_currency_rate =
+            presentment_currency_rate.unwrap_or_else(|| "1.00".to_string());
+        input::Input {
+            cart,
+            discount_node,
+            presentment_currency_rate,
+        }
+    }
+
+    #[test]
+    fn test_discount_with_no_configuration() {
+        let input = input(None, None);
+        let handle_result = serde_json::json!(function(input).unwrap());
+
+        let expected_handle_result = serde_json::json!({
+            "discounts": [
+                {
+                    "targets": [
+                        { "deliveryGroup": { "id": "gid://shopify/CartDeliveryGroup/0" } },
+                        { "deliveryGroup": { "id": "gid://shopify/CartDeliveryGroup/1" } },
+                    ],
+                    "value": { "fixedAmount": { "amount": "50" } },
+                }
+            ],
+            "discountApplicationStrategy": "FIRST",
+        });
+        assert_eq!(handle_result, expected_handle_result);
+    }
+
+    #[test]
+    fn test_discount_with_value() {
+        let input = input(Some(Configuration { value: 12.34 }), None);
+        let handle_result = serde_json::json!(function(input).unwrap());
+
+        let expected_handle_result = serde_json::json!({
+            "discounts": [
+                {
+                    "targets": [
+                        { "deliveryGroup": { "id": "gid://shopify/CartDeliveryGroup/0" } },
+                        { "deliveryGroup": { "id": "gid://shopify/CartDeliveryGroup/1" } },
+                    ],
+                    "value": { "fixedAmount": { "amount": "12.34" } },
+                }
+            ],
+            "discountApplicationStrategy": "FIRST",
+        });
+        assert_eq!(handle_result, expected_handle_result);
+    }
+
+    #[test]
+    fn test_discount_with_presentment_currency_rate() {
+        let input = input(
+            Some(Configuration { value: 10.0 }),
+            Some("2.00".to_string()),
+        );
+        let handle_result = serde_json::json!(function(input).unwrap());
+
+        let expected_handle_result = serde_json::json!({
+            "discounts": [
+                {
+                    "targets": [
+                        { "deliveryGroup": { "id": "gid://shopify/CartDeliveryGroup/0" } },
+                        { "deliveryGroup": { "id": "gid://shopify/CartDeliveryGroup/1" } },
+                    ],
+                    "value": { "fixedAmount": { "amount": "20" } },
+                }
+            ],
+            "discountApplicationStrategy": "FIRST",
+        });
+        assert_eq!(handle_result, expected_handle_result);
+    }
+
+    #[test]
+    fn test_discount_with_empty_cart_delivery_groups() {
+        let input = input::Input {
+            cart: input::Cart {
+                delivery_groups: vec![],
+            },
+            discount_node: input::DiscountNode { metafield: None },
+            presentment_currency_rate: "1.00".to_string(),
+        };
+        let handle_result = serde_json::json!(function(input).unwrap());
+
+        let expected_handle_result = serde_json::json!({
+            "discounts": [],
+            "discountApplicationStrategy": "FIRST",
+        });
+        assert_eq!(handle_result, expected_handle_result);
+    }
+}

--- a/discounts/rust/shipping-discounts/fixed-amount/src/main.rs
+++ b/discounts/rust/shipping-discounts/fixed-amount/src/main.rs
@@ -12,8 +12,8 @@ pub struct Configuration {
 impl Configuration {
     const DEFAULT_VALUE: f64 = 50.00;
 
-    fn from_str(str: &str) -> Self {
-        serde_json::from_str(str).expect("Unable to parse configuration value from metafield")
+    fn from_str(value: &str) -> Self {
+        serde_json::from_str(value).expect("Unable to parse configuration value from metafield")
     }
 }
 

--- a/discounts/wasm/order-discounts/default/schema.graphql
+++ b/discounts/wasm/order-discounts/default/schema.graphql
@@ -3407,7 +3407,7 @@ input OrderMinimumSubtotal {
   """
   The minimum subtotal amount of the order.
   """
-  minimumAmount: Float!
+  minimumAmount: Decimal!
 
   """
   The target type of the condition.
@@ -3436,7 +3436,7 @@ input Percentage {
 
   The value is validated against: >= 0.
   """
-  value: Float!
+  value: Decimal!
 }
 
 """
@@ -3538,7 +3538,7 @@ input ProductMinimumSubtotal {
   """
   The minimum subtotal amount of the product.
   """
-  minimumAmount: Float!
+  minimumAmount: Decimal!
 
   """
   The target type of the condition.

--- a/discounts/wasm/product-discounts/default/schema.graphql
+++ b/discounts/wasm/product-discounts/default/schema.graphql
@@ -3404,7 +3404,7 @@ input Percentage {
 
   The value is validated against: >= 0.
   """
-  value: Float!
+  value: Decimal!
 }
 
 """
@@ -3506,7 +3506,7 @@ input ProductMinimumSubtotal {
   """
   The minimum subtotal amount of the product.
   """
-  minimumAmount: Float!
+  minimumAmount: Decimal!
 
   """
   The target type of the condition.

--- a/discounts/wasm/shipping-discounts/default/schema.graphql
+++ b/discounts/wasm/shipping-discounts/default/schema.graphql
@@ -3386,7 +3386,7 @@ input Percentage {
 
   The value is validated against: >= 0.
   """
-  value: Float!
+  value: Decimal!
 }
 
 """

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/Cargo.toml
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/Cargo.toml
@@ -2,7 +2,6 @@
 name = "order-discount"
 version = "1.0.0"
 edition = "2021"
-include = []
 
 [dependencies]
 serde = {version = "1.0.13", features = ["derive"]}

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/Cargo.toml
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-edition = "2021"
-include = ["*.graphql"]
 name = "order-discount"
 version = "1.0.0"
+edition = "2021"
+include = []
 
 [dependencies]
 serde = {version = "1.0.13", features = ["derive"]}

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/schema.graphql
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/schema.graphql
@@ -244,6 +244,7 @@ input Condition @oneOf {
 }
 
 """
+<<<<<<< HEAD
 A country.
 """
 type Country {
@@ -254,6 +255,8 @@ type Country {
 }
 
 """
+=======
+>>>>>>> c03791f (Update schemas)
 The code designating a country/region, which generally follows ISO 3166-1 alpha-2 guidelines.
 If a territory doesn't have a country code value in the `CountryCode` enum, it might be considered a subdivision
 of another country. For example, the territories associated with Spain are represented by the country code `ES`,
@@ -3407,7 +3410,7 @@ input OrderMinimumSubtotal {
   """
   The minimum subtotal amount of the order.
   """
-  minimumAmount: Float!
+  minimumAmount: Decimal!
 
   """
   The target type of the condition.
@@ -3436,7 +3439,7 @@ input Percentage {
 
   The value is validated against: >= 0.
   """
-  value: Float!
+  value: Decimal!
 }
 
 """
@@ -3538,7 +3541,7 @@ input ProductMinimumSubtotal {
   """
   The minimum subtotal amount of the product.
   """
-  minimumAmount: Float!
+  minimumAmount: Decimal!
 
   """
   The target type of the condition.

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/src/api.rs
@@ -6,7 +6,6 @@ pub type Int = i32;
 pub type ID = String;
 
 pub mod input {
-    use super::*;
     use serde::Deserialize;
 
     #[derive(Clone, Debug, Deserialize)]
@@ -82,12 +81,14 @@ pub enum Target {
     },
 }
 
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     OrderMinimumSubtotal {
         excluded_variant_ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
@@ -100,6 +101,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/src/api.rs
@@ -8,18 +8,18 @@ pub type ID = String;
 pub mod input {
     use serde::Deserialize;
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Metafield {
         pub value: String,

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/src/api.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use serde_with::{serde_as, DisplayFromStr};
-
 pub type Boolean = bool;
 pub type Decimal = f64;
 pub type Int = i32;
@@ -11,26 +9,26 @@ pub mod input {
     use super::*;
     use serde::Deserialize;
 
-    #[serde_as]
     #[derive(Clone, Debug, Deserialize)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Metafield {
         pub value: String,
     }
 }
 
 use serde::Serialize;
-use serde_with::skip_serializing_none;
+use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/src/api.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
+use serde_with::{serde_as, DisplayFromStr};
+
 pub type Boolean = bool;
-pub type Decimal = String;
+pub type Decimal = f64;
 pub type Int = i32;
 pub type ID = String;
 
@@ -9,6 +11,7 @@ pub mod input {
     use super::*;
     use serde::Deserialize;
 
+    #[serde_as]
     #[derive(Clone, Debug, Deserialize)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
@@ -52,21 +55,19 @@ pub struct Discount {
     pub conditions: Option<Vec<Condition>>,
 }
 
+#[skip_serializing_none]
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Value {
-    FixedAmount(FixedAmount),
-    Percentage(Percentage),
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct FixedAmount {
-    pub amount: Decimal,
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct Percentage {
-    pub value: Decimal,
+    FixedAmount {
+        #[serde_as(as = "DisplayFromStr")]
+        amount: Decimal,
+    },
+    Percentage {
+        #[serde_as(as = "DisplayFromStr")]
+        value: Decimal,
+    },
 }
 
 #[skip_serializing_none]

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/src/api.rs
@@ -1,11 +1,12 @@
 #![allow(dead_code)]
 
 pub type Boolean = bool;
-pub type Float = f64;
+pub type Decimal = String;
 pub type Int = i32;
 pub type ID = String;
 
 pub mod input {
+    use super::*;
     use serde::Deserialize;
 
     #[derive(Clone, Debug, Deserialize)]
@@ -59,14 +60,13 @@ pub enum Value {
 }
 
 #[derive(Clone, Debug, Serialize)]
-#[serde(rename_all(serialize = "camelCase"))]
 pub struct FixedAmount {
-    pub value: Float,
+    pub amount: Decimal,
 }
 
 #[derive(Clone, Debug, Serialize)]
 pub struct Percentage {
-    pub value: Float,
+    pub value: Decimal,
 }
 
 #[skip_serializing_none]
@@ -89,7 +89,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     OrderMinimumSubtotal {
         excluded_variant_ids: Vec<ID>,
-        minimum_amount: Float,
+        minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
     #[serde(rename_all(serialize = "camelCase"))]
@@ -101,7 +101,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
-        minimum_amount: Float,
+        minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
 }

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
@@ -13,8 +13,8 @@ pub struct Configuration {
 impl Configuration {
     pub const DEFAULT_VALUE: f64 = 50.0;
 
-    fn from_str(str: &str) -> Self {
-        serde_json::from_str(str).expect("Unable to parse configuration value from metafield")
+    fn from_str(value: &str) -> Self {
+        serde_json::from_str(value).expect("Unable to parse configuration value from metafield")
     }
 }
 

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
@@ -65,15 +65,28 @@ fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::E
 mod tests {
     use super::*;
 
-    fn input(configuration: Option<Configuration>) -> input::Input {
-        let discount_node = input::DiscountNode {
-            metafield: configuration.map(|value| {
-                let value = serde_json::to_string(&value).unwrap();
-                input::Metafield { value }
-            }),
-        };
+    impl Default for input::Input {
+        fn default() -> Self {
+            let json = r#"
+            {
+                "discountNode": { "metafield": null }
+            }
+            "#;
+            serde_json::from_str(json).unwrap()
+        }
+    }
 
-        input::Input { discount_node }
+    fn input(config: Option<Configuration>) -> input::Input {
+        let default_input = input::Input::default();
+        let discount_node = config.map(|value| {
+            let value = serde_json::to_string(&value).unwrap();
+            input::DiscountNode {
+                metafield: Some(input::Metafield { value }),
+            }
+        });
+        input::Input {
+            discount_node: discount_node.unwrap_or(default_input.discount_node),
+        }
     }
 
     #[test]

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
@@ -130,11 +130,34 @@ mod tests {
 
     #[test]
     fn test_input_deserialization() {
-        let input = r#"
+        let input_json = r#"
         {
-            "discountNode": { "metafield": null }
+            "cart": {
+                "lines": [
+                    {
+                        "id": "gid://shopify/CartLine/0",
+                        "merchandise": { "id": "gid://shopify/ProductVariant/0" }
+                    },
+                    {
+                        "id": "gid://shopify/CartLine/1",
+                        "merchandise": {}
+                    }
+                ]
+            },
+            "discountNode": {
+                "metafield": {
+                    "value": "{\"value\":10.0,\"excludedVariantIds\":[\"gid://shopify/ProductVariant/1\"]}"
+                }
+            }
         }
         "#;
-        assert!(serde_json::from_str::<input::Input>(input).is_ok());
+
+        let expected_input = input(
+            Some(Configuration {
+                value: 10.00,
+                excluded_variant_ids: vec!["gid://shopify/ProductVariant/1".to_string()],
+            })
+        );
+        assert_eq!(expected_input, serde_json::from_str::<input::Input>(input_json).unwrap());
     }
 }

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
@@ -53,9 +53,9 @@ fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::E
             targets: vec![Target::OrderSubtotal {
                 excluded_variant_ids: config.excluded_variant_ids,
             }],
-            value: Value::Percentage(Percentage {
-                value: format!("{}", config.value),
-            }),
+            value: Value::Percentage {
+                value: config.value,
+            },
         }],
         discount_application_strategy: DiscountApplicationStrategy::First,
     })

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
@@ -54,7 +54,7 @@ fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::E
                 excluded_variant_ids: config.excluded_variant_ids,
             }],
             value: Value::Percentage(Percentage {
-                value: config.value,
+                value: format!("{}", config.value),
             }),
         }],
         discount_application_strategy: DiscountApplicationStrategy::First,
@@ -84,7 +84,7 @@ mod tests {
         let expected_handle_result = serde_json::json!({
             "discounts": [{
                 "targets": [{ "orderSubtotal": { "excludedVariantIds": [] } }],
-                "value": { "percentage": { "value": 50.0 } },
+                "value": { "percentage": { "value": "50" } },
             }],
             "discountApplicationStrategy": "FIRST",
         });
@@ -94,7 +94,7 @@ mod tests {
     #[test]
     fn test_discount_with_value() {
         let input = input(Some(Configuration {
-            value: 10.0,
+            value: 12.34,
             excluded_variant_ids: vec![],
         }));
         let result = serde_json::json!(function(input).unwrap());
@@ -102,7 +102,7 @@ mod tests {
         let expected_result = serde_json::json!({
             "discounts": [{
                 "targets": [{ "orderSubtotal": { "excludedVariantIds": [] } }],
-                "value": { "percentage": { "value": 10.0 } },
+                "value": { "percentage": { "value": "12.34" } },
             }],
             "discountApplicationStrategy": "FIRST",
         });
@@ -120,7 +120,7 @@ mod tests {
         let expected_result = serde_json::json!({
             "discounts": [{
                 "targets": [{ "orderSubtotal": { "excludedVariantIds": ["gid://shopify/ProductVariant/1"] } }],
-                "value": { "percentage": { "value": 50.0 } },
+                "value": { "percentage": { "value": "50" } },
             }],
             "discountApplicationStrategy": "FIRST",
         });

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/src/main.rs
@@ -65,27 +65,15 @@ fn function(input: input::Input) -> Result<FunctionResult, Box<dyn std::error::E
 mod tests {
     use super::*;
 
-    impl Default for input::Input {
-        fn default() -> Self {
-            let json = r#"
-            {
-                "discountNode": { "metafield": null }
-            }
-            "#;
-            serde_json::from_str(json).unwrap()
-        }
-    }
-
-    fn input(config: Option<Configuration>) -> input::Input {
-        let default_input = input::Input::default();
-        let discount_node = config.map(|value| {
-            let value = serde_json::to_string(&value).unwrap();
-            input::DiscountNode {
-                metafield: Some(input::Metafield { value }),
-            }
-        });
+    fn input(
+        config: Option<Configuration>,
+    ) -> input::Input {
         input::Input {
-            discount_node: discount_node.unwrap_or(default_input.discount_node),
+            discount_node: input::DiscountNode {
+                metafield: Some(input::Metafield {
+                    value: serde_json::to_string(&config.unwrap_or_default()).unwrap()
+                })
+            }
         }
     }
 
@@ -138,5 +126,15 @@ mod tests {
             "discountApplicationStrategy": "FIRST",
         });
         assert_eq!(result, expected_result);
+    }
+
+    #[test]
+    fn test_input_deserialization() {
+        let input = r#"
+        {
+            "discountNode": { "metafield": null }
+        }
+        "#;
+        assert!(serde_json::from_str::<input::Input>(input).is_ok());
     }
 }

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/Cargo.toml
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/Cargo.toml
@@ -2,7 +2,7 @@
 name = "product-discount"
 version = "1.0.0"
 edition = "2021"
-include = ["*.graphql"]
+include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/Cargo.toml
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/Cargo.toml
@@ -2,7 +2,6 @@
 name = "product-discount"
 version = "1.0.0"
 edition = "2021"
-include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/schema.graphql
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/schema.graphql
@@ -239,6 +239,7 @@ input Condition @oneOf {
 }
 
 """
+<<<<<<< HEAD
 A country.
 """
 type Country {
@@ -249,6 +250,8 @@ type Country {
 }
 
 """
+=======
+>>>>>>> c03791f (Update schemas)
 The code designating a country/region, which generally follows ISO 3166-1 alpha-2 guidelines.
 If a territory doesn't have a country code value in the `CountryCode` enum, it might be considered a subdivision
 of another country. For example, the territories associated with Spain are represented by the country code `ES`,
@@ -3404,7 +3407,7 @@ input Percentage {
 
   The value is validated against: >= 0.
   """
-  value: Float!
+  value: Decimal!
 }
 
 """
@@ -3506,7 +3509,7 @@ input ProductMinimumSubtotal {
   """
   The minimum subtotal amount of the product.
   """
-  minimumAmount: Float!
+  minimumAmount: Decimal!
 
   """
   The target type of the condition.

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/src/api.rs
@@ -9,35 +9,35 @@ pub mod input {
     use super::*;
     use serde::Deserialize;
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
         pub cart: Cart,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct Metafield {
         pub value: String,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct Cart {
         pub lines: Vec<CartLine>,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct CartLine {
         pub id: ID,
         pub merchandise: Merchandise,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct Merchandise {
         pub id: Option<ID>,
     }

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/src/api.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use serde_with::{serde_as, DisplayFromStr};
-
 pub type Boolean = bool;
 pub type Decimal = f64;
 pub type Int = i32;
@@ -18,12 +16,12 @@ pub mod input {
         pub cart: Cart,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct Metafield {
         pub value: String,
     }
@@ -46,7 +44,7 @@ pub mod input {
 }
 
 use serde::Serialize;
-use serde_with::skip_serializing_none;
+use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/src/api.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 pub type Boolean = bool;
-pub type Float = f64;
+pub type Decimal = String;
 pub type Int = i32;
 pub type ID = String;
 
@@ -77,16 +77,17 @@ pub enum Value {
     Percentage(Percentage),
 }
 
+#[skip_serializing_none]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct FixedAmount {
+    pub amount: Decimal,
     pub applies_to_each_item: Option<Boolean>,
-    pub value: Float,
 }
 
 #[derive(Clone, Debug, Serialize)]
 pub struct Percentage {
-    pub value: Float,
+    pub value: Decimal,
 }
 
 #[skip_serializing_none]
@@ -108,7 +109,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
-        minimum_amount: Float,
+        minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
 }

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/src/api.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
+use serde_with::{serde_as, DisplayFromStr};
+
 pub type Boolean = bool;
-pub type Decimal = String;
+pub type Decimal = f64;
 pub type Int = i32;
 pub type ID = String;
 
@@ -22,7 +24,6 @@ pub mod input {
     }
 
     #[derive(Clone, Debug, Deserialize, Default)]
-    #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Metafield {
         pub value: String,
     }
@@ -70,24 +71,21 @@ pub struct Discount {
     pub conditions: Option<Vec<Condition>>,
 }
 
+#[skip_serializing_none]
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Value {
-    FixedAmount(FixedAmount),
-    Percentage(Percentage),
-}
-
-#[skip_serializing_none]
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all(serialize = "camelCase"))]
-pub struct FixedAmount {
-    pub amount: Decimal,
-    pub applies_to_each_item: Option<Boolean>,
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct Percentage {
-    pub value: Decimal,
+    #[serde(rename_all(serialize = "camelCase"))]
+    FixedAmount {
+        #[serde_as(as = "DisplayFromStr")]
+        amount: Decimal,
+        applies_to_each_item: Option<Boolean>,
+    },
+    Percentage {
+        #[serde_as(as = "DisplayFromStr")]
+        value: Decimal,
+    },
 }
 
 #[skip_serializing_none]

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/src/api.rs
@@ -78,7 +78,7 @@ pub enum Value {
     FixedAmount {
         #[serde_as(as = "DisplayFromStr")]
         amount: Decimal,
-        applies_to_each_item: Option<Boolean>,
+        applies_to_each_item: Boolean,
     },
     Percentage {
         #[serde_as(as = "DisplayFromStr")]
@@ -93,6 +93,7 @@ pub enum Target {
     ProductVariant { id: ID, quantity: Option<Int> },
 }
 
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Condition {
@@ -105,6 +106,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/src/main.rs
@@ -13,8 +13,8 @@ pub struct Configuration {
 impl Configuration {
     pub const DEFAULT_VALUE: f64 = 50.0;
 
-    fn from_str(str: &str) -> Self {
-        serde_json::from_str(str).expect("Unable to parse configuration value from metafield")
+    fn from_str(value: &str) -> Self {
+        serde_json::from_str(value).expect("Unable to parse configuration value from metafield")
     }
 }
 

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/src/main.rs
@@ -77,7 +77,9 @@ fn build_result(value: f64, targets: Vec<Target>) -> FunctionResult {
             message: None,
             conditions: None,
             targets,
-            value: Value::Percentage(Percentage { value }),
+            value: Value::Percentage(Percentage {
+                value: format!("{}", value),
+            }),
         }]
     };
     FunctionResult {
@@ -129,7 +131,7 @@ mod tests {
                     { "productVariant": { "id": "gid://shopify/ProductVariant/0" } },
                     { "productVariant": { "id": "gid://shopify/ProductVariant/1" } },
                 ],
-                "value": { "percentage": { "value": 50.0 } },
+                "value": { "percentage": { "value": "50" } },
             }],
             "discountApplicationStrategy": "FIRST",
         });
@@ -139,7 +141,7 @@ mod tests {
     #[test]
     fn test_discount_with_value() {
         let input = input(Some(Configuration {
-            value: 10.0,
+            value: 12.34,
             excluded_variant_ids: vec![],
         }));
         let result = serde_json::json!(function(input).unwrap());
@@ -150,7 +152,7 @@ mod tests {
                     { "productVariant": { "id": "gid://shopify/ProductVariant/0" } },
                     { "productVariant": { "id": "gid://shopify/ProductVariant/1" } },
                 ],
-                "value": { "percentage": { "value": 10.0 } },
+                "value": { "percentage": { "value": "12.34" } },
             }],
             "discountApplicationStrategy": "FIRST",
         });
@@ -165,12 +167,12 @@ mod tests {
         }));
         let result = serde_json::json!(function(input).unwrap());
 
-        let expected_result = serde_json::json!(            {
+        let expected_result = serde_json::json!({
             "discounts": [{
                 "targets": [
                     { "productVariant": { "id": "gid://shopify/ProductVariant/0" } },
                 ],
-                "value": { "percentage": { "value": 50.0 } },
+                "value": { "percentage": { "value": "50" } },
             }],
             "discountApplicationStrategy": "FIRST",
         });

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/src/main.rs
@@ -77,9 +77,7 @@ fn build_result(value: f64, targets: Vec<Target>) -> FunctionResult {
             message: None,
             conditions: None,
             targets,
-            value: Value::Percentage(Percentage {
-                value: format!("{}", value),
-            }),
+            value: Value::Percentage { value },
         }]
     };
     FunctionResult {

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/Cargo.toml
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/Cargo.toml
@@ -2,7 +2,6 @@
 name = "shipping-discount"
 version = "1.0.0"
 edition = "2021"
-include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/Cargo.toml
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/Cargo.toml
@@ -2,7 +2,7 @@
 name = "shipping-discount"
 version = "1.0.0"
 edition = "2021"
-include = ["*.graphql"]
+include = []
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/schema.graphql
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/schema.graphql
@@ -3386,7 +3386,7 @@ input Percentage {
 
   The value is validated against: >= 0.
   """
-  value: Float!
+  value: Decimal!
 }
 
 """

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/api.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use serde_with::{serde_as, DisplayFromStr};
-
 pub type Boolean = bool;
 pub type Decimal = f64;
 pub type Int = i32;
@@ -18,12 +16,12 @@ pub mod input {
         pub cart: Cart,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize, Default)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct Metafield {
         pub value: String,
     }
@@ -41,7 +39,7 @@ pub mod input {
 }
 
 use serde::Serialize;
-use serde_with::skip_serializing_none;
+use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/api.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 pub type Boolean = bool;
-pub type Float = f64;
+pub type Decimal = String;
 pub type Int = i32;
 pub type ID = String;
 
@@ -72,14 +72,13 @@ pub enum Value {
 }
 
 #[derive(Clone, Debug, Serialize)]
-#[serde(rename_all(serialize = "camelCase"))]
 pub struct FixedAmount {
-    pub value: Float,
+    pub amount: Decimal,
 }
 
 #[derive(Clone, Debug, Serialize)]
 pub struct Percentage {
-    pub value: Float,
+    pub value: Decimal,
 }
 
 #[skip_serializing_none]
@@ -95,7 +94,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     OrderMinimumSubtotal {
         excluded_variant_ids: Vec<ID>,
-        minimum_amount: Float,
+        minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
     #[serde(rename_all(serialize = "camelCase"))]
@@ -107,7 +106,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
-        minimum_amount: Float,
+        minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
 }

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/api.rs
@@ -86,12 +86,14 @@ pub enum Target {
     DeliveryGroup { id: ID },
 }
 
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     OrderMinimumSubtotal {
         excluded_variant_ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },
@@ -104,6 +106,7 @@ pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
         ids: Vec<ID>,
+        #[serde_as(as = "DisplayFromStr")]
         minimum_amount: Decimal,
         target_type: ConditionTargetType,
     },

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/api.rs
@@ -9,30 +9,31 @@ pub mod input {
     use super::*;
     use serde::Deserialize;
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[serde_as]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub discount_node: DiscountNode,
         pub cart: Cart,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct DiscountNode {
         pub metafield: Option<Metafield>,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct Metafield {
         pub value: String,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct Cart {
         pub delivery_groups: Vec<CartDeliveryGroup>,
     }
 
-    #[derive(Clone, Debug, Deserialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct CartDeliveryGroup {
         pub id: ID,
     }

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/api.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/api.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
+use serde_with::{serde_as, DisplayFromStr};
+
 pub type Boolean = bool;
-pub type Decimal = String;
+pub type Decimal = f64;
 pub type Int = i32;
 pub type ID = String;
 
@@ -64,21 +66,19 @@ pub struct Discount {
     pub conditions: Option<Vec<Condition>>,
 }
 
+#[skip_serializing_none]
+#[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Value {
-    FixedAmount(FixedAmount),
-    Percentage(Percentage),
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct FixedAmount {
-    pub amount: Decimal,
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct Percentage {
-    pub value: Decimal,
+    FixedAmount {
+        #[serde_as(as = "DisplayFromStr")]
+        amount: Decimal,
+    },
+    Percentage {
+        #[serde_as(as = "DisplayFromStr")]
+        value: Decimal,
+    },
 }
 
 #[skip_serializing_none]

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/main.rs
@@ -65,7 +65,9 @@ fn build_result(value: f64, targets: Vec<Target>) -> FunctionResult {
             message: None,
             conditions: None,
             targets,
-            value: Value::Percentage(Percentage { value }),
+            value: Value::Percentage(Percentage {
+                value: format!("{}", value),
+            }),
         }]
     };
     FunctionResult {
@@ -105,7 +107,7 @@ mod tests {
                 "targets": [
                     { "deliveryGroup": { "id": "gid://shopify/CartDeliveryGroup/0" } },
                 ],
-                "value": { "percentage": { "value": 50.0 } },
+                "value": { "percentage": { "value": "50" } },
             }],
             "discountApplicationStrategy": "FIRST",
         });
@@ -114,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_discount_with_value() {
-        let input = input(Some(Configuration { value: 10.0 }));
+        let input = input(Some(Configuration { value: 12.34 }));
         let result = serde_json::json!(function(input).unwrap());
 
         let expected_result = serde_json::json!({
@@ -122,7 +124,7 @@ mod tests {
                 "targets": [
                     { "deliveryGroup": { "id": "gid://shopify/CartDeliveryGroup/0" } },
                 ],
-                "value": { "percentage": { "value": 10.0 } },
+                "value": { "percentage": { "value": "12.34" } },
             }],
             "discountApplicationStrategy": "FIRST",
         });

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/main.rs
@@ -11,8 +11,8 @@ pub struct Configuration {
 impl Configuration {
     pub const DEFAULT_VALUE: f64 = 50.0;
 
-    fn from_str(str: &str) -> Self {
-        serde_json::from_str(str).expect("Unable to parse configuration value from metafield")
+    fn from_str(value: &str) -> Self {
+        serde_json::from_str(value).expect("Unable to parse configuration value from metafield")
     }
 }
 

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/main.rs
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/src/main.rs
@@ -65,9 +65,7 @@ fn build_result(value: f64, targets: Vec<Target>) -> FunctionResult {
             message: None,
             conditions: None,
             targets,
-            value: Value::Percentage(Percentage {
-                value: format!("{}", value),
-            }),
+            value: Value::Percentage { value },
         }]
     };
     FunctionResult {


### PR DESCRIPTION
Adds example Rust functions for Discounts APIs:

- `order-discounts`
- `product-discounts`
- `shipping-discounts`

Demonstrating:

- Fixed amount value
- Presentment currency rate

Updates tests and schemas for all discount functions to use `Decimal` instead of `Float`

- [ ] Core PR: https://github.com/Shopify/shopify/pull/360303