### PR TITLE
Add cart-transform template

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "rust-analyzer.linkedProjects": [
       "checkout/rust/delivery-customization/default/Cargo.toml",
       "checkout/rust/payment-customization/default/Cargo.toml",
+      "checkout/rust/cart-transform/bundles/Cargo.toml",
       "discounts/rust/order-discounts/default/Cargo.toml",
       "discounts/rust/order-discounts/fixed-amount/Cargo.toml",
       "discounts/rust/product-discounts/default/Cargo.toml",

--- a/checkout/rust/cart-transform/bundles/.gitignore
+++ b/checkout/rust/cart-transform/bundles/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/checkout/rust/cart-transform/bundles/Cargo.toml.liquid
+++ b/checkout/rust/cart-transform/bundles/Cargo.toml.liquid
@@ -1,0 +1,12 @@
+[package]
+name = "bundle_cart_transform"
+version = "1.0.0"
+edition = "2021"
+
+[dependencies]
+serde_json = "1.0"
+serde = { version = "1.0.13", features = ["derive"] }
+
+[profile.release]
+lto = true
+opt-level = 's'

--- a/checkout/rust/cart-transform/bundles/input.graphql.liquid
+++ b/checkout/rust/cart-transform/bundles/input.graphql.liquid
@@ -1,0 +1,31 @@
+query Input {
+  cart {
+    lines {
+      id
+      quantity
+      merchandise {
+        ... on ProductVariant {
+          id
+          component_parents: metafield(
+            namespace: "custom"
+            key: "component_parents"
+          ) {
+            value
+          }
+          component_reference: metafield(
+            namespace: "custom"
+            key: "component_reference"
+          ) {
+            value
+          }
+          component_quantities: metafield(
+            namespace: "custom"
+            key: "component_quantities"
+          ) {
+            value
+          }
+        }
+      }
+    }
+  }
+}

--- a/checkout/rust/cart-transform/bundles/metadata.json
+++ b/checkout/rust/cart-transform/bundles/metadata.json
@@ -1,0 +1,1 @@
+{ "schemaVersions": { "cart_transform": { "major": 1, "minor": 0 } } }

--- a/checkout/rust/cart-transform/bundles/shopify.function.extension.toml.liquid
+++ b/checkout/rust/cart-transform/bundles/shopify.function.extension.toml.liquid
@@ -1,0 +1,8 @@
+name = "bundle cart transform"
+type = "cart_transform"
+title = "bundle cart transform"
+api_version = "unstable"
+
+[build]
+command = "cargo wasi build --release"
+path = "target/wasm32-wasi/release/bundle_cart_transform.wasm"

--- a/checkout/rust/cart-transform/bundles/src/api.rs
+++ b/checkout/rust/cart-transform/bundles/src/api.rs
@@ -1,0 +1,119 @@
+#![allow(non_camel_case_types, non_snake_case)]
+use serde::{Deserialize, Serialize};
+
+// Common types
+
+pub type ID = String;
+
+// Input types
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Input {
+    pub cart: Cart,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Cart {
+    pub lines: Vec<CartLine>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct CartLine {
+    pub id: ID,
+    pub quantity: i32,
+    pub merchandise: Option<ProductVariant>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ProductVariant {
+    pub id: ID,
+    pub component_parents: Option<Metafield>,
+    pub component_reference: Option<Metafield>,
+    pub component_quantities: Option<Metafield>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Metafield {
+    pub value: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ComponentParentMetafield {
+    pub id: ID,
+    pub component_reference: ComponentParentMetafieldReference,
+    pub component_quantities: ComponentParentMetafieldQuantities,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ComponentParentMetafieldReference {
+    pub value: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ComponentParentMetafieldQuantities {
+    pub value: Vec<i32>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct ComponentParent {
+    pub id: ID,
+    pub component_reference: Vec<ID>,
+    pub component_quantities: Vec<i32>,
+}
+// Output types
+
+#[derive(Clone, Debug, Serialize)]
+pub struct FunctionResult {
+    pub operations: Vec<CartOperation>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub enum CartOperation {
+  merge(MergeOperation),
+  expand(ExpandOperation),
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ExpandOperation {
+    pub cartLineId: ID,
+    pub expandedCartItems: Vec<ExpandRelationship>,
+    pub price: Option<PriceAdjustment>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ExpandRelationship {
+    pub merchandiseId: ID,
+    pub quantity: i32,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct MergeOperation {
+    pub parentVariantId: ID,
+    pub title: Option<String>,
+    pub cartLines: Vec<CartLineMergeOperation>,
+    pub price: Option<PriceAdjustment>,
+    pub quantity: i32,
+    pub image: Option<ImageInput>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CartLineMergeOperation {
+    pub cartLineId: ID,
+    pub quantity: i32,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PriceAdjustment {
+    pub percentageDecrease: Option<PriceAdjustmentValue>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PriceAdjustmentValue {
+    pub value: f64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ImageInput {
+    pub url: String,
+}

--- a/checkout/rust/cart-transform/bundles/src/main.rs
+++ b/checkout/rust/cart-transform/bundles/src/main.rs
@@ -1,0 +1,180 @@
+use serde::Serialize;
+
+mod api;
+use api::*;
+
+#[allow(unused_must_use)]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let input: Input = serde_json::from_reader(std::io::BufReader::new(std::io::stdin()))?;
+
+    let mut out = std::io::stdout();
+    let mut serializer = serde_json::Serializer::new(&mut out);
+
+    cart_transform(&input.cart).serialize(&mut serializer);
+
+    Ok(())
+}
+
+fn cart_transform(cart: &Cart) -> FunctionResult {
+    let mut merge_cart_operations: Vec<CartOperation> = get_merge_cart_operations(cart);
+    let expand_cart_operations: Vec<CartOperation> = get_expand_cart_operations(cart);
+
+    merge_cart_operations.extend(expand_cart_operations);
+
+    return FunctionResult {
+        operations: merge_cart_operations,
+    };
+}
+
+// merge operation logic
+
+fn get_merge_cart_operations(cart: &Cart) -> Vec<CartOperation> {
+    let merge_parent_defintions: Vec<ComponentParent> = get_merge_parent_definitions(cart);
+    let mut result: Vec<MergeOperation> = Vec::new();
+
+    for definition in merge_parent_defintions.iter() {
+        let (components_in_cart, parent_variant_quantity) =
+            get_components_in_cart(cart, definition);
+        if components_in_cart.len() == definition.component_reference.len() {
+            let cart_lines: Vec<CartLineMergeOperation> = components_in_cart
+                .iter()
+                .map(|component| CartLineMergeOperation {
+                    cartLineId: component.cartLineId.clone(),
+                    quantity: parent_variant_quantity * component.quantity,
+                })
+                .collect();
+
+            let merge_operation: MergeOperation = MergeOperation {
+                parentVariantId: definition.id.clone(),
+                title: None,
+                cartLines: cart_lines.clone(),
+                quantity: parent_variant_quantity.clone(),
+                image: None,
+                price: None,
+            };
+
+            result.push(merge_operation);
+        }
+    }
+
+    return result.iter().map(|op| CartOperation::merge(op.clone())).collect();
+}
+
+fn get_components_in_cart(
+    cart: &Cart,
+    definition: &ComponentParent,
+) -> (Vec<CartLineMergeOperation>, i32) {
+    let mut line_results: Vec<CartLineMergeOperation> = Vec::new();
+    let mut maximum_available_component: Vec<i32> = Vec::new();
+    for (reference, quantity) in definition
+        .component_reference
+        .iter()
+        .zip(definition.component_quantities.iter())
+    {
+        for line in cart.lines.iter() {
+            if let Some(merchandise) = &line.merchandise {
+                if reference == &merchandise.id && &line.quantity >= quantity {
+                    line_results.push(CartLineMergeOperation {
+                        cartLineId: line.id.clone(),
+                        quantity: quantity.clone(),
+                    });
+                    let maximum_available = if quantity > &0 {
+                        line.quantity / quantity
+                    } else {
+                        0
+                    };
+                    maximum_available_component.push(maximum_available)
+                }
+            }
+        }
+    }
+    let parent_variant_quantity: i32 = match maximum_available_component.iter().min() {
+        Some(available) => available.clone(),
+        None => 0,
+    };
+
+    return (line_results, parent_variant_quantity);
+}
+
+fn get_merge_parent_definitions(cart: &Cart) -> Vec<ComponentParent> {
+    let mut merge_parent_defintions: Vec<ComponentParent> = Vec::new();
+
+    for line in cart.lines.iter() {
+        if let Some(merchandise) = &line.merchandise {
+            merge_parent_defintions.append(&mut get_component_parents(&merchandise));
+        }
+    }
+    merge_parent_defintions.dedup_by(|a, b| a.id == b.id);
+    return merge_parent_defintions;
+}
+
+fn get_component_parents(variant: &ProductVariant) -> Vec<ComponentParent> {
+    let mut component_parents: Vec<ComponentParent> = Vec::new();
+    if let Some(component_parents_metafield) = &variant.component_parents {
+        let value: Vec<ComponentParentMetafield> =
+            serde_json::from_str(&component_parents_metafield.value).unwrap();
+        for parent_definition in value.iter() {
+            component_parents.push(ComponentParent {
+                id: parent_definition.id.clone(),
+                component_reference: parent_definition.component_reference.value.clone(),
+                component_quantities: parent_definition.component_quantities.value.clone(),
+            });
+        }
+    }
+
+    return component_parents;
+}
+
+// expand operation logic
+
+fn get_expand_cart_operations(cart: &Cart) -> Vec<CartOperation> {
+    let mut result: Vec<ExpandOperation> = Vec::new();
+
+    for line in cart.lines.iter() {
+        if let Some(merchandise) = &line.merchandise {
+            let component_references: Vec<ID> = get_component_references(&merchandise);
+            let component_quantities: Vec<i32> = get_component_quantities(&merchandise);
+
+            if component_references.is_empty() || component_references.len() != component_quantities.len() {
+                continue;
+            }
+
+            let mut expand_relationships: Vec<ExpandRelationship> = Vec::new();
+
+            for (reference, quantity) in component_references.iter().zip(component_quantities.iter()) {
+                let expand_relationship: ExpandRelationship = ExpandRelationship {
+                    merchandiseId: reference.clone(),
+                    quantity: quantity.clone(),
+                };
+
+                expand_relationships.push(expand_relationship);
+            }
+
+            let expand_operation: ExpandOperation = ExpandOperation{
+                cartLineId: line.id.clone(),
+                expandedCartItems: expand_relationships,
+                price: None,
+            };
+
+            result.push(expand_operation);
+        }
+    }
+
+    return result.iter().map(|op| CartOperation::expand(op.clone())).collect();
+}
+
+fn get_component_quantities(variant: &ProductVariant) -> Vec<i32> {
+    if let Some(component_quantities_metafield) = &variant.component_quantities {
+        return serde_json::from_str(&component_quantities_metafield.value).unwrap();
+    }
+
+    return Vec::new();
+}
+
+fn get_component_references(variant: &ProductVariant) -> Vec<ID> {
+    if let Some(component_reference_metafield) = &variant.component_reference {
+        return serde_json::from_str(&component_reference_metafield.value).unwrap();
+    }
+
+    return Vec::new();
+}


### PR DESCRIPTION
## What this is adding
*Bundles for core* is introducing a new extension: `cart-transform`. We need to add a template/ example for `cart-transform`.

This template is based off of the `bundles-cart-transform` extension used in the [bundles-reference-app](https://github.com/Shopify/bundles-reference-app).
