### PR TITLE
Various suggestions for payment and delivery templates

### DIFF
--- a/checkout/rust/delivery-customization/default/.gitignore
+++ b/checkout/rust/delivery-customization/default/.gitignore
@@ -1,0 +1,2 @@
+/target
+.output.graphql

--- a/checkout/rust/delivery-customization/default/Cargo.toml.liquid
+++ b/checkout/rust/delivery-customization/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ edition = "2021"
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
 shopify_function = { version = "0.2.3" }
-graphql_client = { git = "https://github.com/graphql-rust/graphql-client" }
+graphql_client = { git = "https://github.com/graphql-rust/graphql-client", rev = "0776197ad7cfde2c658490e7c7e627a21ed622cb" }
 
 [profile.release]
 lto = true

--- a/checkout/rust/payment-customization/default/.gitignore
+++ b/checkout/rust/payment-customization/default/.gitignore
@@ -1,0 +1,2 @@
+/target
+.output.graphql

--- a/checkout/rust/payment-customization/default/Cargo.toml.liquid
+++ b/checkout/rust/payment-customization/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ edition = "2021"
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
 shopify_function = { version = "0.2.3" }
-graphql_client = { git = "https://github.com/graphql-rust/graphql-client" }
+graphql_client = { git = "https://github.com/graphql-rust/graphql-client", rev = "0776197ad7cfde2c658490e7c7e627a21ed622cb" }
 
 [profile.release]
 lto = true

--- a/checkout/rust/payment-customization/default/src/main.rs
+++ b/checkout/rust/payment-customization/default/src/main.rs
@@ -1,9 +1,7 @@
 use shopify_function::prelude::*;
 use shopify_function::Result;
 
-use graphql_client;
 use serde::{Deserialize, Serialize};
-use serde_json;
 
 generate_types!(
     query_path = "./input.graphql",
@@ -11,17 +9,26 @@ generate_types!(
 );
 
 #[derive(Serialize, Deserialize, Default, PartialEq)]
-struct Config {}
+#[serde(rename_all(deserialize = "camelCase"))]
+struct Configuration {
+
+}
+
+impl Configuration {
+    fn from_str(value: &str) -> Self {
+        serde_json::from_str(value).expect("Unable to parse configuration value from metafield")
+    }
+}
 
 #[shopify_function]
 fn function(input: input::ResponseData) -> Result<output::FunctionResult> {
-    let _config: Config = input
-        .payment_customization
-        .metafield
-        .as_ref()
-        .map(|m| serde_json::from_str::<Config>(m.value.as_str()))
-        .transpose()?
-        .unwrap_or_default();
+    let no_changes = output::FunctionResult { operations: vec![] };
+
+    let _config = match input.payment_customization.metafield {
+        Some(input::InputPaymentCustomizationMetafield { value }) =>
+            Configuration::from_str(&value),
+        None => return Ok(no_changes),
+    };
 
     Ok(output::FunctionResult { operations: vec![] })
 }


### PR DESCRIPTION
Resolves some issues and better aligns with tutorials.

* Adds .gitignore for build output and mock output query
* Pins graphql_client to the version compatible with shopify_function (hopefully this will no longer be an issue soon once @surma can help ship a new version of this lib)
* Removes unneeded imports from Rust code
* (subjective) Makes example configuration handling cleaner