### PR TITLE
Remove extensionType variables

### DIFF
--- a/checkout/javascript/cart-checkout-validation/default/shopify.function.extension.toml.liquid
+++ b/checkout/javascript/cart-checkout-validation/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "cart_checkout_validation"
 api_version = "2023-04"
 
 [build]

--- a/checkout/javascript/delivery-customization/default/shopify.function.extension.toml.liquid
+++ b/checkout/javascript/delivery-customization/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "delivery_customization"
 api_version = "2023-04"
 
 [build]

--- a/checkout/javascript/payment-customization/default/shopify.function.extension.toml.liquid
+++ b/checkout/javascript/payment-customization/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "payment_customization"
 api_version = "2023-04"
 
 [build]

--- a/checkout/rust/cart-checkout-validation/default/shopify.function.extension.toml.liquid
+++ b/checkout/rust/cart-checkout-validation/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "cart_checkout_validation"
 api_version = "unstable"
 
 [build]

--- a/checkout/rust/delivery-customization/default/shopify.function.extension.toml.liquid
+++ b/checkout/rust/delivery-customization/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "delivery_customization"
 api_version = "2023-04"
 
 [build]

--- a/checkout/rust/payment-customization/default/shopify.function.extension.toml.liquid
+++ b/checkout/rust/payment-customization/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "payment_customization"
 api_version = "2023-04"
 
 [build]

--- a/checkout/wasm/cart-checkout-validation/default/shopify.function.extension.toml.liquid
+++ b/checkout/wasm/cart-checkout-validation/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "cart_checkout_validation"
 api_version = "unstable"
 
 [build]

--- a/checkout/wasm/delivery-customization/default/shopify.function.extension.toml.liquid
+++ b/checkout/wasm/delivery-customization/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "delivery_customization"
 api_version = "2023-04"
 
 [build]

--- a/checkout/wasm/payment-customization/default/shopify.function.extension.toml.liquid
+++ b/checkout/wasm/payment-customization/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "payment_customization"
 api_version = "2023-04"
 
 [build]

--- a/checkout/wasm/shipping-rates-consolidation/default/shopify.function.extension.toml.liquid
+++ b/checkout/wasm/shipping-rates-consolidation/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "shipping_rates_consolidation"
 description = "Shipping rates consolidation base script"
 api_version = "2022-07"
 

--- a/discounts/javascript/order-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/javascript/order-discounts/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "order_discounts"
 api_version = "2023-01"
 
 [build]

--- a/discounts/javascript/product-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/javascript/product-discounts/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "product_discounts"
 api_version = "2022-07"
 
 [build]

--- a/discounts/javascript/shipping-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/javascript/shipping-discounts/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "shipping_discounts"
 api_version = "2023-01"
 
 [build]

--- a/discounts/rust/order-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/rust/order-discounts/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "order_discounts"
 api_version = "2023-01"
 
 [build]

--- a/discounts/rust/product-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/rust/product-discounts/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "product_discounts"
 api_version = "2023-01"
 
 [build]

--- a/discounts/rust/shipping-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/rust/shipping-discounts/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "shipping_discounts"
 api_version = "2023-01"
 
 [build]

--- a/discounts/wasm/order-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/wasm/order-discounts/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "order_discounts"
 api_version = "2023-01"
 
 [build]

--- a/discounts/wasm/product-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/wasm/product-discounts/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "product_discounts"
 api_version = "2023-01"
 
 [build]

--- a/discounts/wasm/shipping-discounts/default/shopify.function.extension.toml.liquid
+++ b/discounts/wasm/shipping-discounts/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "shipping_discounts"
 api_version = "2023-01"
 
 [build]

--- a/order-routing/rust/fulfillment-constraints/default/shopify.function.extension.toml.liquid
+++ b/order-routing/rust/fulfillment-constraints/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "fulfillment_constraints"
 api_version = "unstable"
 
 [build]

--- a/util/expand-liquid.js
+++ b/util/expand-liquid.js
@@ -76,7 +76,6 @@ async function expandExtensionLiquidTemplates(domainName) {
         const templatePath = path.join(extensionTypePath, templateName);
         const liquidData = {
           name: templateName,
-          extensionType: extensionTypeName.replaceAll('-', '_'),
         };
 
         await expandLiquidTemplates(templatePath, liquidData);


### PR DESCRIPTION
I'm refactoring the CLI code and I noticed we are passing the type as a variable to generate the functions code from the liquid files, but it's actually not needed, as every function only allows one value.

Also, some functions like cart-transform are already hard-coded: https://github.com/Shopify/function-examples/blob/4b19a27376926ccd5fcea7d8537ebe6c2c497682/checkout/wasm/cart-transform/default/shopify.function.extension.toml.liquid#L2

So I'm hard-coding all the values, which will simplify the CLI code and the Partners API with the function specifications.