### PR TITLE
reference unstable directly

### DIFF
--- a/sample-apps/payment-customization-hide/extensions/hide-first-payment/shopify.function.extension.toml
+++ b/sample-apps/payment-customization-hide/extensions/hide-first-payment/shopify.function.extension.toml
@@ -1,7 +1,7 @@
 name = "hide first payment"
 type = "payment_customization"
 title = "hide first payment"
-api_version = "2022-07"
+api_version = "unstable"
 
 [build]
 command = "cargo wasi build --release"

--- a/sample-apps/payment-customization-hide/extensions/hide-payment-by-name/shopify.function.extension.toml
+++ b/sample-apps/payment-customization-hide/extensions/hide-payment-by-name/shopify.function.extension.toml
@@ -1,7 +1,7 @@
 name = "hide payment by name"
 type = "payment_customization"
 title = "hide payment by name"
-api_version = "2022-07"
+api_version = "unstable"
 
 [build]
 command = "cargo wasi build --release"


### PR DESCRIPTION
After some changes to our schema system, these fields are actually being used. Since we're using these examples for internal testing, we should point them at unstable.

This is also helpful since we're recommending folks copy this file for their internal prototypes, and they will certainly want to point at unstable.