### PR TITLE
Change `fulfillment_constriants` Rust template to `unstable`

### DIFF
--- a/order-routing/rust/fulfillment-constraints/default/shopify.function.extension.toml.liquid
+++ b/order-routing/rust/fulfillment-constraints/default/shopify.function.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "{{extensionType}}"
-api_version = "2023-04"
+api_version = "unstable"
 
 [build]
 command = "cargo wasi build --release"


### PR DESCRIPTION
Quick adjustment to fix the API version to unblock our fulfillment constraints tutorial after noticing the API version in the template was wrong.

Will update this once we have a proper version to use.