### PR TITLE
Bump @shopify/app and @shopify/cli for payments sample app

### DIFF
--- a/sample-apps/payment-customization-sample-app/extensions/hide-payment-by-name-and-cart-subtotal/metadata.json
+++ b/sample-apps/payment-customization-sample-app/extensions/hide-payment-by-name-and-cart-subtotal/metadata.json
@@ -1,1 +1,0 @@
-{ "schemaVersions": { "payment_customization": { "major": 1, "minor": 0 } } }

--- a/sample-apps/payment-customization-sample-app/package.json
+++ b/sample-apps/payment-customization-sample-app/package.json
@@ -12,8 +12,8 @@
     "deploy": "shopify app deploy"
   },
   "dependencies": {
-    "@shopify/app": "3.25.0",
-    "@shopify/cli": "3.25.0",
+    "@shopify/app": "^3.29.0",
+    "@shopify/cli": "^3.29.0",
     "@shopify/react-form": "^2.4.1"
   },
   "author": "marlonmarcello"


### PR DESCRIPTION
This PR bumps the @shopify/app and @shopify/cli dependencies for the payment sample app. It also specifies the versions as `^3.29.0`, which means we won't need to bump this as often because it'll install the latest minor version.