### PR TITLE
Remove Function's `metadata.json` files

### DIFF
--- a/checkout/javascript/cart-checkout-validation/default/metadata.json
+++ b/checkout/javascript/cart-checkout-validation/default/metadata.json
@@ -1,1 +1,0 @@
-{"schemaVersions":{"cart_checkout_validation":{"major":1,"minor":0}}}

--- a/checkout/rust/cart-checkout-validation/default/metadata.json
+++ b/checkout/rust/cart-checkout-validation/default/metadata.json
@@ -1,1 +1,0 @@
-{"schemaVersions":{"cart_checkout_validation":{"major":1,"minor":0}}}

--- a/checkout/rust/cart-transform/bundles/metadata.json
+++ b/checkout/rust/cart-transform/bundles/metadata.json
@@ -1,1 +1,0 @@
-{ "schemaVersions": { "cart_transform": { "major": 1, "minor": 0 } } }

--- a/checkout/rust/cart-transform/default/metadata.json
+++ b/checkout/rust/cart-transform/default/metadata.json
@@ -1,1 +1,0 @@
-{ "schemaVersions": { "cart_transform": { "major": 1, "minor": 0 } } }

--- a/checkout/rust/delivery-customization/default/metadata.json
+++ b/checkout/rust/delivery-customization/default/metadata.json
@@ -1,1 +1,0 @@
-{"schemaVersions":{"delivery_customization":{"major":1,"minor":0}}}

--- a/checkout/rust/payment-customization/default/metadata.json
+++ b/checkout/rust/payment-customization/default/metadata.json
@@ -1,1 +1,0 @@
-{"schemaVersions":{"payment_customization":{"major":1,"minor":0}}}

--- a/checkout/wasm/cart-checkout-validation/default/metadata.json
+++ b/checkout/wasm/cart-checkout-validation/default/metadata.json
@@ -1,1 +1,0 @@
-{"schemaVersions":{"cart_checkout_validation":{"major":1,"minor":0}}}

--- a/checkout/wasm/cart-transform/metadata.json
+++ b/checkout/wasm/cart-transform/metadata.json
@@ -1,1 +1,0 @@
-{ "schemaVersions": { "cart_transform": { "major": 1, "minor": 0 } } }

--- a/checkout/wasm/delivery-customization/default/metadata.json
+++ b/checkout/wasm/delivery-customization/default/metadata.json
@@ -1,1 +1,0 @@
-{"schemaVersions":{"delivery_customization":{"major":1,"minor":0}}}

--- a/checkout/wasm/payment-customization/default/metadata.json
+++ b/checkout/wasm/payment-customization/default/metadata.json
@@ -1,1 +1,0 @@
-{"schemaVersions":{"payment_customization":{"major":1,"minor":0}}}

--- a/checkout/wasm/shipping-rates-consolidation/default/metadata.json
+++ b/checkout/wasm/shipping-rates-consolidation/default/metadata.json
@@ -1,1 +1,0 @@
-{"schemaVersions":{"shipping_rates_consolidation":{"major":1,"minor":0}}}

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand/metadata.json
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand/metadata.json
@@ -1,1 +1,0 @@
-{ "schemaVersions": { "cart_transform": { "major": 1, "minor": 0 } } }

--- a/sample-apps/delivery-customizations/extensions/delivery-customization/metadata.json
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization/metadata.json
@@ -1,1 +1,0 @@
-{"schemaVersions":{"delivery_customization":{"major":1,"minor":0}}}

--- a/sample-apps/payment-customizations/extensions/payment-customization/metadata.json
+++ b/sample-apps/payment-customizations/extensions/payment-customization/metadata.json
@@ -1,1 +1,0 @@
-{"schemaVersions":{"payment_customization":{"major":1,"minor":0}}}


### PR DESCRIPTION
We no longer use it, it's a relic of a prior era. It has been removed from the [CLI in 3.24](https://github.com/Shopify/cli/blob/46f58cfaf372206dcebc5b649ffce3d297f5eec2/fixtures/app/CHANGELOG.md#L308-L312).

Only removing from non-discounts since those may still be used by older CLI versions (see Nick's comment below):


```
$ rg schemaVersions -l
discounts/rust/product-discounts/fixed-amount/metadata.json
sample-apps/discounts/extensions/product-discount/metadata.json
discounts/wasm/product-discounts/default/metadata.json
discounts/rust/product-discounts/default/metadata.json
discounts/rust/order-discounts/fixed-amount/metadata.json
discounts/rust/shipping-discounts/fixed-amount/metadata.json
discounts/rust/shipping-discounts/default/metadata.json
discounts/wasm/shipping-discounts/default/metadata.json
discounts/rust/order-discounts/default/metadata.json
discounts/wasm/order-discounts/default/metadata.json
```

^ `schemaVersions` is only found in discounts' `metadata.json` now.