### PR TITLE
[Functions] Fix spelling error for `payment_customization` operation key name

### DIFF
--- a/checkout/rust/payment-customization/default/src/api.rs
+++ b/checkout/rust/payment-customization/default/src/api.rs
@@ -26,7 +26,7 @@ pub struct FunctionResult {
 #[derive(Clone, Debug, Serialize)]
 pub struct Operation {
     pub hide: Option<HideOperation>,
-    pub r#move: Option<MoveOperation>,
+    pub remove: Option<MoveOperation>,
     pub rename: Option<RenameOperation>,
 }
 


### PR DESCRIPTION
Change from `r#name` to `rename` for Operations key. 