### PR TITLE
We only support unstable api_version right now

### DIFF
--- a/discounts/rust/order-discounts/fixed-amount/shopify.function.extension.toml
+++ b/discounts/rust/order-discounts/fixed-amount/shopify.function.extension.toml
@@ -1,6 +1,6 @@
 name = "Fixed Amount Off Order"
 type = "order_discounts"
-api_version = "2022-07"
+api_version = "unstable"
 
 [build]
 command = "cargo wasi build --release"

--- a/discounts/rust/product-discounts/fixed-amount/shopify.function.extension.toml
+++ b/discounts/rust/product-discounts/fixed-amount/shopify.function.extension.toml
@@ -1,6 +1,6 @@
 name = "Fixed Amount"
 type = "product_discounts"
-api_version = "2022-07"
+api_version = "unstable"
 
 [build]
 command = "cargo wasi build --release"

--- a/discounts/rust/shipping-discounts/fixed-amount/shopify.function.extension.toml
+++ b/discounts/rust/shipping-discounts/fixed-amount/shopify.function.extension.toml
@@ -1,6 +1,6 @@
 name = "Fixed Amount"
 type = "product_discounts"
-api_version = "2022-07"
+api_version = "unstable"
 
 [build]
 command = "cargo wasi build --release"

--- a/sample-apps/discount-functions-sample-app/extensions/order-discount/shopify.function.extension.toml
+++ b/sample-apps/discount-functions-sample-app/extensions/order-discount/shopify.function.extension.toml
@@ -1,6 +1,6 @@
 name = "Order Discount"
 type = "order_discounts"
-api_version = "2022-07"
+api_version = "unstable"
 
 [ui.paths]
 create = "/order-discount/new"

--- a/sample-apps/discount-functions-sample-app/extensions/product-discount/shopify.function.extension.toml
+++ b/sample-apps/discount-functions-sample-app/extensions/product-discount/shopify.function.extension.toml
@@ -1,6 +1,6 @@
 name = "Product Discount"
 type = "product_discounts"
-api_version = "2022-07"
+api_version = "unstable"
 
 [ui.paths]
 create = "/product-discount/new"

--- a/sample-apps/discount-functions-sample-app/extensions/shipping-discount/shopify.function.extension.toml
+++ b/sample-apps/discount-functions-sample-app/extensions/shipping-discount/shopify.function.extension.toml
@@ -1,6 +1,6 @@
 name = "Shipping Discount"
 type = "shipping_discounts"
-api_version = "2022-07"
+api_version = "unstable"
 
 [ui.paths]
 create = "/shipping-discount/new"

--- a/sample-apps/discounts-tutorial/extensions/volume/shopify.function.extension.toml
+++ b/sample-apps/discounts-tutorial/extensions/volume/shopify.function.extension.toml
@@ -1,6 +1,6 @@
 name = "Volume"
 type = "product_discounts"
-api_version = "2022-07"
+api_version = "unstable"
 
 [build]
 command = "cargo wasi build --release"


### PR DESCRIPTION
Fixes this error since we only support `unstable` right now

````  {                                                                         
     "field": null,                                                          
     "message": "No version '2022-07' for 'order_discounts'",                
     "tag": "input_query_validation_error"                                   
   }
````