### PR TITLE
Remove NavigationMenu component

### DIFF
--- a/sample-apps/discount-functions-sample-app/web/frontend/App.jsx
+++ b/sample-apps/discount-functions-sample-app/web/frontend/App.jsx
@@ -1,5 +1,4 @@
 import { BrowserRouter } from "react-router-dom";
-import { NavigationMenu } from "@shopify/app-bridge-react";
 import Routes from "./Routes";
 
 import {
@@ -18,22 +17,6 @@ export default function App() {
       <BrowserRouter>
         <AppBridgeProvider>
           <QueryProvider>
-            <NavigationMenu
-              navigationLinks={[
-                {
-                  label: "Order Discount",
-                  destination: "/order-discount/new",
-                },
-                {
-                  label: "Product Discount",
-                  destination: "/product-discount/new",
-                },
-                {
-                  label: "Shipping Discount",
-                  destination: "/shipping-discount/new",
-                },
-              ]}
-            />
             <Routes pages={pages} />
           </QueryProvider>
         </AppBridgeProvider>

--- a/sample-apps/discounts-tutorial/web/frontend/App.jsx
+++ b/sample-apps/discounts-tutorial/web/frontend/App.jsx
@@ -1,5 +1,4 @@
 import { BrowserRouter } from "react-router-dom";
-import { NavigationMenu } from "@shopify/app-bridge-react";
 import Routes from "./Routes";
 
 import {
@@ -20,14 +19,6 @@ export default function App() {
         <AppBridgeProvider>
           <DiscountProvider>
             <QueryProvider>
-              <NavigationMenu
-                navigationLinks={[
-                  {
-                    label: "New volume discount",
-                    destination: "/Volume/new",
-                  },
-                ]}
-              />
               <Routes pages={pages} />
             </QueryProvider>
           </DiscountProvider>

--- a/sample-apps/payment-customization-sample-app/web/frontend/App.jsx
+++ b/sample-apps/payment-customization-sample-app/web/frontend/App.jsx
@@ -1,5 +1,4 @@
 import { BrowserRouter } from "react-router-dom";
-import { NavigationMenu } from "@shopify/app-bridge-react";
 import Routes from "./Routes";
 
 import {


### PR DESCRIPTION
Our usage of the `NavigationMenu` doesn't follow the [design guidelines](https://shopify.dev/apps/design-guidelines/navigation#app-nav). For the time being, until we revisit the navigation, this PR removes the use of the `NavigationMenu` component.