### PR TITLE
App owned metafields in templates and samples

### DIFF
--- a/checkout/rust/delivery-customization/default/input.graphql.liquid
+++ b/checkout/rust/delivery-customization/default/input.graphql.liquid
@@ -1,6 +1,6 @@
 query Input {
   deliveryCustomization {
-    metafield(namespace: "{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
+    metafield(namespace: "$app:{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
       value
     }
   }

--- a/checkout/rust/payment-customization/default/input.graphql.liquid
+++ b/checkout/rust/payment-customization/default/input.graphql.liquid
@@ -1,6 +1,6 @@
 query Input {
   paymentCustomization {
-    metafield(namespace: "{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
+    metafield(namespace: "$app:{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
       value
     }
   }

--- a/checkout/wasm/delivery-customization/default/input.graphql.liquid
+++ b/checkout/wasm/delivery-customization/default/input.graphql.liquid
@@ -1,6 +1,6 @@
 query Input {
   deliveryCustomization {
-    metafield(namespace: "{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
+    metafield(namespace: "$app:{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
       value
     }
   }

--- a/checkout/wasm/payment-customization/default/input.graphql.liquid
+++ b/checkout/wasm/payment-customization/default/input.graphql.liquid
@@ -1,6 +1,6 @@
 query Input {
   paymentCustomization {
-    metafield(namespace: "{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
+    metafield(namespace: "$app:{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
       value
     }
   }

--- a/discounts/javascript/product-discounts/default/input.graphql.liquid
+++ b/discounts/javascript/product-discounts/default/input.graphql.liquid
@@ -1,6 +1,6 @@
 query Input {
   discountNode {
-    metafield(namespace: "{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
+    metafield(namespace: "$app:{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
       value
     }
   }

--- a/discounts/rust/order-discounts/default/input.graphql.liquid
+++ b/discounts/rust/order-discounts/default/input.graphql.liquid
@@ -1,6 +1,6 @@
 query Input {
   discountNode {
-    metafield(namespace: "{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
+    metafield(namespace: "$app:{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
       value
     }
   }

--- a/discounts/rust/product-discounts/default/input.graphql.liquid
+++ b/discounts/rust/product-discounts/default/input.graphql.liquid
@@ -1,6 +1,6 @@
 query Input {
   discountNode {
-    metafield(namespace: "{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
+    metafield(namespace: "$app:{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
       value
     }
   }

--- a/discounts/rust/shipping-discounts/default/input.graphql.liquid
+++ b/discounts/rust/shipping-discounts/default/input.graphql.liquid
@@ -1,6 +1,6 @@
 query Input {
   discountNode {
-    metafield(namespace: "{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
+    metafield(namespace: "$app:{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
       value
     }
   }

--- a/discounts/wasm/order-discounts/default/input.graphql.liquid
+++ b/discounts/wasm/order-discounts/default/input.graphql.liquid
@@ -1,6 +1,6 @@
 query Input {
   discountNode {
-    metafield(namespace: "{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
+    metafield(namespace: "$app:{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
       value
     }
   }

--- a/discounts/wasm/product-discounts/default/input.graphql.liquid
+++ b/discounts/wasm/product-discounts/default/input.graphql.liquid
@@ -1,6 +1,6 @@
 query Input {
   discountNode {
-    metafield(namespace: "{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
+    metafield(namespace: "$app:{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
       value
     }
   }

--- a/discounts/wasm/shipping-discounts/default/input.graphql.liquid
+++ b/discounts/wasm/shipping-discounts/default/input.graphql.liquid
@@ -1,6 +1,6 @@
 query Input {
   discountNode {
-    metafield(namespace: "{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
+    metafield(namespace: "$app:{{name | replace: " ", "-" | downcase}}", key: "function-configuration") {
       value
     }
   }

--- a/sample-apps/delivery-customizations/extensions/delivery-customization/input.graphql
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization/input.graphql
@@ -11,10 +11,7 @@ query Input {
     }
   }
   deliveryCustomization {
-    metafield(
-      namespace: "{{ app_name | replace: " ", "-" | downcase }}"
-      key: "function-configuration"
-    ) {
+    metafield(namespace: "$app:delivery-customization", key: "function-configuration") {
       value
     }
   }

--- a/sample-apps/delivery-customizations/web/metafields.js
+++ b/sample-apps/delivery-customizations/web/metafields.js
@@ -1,0 +1,4 @@
+export default {
+  namespace: '$app:delivery-customization',
+  key: "function-configuration",
+};

--- a/sample-apps/delivery-customizations/web/metafields.js.liquid
+++ b/sample-apps/delivery-customizations/web/metafields.js.liquid
@@ -1,4 +1,0 @@
-export default {
-  namespace: '{{ app_name | replace: " ", "-" | downcase }}',
-  key: "function-configuration",
-};

--- a/sample-apps/payment-customizations/extensions/payment-customization/input.graphql
+++ b/sample-apps/payment-customizations/extensions/payment-customization/input.graphql
@@ -11,10 +11,7 @@ query Input {
     name
   }
   paymentCustomization {
-    metafield(
-      namespace: "{{ app_name | replace: " ", "-" | downcase }}"
-      key: "function-configuration"
-    ) {
+    metafield(namespace: "$app:payment-customization", key: "function-configuration") {
       value
     }
   }

--- a/sample-apps/payment-customizations/web/metafields.js
+++ b/sample-apps/payment-customizations/web/metafields.js
@@ -1,0 +1,4 @@
+export default {
+  namespace: '$app:payment-customization',
+  key: "function-configuration",
+};

--- a/sample-apps/payment-customizations/web/metafields.js.liquid
+++ b/sample-apps/payment-customizations/web/metafields.js.liquid
@@ -1,4 +1,0 @@
-export default {
-  namespace: '{{ app_name | replace: " ", "-" | downcase }}',
-  key: "function-configuration",
-};


### PR DESCRIPTION
Update templates for payment, delivery, and discounts, and samples for payment and delivery, to use app-owned metafields. Discount sample already had them.

We'll need to request other APIs to add them as well.

## How this has been tested

### Templates
From a newly created app:

```
export SHOPIFY_CLI_FUNCTIONS_JAVASCRIPT=1
yarn generate extension --clone-url https://github.com/Shopify/function-examples#app-owned-metafields -t product_discounts --template wasm -n product_discounts_wasm
yarn generate extension --clone-url https://github.com/Shopify/function-examples#app-owned-metafields -t product_discounts --template rust -n product_discounts_rust
yarn generate extension --clone-url https://github.com/Shopify/function-examples#app-owned-metafields -t product_discounts --template vanilla-js -n product_discounts_javascript
yarn generate extension --clone-url https://github.com/Shopify/function-examples#app-owned-metafields -t order_discounts --template wasm -n order_discounts_wasm
yarn generate extension --clone-url https://github.com/Shopify/function-examples#app-owned-metafields -t order_discounts --template rust -n order_discounts_rust
yarn generate extension --clone-url https://github.com/Shopify/function-examples#app-owned-metafields -t shipping_discounts --template wasm -n shipping_discounts_wasm
yarn generate extension --clone-url https://github.com/Shopify/function-examples#app-owned-metafields -t shipping_discounts --template rust -n shipping_discounts_rust
yarn generate extension --clone-url https://github.com/Shopify/function-examples#app-owned-metafields -t payment_customization --template wasm -n payment_customization_wasm
yarn generate extension --clone-url https://github.com/Shopify/function-examples#app-owned-metafields -t payment_customization --template rust -n payment_customization_rust
yarn generate extension --clone-url https://github.com/Shopify/function-examples#app-owned-metafields -t delivery_customization --template wasm -n delivery_customization_wasm
yarn generate extension --clone-url https://github.com/Shopify/function-examples#app-owned-metafields -t delivery_customization --template rust -n delivery_customization_rust
find . -name "input.graphql" | xargs cat | grep \$app
```

### Samples
Created the apps:

```
yarn create @shopify/app --template https://github.com/Shopify/function-examples/sample-apps/delivery-customizations#app-owned-metafields
```
```
yarn create @shopify/app --template https://github.com/Shopify/function-examples/sample-apps/payment-customizations#app-owned-metafields
```

Then `yarn deploy`, `yarn dev`, and followed the tutorial testing instructions for each.