### PR TITLE
Expand extension liquid templates

### DIFF
--- a/sample-apps/discounts-tutorial/extensions/volume/input.graphql
+++ b/sample-apps/discounts-tutorial/extensions/volume/input.graphql
@@ -10,7 +10,7 @@ query Input {
     }
   }
   discountNode {
-    metafield(namespace: "{{ app_name | replace: " ", "-" | downcase }}", key: "function-config") {
+    metafield(namespace: "discounts-tutorial", key: "function-config") {
       value
     }
   }

--- a/util/expand-liquid.js
+++ b/util/expand-liquid.js
@@ -3,48 +3,95 @@
  * This script replaces the liquid expansion functionality of the Shopify CLI for use cases where the Shopify CLI is not being used, like local sample development.
  */
 
- import glob from 'fast-glob';
- import { Liquid } from 'liquidjs';
- import path from 'path';
- import fs from 'node:fs/promises';
- import { existsSync } from 'fs';
- import toml from '@iarna/toml';
+import glob from 'fast-glob';
+import { Liquid } from 'liquidjs';
+import path from 'path';
+import fs from 'node:fs/promises';
+import { existsSync } from 'fs';
+import toml from '@iarna/toml';
 
- const samplePath = path.join(process.cwd(), 'sample-apps');
- const samples = (await fs.readdir(samplePath, { withFileTypes: true }))
-     .filter(dirent => dirent.isDirectory())
-     .map(dirent => path.join(samplePath, dirent.name));
+async function expandLiquidTemplates(template, liquidData) {
+  const entries = await glob([path.join(template, "**/*.liquid")], {
+    dot: true,
+    ignore: ["**/node_modules"],
+  });
 
- for (const sample of samples) {
-   const configPath = path.join(sample, "shopify.app.toml");
-   if (!existsSync(configPath)) {
-     console.error(`${configPath} does not exist`);
-     continue;
-   }
-   const appConfig = toml.parse(await fs.readFile(configPath, "utf8"));
+  for (const entry of entries) {
+    const engine = new Liquid();
+    const content = await fs.readFile(entry, "utf8");
+    const rendered = await engine.renderFile(entry, liquidData);
+    const outputPath = entry.replace(".liquid", "");
+    await fs.writeFile(outputPath, rendered);
+    console.log(`  ${path.relative(process.cwd(), outputPath)}`);
+  }
+}
 
-   console.log(`Expanding liquid templates for ${appConfig.name}`);
+async function expandAppLiquidTemplates(appDir) {
+  const samplePath = path.join(process.cwd(), appDir);
+  const samples = (await fs.readdir(samplePath, { withFileTypes: true }))
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => path.join(samplePath, dirent.name));
 
-   const liquidData = {
-     app_name: appConfig.name,
-     dependency_manager: "yarn",
-   };
+  for (const sample of samples) {
+    const configPath = path.join(sample, "shopify.app.toml");
+    if (!existsSync(configPath)) {
+      console.error(`${configPath} does not exist`);
+      continue;
+    }
+    const appConfig = toml.parse(await fs.readFile(configPath, "utf8"));
 
-   const entries = await glob([path.join(sample, "**/*.liquid")], {
-     dot: true,
-     ignore: ["**/node_modules"],
-   });
+    console.log(`Expanding liquid templates for ${appConfig.name}`);
 
-   for (const entry of entries) {
-     const engine = new Liquid();
-     const content = await fs.readFile(entry, "utf8");
-     const rendered = await engine.renderFile(entry, liquidData);
-     const outputPath = entry.replace(".liquid", "");
-     await fs.writeFile(outputPath, rendered);
-     console.log(outputPath);
-   }
+    const liquidData = {
+      app_name: appConfig.name,
+      dependency_manager: "yarn",
+    };
 
-   console.log();
- }
+    await expandLiquidTemplates(sample, liquidData);
 
- console.log('The above files should be added to .gitignore if they have not already been added.');
+    console.log();
+  }
+}
+
+async function directoryNames(parentPath) {
+  return (await fs.readdir(parentPath, { withFileTypes: true }))
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => dirent.name);
+}
+
+async function expandExtensionLiquidTemplates(domainName) {
+  console.log(`Expanding liquid templates for ${domainName}`);
+  const domainPath = path.join(process.cwd(), domainName);
+
+  const langNames = await directoryNames(domainPath);
+  for (const langName of langNames) {
+    const langPath = path.join(domainPath, langName);
+    const extensionTypeNames = await directoryNames(langPath);
+
+    for (const extensionTypeName of extensionTypeNames) {
+      const extensionTypePath = path.join(langPath, extensionTypeName);
+      const templateNames = await directoryNames(extensionTypePath);
+
+      for (const templateName of templateNames) {
+        const templatePath = path.join(extensionTypePath, templateName);
+        const liquidData = {
+          name: templateName,
+          type: extensionTypeName.replaceAll('-', '_'),
+        };
+
+        await expandLiquidTemplates(templatePath, liquidData);
+      }
+    }
+  }
+  console.log();
+}
+
+const SAMPLE_APP_DIR = 'sample-apps';
+await expandAppLiquidTemplates(SAMPLE_APP_DIR);
+
+const DOMAINS = ['checkout', 'discounts'];
+for (const domain of DOMAINS) {
+  await expandExtensionLiquidTemplates(domain);
+}
+
+console.log('The above files should be added to .gitignore if they have not already been added.');


### PR DESCRIPTION
```
yarn expand-liquid
yarn run v1.22.19
$ node ./util/expand-liquid.js
Expanding liquid templates for Discount Functions Sample App

Expanding liquid templates for Discounts Tutorial
  sample-apps/discounts-tutorial/extensions/volume/input.graphql
  sample-apps/discounts-tutorial/web/frontend/metafields.js

Expanding liquid templates for undefined

Expanding liquid templates for Payment Customization Functions Sample App

Expanding liquid templates for checkout
  checkout/rust/delivery-customization/default/Cargo.toml
  checkout/rust/delivery-customization/default/input.graphql
  checkout/rust/delivery-customization/default/shopify.function.extension.toml
  checkout/rust/payment-customization/default/Cargo.toml
  checkout/rust/payment-customization/default/input.graphql
  checkout/rust/payment-customization/default/shopify.function.extension.toml
  checkout/wasm/shipping-rates-consolidation/default/shopify.function.extension.toml

Expanding liquid templates for discounts
  discounts/rust/order-discounts/default/Cargo.toml
  discounts/rust/order-discounts/default/input.graphql
  discounts/rust/order-discounts/default/shopify.function.extension.toml
  discounts/rust/product-discounts/default/Cargo.toml
  discounts/rust/product-discounts/default/input.graphql
  discounts/rust/product-discounts/default/shopify.function.extension.toml
  discounts/rust/shipping-discounts/default/Cargo.toml
  discounts/rust/shipping-discounts/default/input.graphql
  discounts/rust/shipping-discounts/default/shopify.function.extension.toml
  discounts/wasm/order-discounts/default/input.graphql
  discounts/wasm/order-discounts/default/shopify.function.extension.toml
  discounts/wasm/product-discounts/default/input.graphql
  discounts/wasm/product-discounts/default/shopify.function.extension.toml
  discounts/wasm/shipping-discounts/default/input.graphql
  discounts/wasm/shipping-discounts/default/shopify.function.extension.toml
```

🤔 This one was also generated so I replaced the `.liquid` in the `discounts-tutorial` volume extension:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        sample-apps/discounts-tutorial/extensions/volume/input.graphql
```

> `Expanding liquid templates for undefined`

This one was `payment-customization-hide` with no `name`, sample app has been deleted