### PR TITLE
[Delivery Customization API] Change input fields from `name` to `title`

### DIFF
--- a/checkout/rust/delivery-customization/default/input.graphql
+++ b/checkout/rust/delivery-customization/default/input.graphql
@@ -1,6 +1,6 @@
 query Input {
   deliveryOptions {
     id
-    name
+    title
   }
 }

--- a/checkout/rust/delivery-customization/default/schema.graphql
+++ b/checkout/rust/delivery-customization/default/schema.graphql
@@ -15,13 +15,16 @@ Exactly one field of input must be provided, and all others omitted.
 """
 directive @oneOf on INPUT_OBJECT
 
-type DeliveryOption {
+type DeliveryCustomizationDeliveryOption {
+  """
+  Unique identifier for the delivery option.
+  """
   id: ID!
-  name: String!
+  title: String!
 }
 
 """
-The result of a delivery option function.
+The result of a delivery customization function.
 """
 input FunctionResult {
   """
@@ -32,22 +35,21 @@ input FunctionResult {
 
 input HideOperation {
   """
-  The identifier of the delivery option to hide out.
+  The identifier of the delivery option to hide.
   """
   deliveryOptionId: ID!
 }
 
 """
-Represents a unique identifier that is Base64 obfuscated. It is often used to
-refetch an object or as key for a cache. The ID type appears in a JSON response
-as a String; however, it is not intended to be human-readable. When expected as
-an input type, any string (such as `"VXNlci0xMA=="`) or integer (such as `4`)
-input value will be accepted as an ID.
+Represents a unique identifier, often used to refetch an object.
+The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
+
+Example value: `"gid://shopify/Product/10079785100"`
 """
 scalar ID
 
 type Input {
-  deliveryOptions: [DeliveryOption!]!
+  deliveryOptions: [DeliveryCustomizationDeliveryOption!]!
 }
 
 input MoveOperation {
@@ -90,7 +92,7 @@ input RenameOperation {
   deliveryOptionId: ID!
 
   """
-  The new name for the delivery method.
+  The new name for the delivery option.
   """
   title: String!
 }

--- a/checkout/rust/delivery-customization/default/src/api.rs
+++ b/checkout/rust/delivery-customization/default/src/api.rs
@@ -12,7 +12,7 @@ pub struct Input {
 #[serde(rename_all = "camelCase")]
 pub struct DeliveryOption {
     pub id: ID,
-    pub name: String,
+    pub title: String,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -44,5 +44,5 @@ pub struct MoveOperation {
 #[serde(rename_all = "camelCase")]
 pub struct RenameOperation {
     pub delivery_option_id: ID,
-    pub name: String,
+    pub title: String,
 }

--- a/checkout/rust/delivery-customization/default/src/main.rs
+++ b/checkout/rust/delivery-customization/default/src/main.rs
@@ -25,11 +25,11 @@ mod tests {
             delivery_options: vec![
                 DeliveryOption {
                     id: "1".to_string(),
-                    name: "Standard".to_string()
+                    title: "Standard".to_string()
                 },
                 DeliveryOption {
                     id: "2".to_string(),
-                    name: "Express".to_string()
+                    title: "Express".to_string()
                 }
             ],
         };


### PR DESCRIPTION
To ensure constant parity between field references in various platforms, we will be changing `name` to `title`. 