### PR TITLE
Fix order routing and fulfillment constrainst template

### DIFF
--- a/order-routing/javascript/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/javascript/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "fulfillment_constraints"
 api_version = "unstable"
 
 [build]

--- a/order-routing/javascript/rankers/default/shopify.extension.toml.liquid
+++ b/order-routing/javascript/rankers/default/shopify.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "order_routing_location_rule"
 api_version = "unstable"
 
 [build]

--- a/order-routing/rust/rankers/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/rankers/default/shopify.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "order_routing_location_rule"
 api_version = "unstable"
 
 [build]


### PR DESCRIPTION
Right now when you try to generate either a `Fulfillment constraints - Function` or a `Order routing location rule - Function` from the latest CLI version, you receive an error like this 

```
╭─ error ──────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Invalid extension type “order_routing_location_rule” in                     │
│  “extensions/closest-location-to-buyer/shopify.function.extension.toml”      │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

the problem is that the current template for those functions does not set the `type` properly.

To make the  `Order routing location rule - Function` works this [PR](https://github.com/Shopify/cli/pull/2529) should be merged as well 