### PR TITLE
Remove wasm-opt instructions that aren't necessary

### DIFF
--- a/discounts/rust/order-discounts/default/README.md
+++ b/discounts/rust/order-discounts/default/README.md
@@ -6,9 +6,6 @@
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
 - Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
   - `cargo install cargo-wasi`
-- On Macs with Apple Silicon, you'll also need to install the Binaryen toolchain and set the `WASM_OPT` environment variable. ([related issue](https://github.com/bytecodealliance/cargo-wasi/issues/112))
-  - `brew install binaryen`
-  - Add `export WASM_OPT=/opt/homebrew/bin/wasm-opt` to your `.bashrc` or `.zshrc`
 
 ## Building the function
 

--- a/discounts/rust/order-discounts/fixed-amount/README.md
+++ b/discounts/rust/order-discounts/fixed-amount/README.md
@@ -6,9 +6,6 @@
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
 - Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
   - `cargo install cargo-wasi`
-- On Macs with Apple Silicon, you'll also need to install the Binaryen toolchain and set the `WASM_OPT` environment variable. ([related issue](https://github.com/bytecodealliance/cargo-wasi/issues/112))
-  - `brew install binaryen`
-  - Add `export WASM_OPT=/opt/homebrew/bin/wasm-opt` to your `.bashrc` or `.zshrc`
 
 ## Building the function
 

--- a/discounts/rust/product-discounts/default/README.md
+++ b/discounts/rust/product-discounts/default/README.md
@@ -6,9 +6,6 @@
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
 - Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
   - `cargo install cargo-wasi`
-- On Macs with Apple Silicon, you'll also need to install the Binaryen toolchain and set the `WASM_OPT` environment variable. ([related issue](https://github.com/bytecodealliance/cargo-wasi/issues/112))
-  - `brew install binaryen`
-  - Add `export WASM_OPT=/opt/homebrew/bin/wasm-opt` to your `.bashrc` or `.zshrc`
 
 ## Building the function
 

--- a/discounts/rust/product-discounts/fixed-amount/README.md
+++ b/discounts/rust/product-discounts/fixed-amount/README.md
@@ -6,9 +6,6 @@
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
 - Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
   - `cargo install cargo-wasi`
-- On Macs with Apple Silicon, you'll also need to install the Binaryen toolchain and set the `WASM_OPT` environment variable. ([related issue](https://github.com/bytecodealliance/cargo-wasi/issues/112))
-  - `brew install binaryen`
-  - Add `export WASM_OPT=/opt/homebrew/bin/wasm-opt` to your `.bashrc` or `.zshrc`
 
 ## Building the function
 

--- a/discounts/rust/shipping-discounts/default/README.md
+++ b/discounts/rust/shipping-discounts/default/README.md
@@ -6,9 +6,6 @@
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
 - Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
   - `cargo install cargo-wasi`
-- On Macs with Apple Silicon, you'll also need to install the Binaryen toolchain and set the `WASM_OPT` environment variable. ([related issue](https://github.com/bytecodealliance/cargo-wasi/issues/112))
-  - `brew install binaryen`
-  - Add `export WASM_OPT=/opt/homebrew/bin/wasm-opt` to your `.bashrc` or `.zshrc`
 
 ## Building the function
 

--- a/discounts/rust/shipping-discounts/fixed-amount/README.md
+++ b/discounts/rust/shipping-discounts/fixed-amount/README.md
@@ -6,9 +6,6 @@
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
 - Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
   - `cargo install cargo-wasi`
-- On Macs with Apple Silicon, you'll also need to install the Binaryen toolchain and set the `WASM_OPT` environment variable. ([related issue](https://github.com/bytecodealliance/cargo-wasi/issues/112))
-  - `brew install binaryen`
-  - Add `export WASM_OPT=/opt/homebrew/bin/wasm-opt` to your `.bashrc` or `.zshrc`
 
 ## Building the function
 

--- a/sample-apps/discount-functions-sample-app/README.md
+++ b/sample-apps/discount-functions-sample-app/README.md
@@ -16,9 +16,6 @@ It also provides [Shopify Functions](#) that allow merchants to set up discounts
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
 - Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
   - `cargo install cargo-wasi`
-- On M1 Macs, you'll also need to install the Binaryen toolchain separately and set the `WASM_OPT` environment variable. ([related issue](https://github.com/bytecodealliance/cargo-wasi/issues/112))
-  - `brew install binaryen`
-  - Add `export WASM_OPT=/opt/homebrew/bin/wasm-opt` to your `.bashrc` or `.zshrc`
 
 ## Installation
 

--- a/sample-apps/discounts-tutorial/extensions/volume/README.md
+++ b/sample-apps/discounts-tutorial/extensions/volume/README.md
@@ -6,9 +6,6 @@
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
 - Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
   - `cargo install cargo-wasi`
-- On Macs with Apple Silicon, you'll also need to install the Binaryen toolchain and set the `WASM_OPT` environment variable. ([related issue](https://github.com/bytecodealliance/cargo-wasi/issues/112))
-  - `brew install binaryen`
-  - Add `export WASM_OPT=/opt/homebrew/bin/wasm-opt` to your `.bashrc` or `.zshrc`
 
 ## Building the function
 

--- a/sample-apps/payment-customization-sample-app/README.md
+++ b/sample-apps/payment-customization-sample-app/README.md
@@ -16,9 +16,6 @@ It also provides a [Shopify Function](https://shopify.dev/api/functions) that al
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
 - Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
   - `cargo install cargo-wasi`
-- On M1 Macs, you'll also need to install the Binaryen toolchain separately and set the `WASM_OPT` environment variable. ([related issue](https://github.com/bytecodealliance/cargo-wasi/issues/112))
-  - `brew install binaryen`
-  - Add `export WASM_OPT=/opt/homebrew/bin/wasm-opt` to your `.bashrc` or `.zshrc`
 
 ### Before you start
 - Enable the **Bogus Gateway** payment method in your development store's admin.


### PR DESCRIPTION
Figured I'd remove these instructions since I spotted them while giving the one README a glance.