### PR TITLE
bumping cli version

### DIFF
--- a/sample-apps/payment-customization-sample-app/package.json
+++ b/sample-apps/payment-customization-sample-app/package.json
@@ -12,8 +12,8 @@
     "deploy": "shopify app deploy"
   },
   "dependencies": {
-    "@shopify/app": "3.14.0",
-    "@shopify/cli": "3.14.0"
+    "@shopify/app": "3.25.0",
+    "@shopify/cli": "3.25.0"
   },
   "author": "marlonmarcello"
 }


### PR DESCRIPTION
I've run into a few different issues on 3.14.0, including ngrok failing to create tunnels and strange issues interacting with spin. They don't seem to be present on the latest version.