### PR TITLE
Fix function extension toml and graphql input query

### DIFF
--- a/checkout/rust/delivery-customization/default/input.graphql
+++ b/checkout/rust/delivery-customization/default/input.graphql
@@ -1,5 +1,5 @@
 query Input {
-  deliveryCustomization {
+  deliveryOptions {
     id
     name
   }

--- a/checkout/rust/delivery-customization/default/shopify.function.extension.toml.liquid
+++ b/checkout/rust/delivery-customization/default/shopify.function.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "{{extensionType}}"
-api_version = "2022-07"
+api_version = "unstable"
 
 [build]
 command = "cargo wasi build --release"


### PR DESCRIPTION
Changes for delivery customization default sample function
- GraphQL input to use `deliveryOptions` instead of `deliveryCustomization`
- Use `unstable` instead of versioned API

✅ Successfully generates a delivery customization extension and can push to Shopify