### PR TITLE
Fix order routing template tomls used by older CLI versions

### DIFF
--- a/order-routing/javascript/fulfillment-constraints/default/shopify.function.extension.toml.liquid
+++ b/order-routing/javascript/fulfillment-constraints/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "fulfillment_constraints"
 api_version = "unstable"
 
 [build]

--- a/order-routing/javascript/rankers/default/shopify.function.extension.toml.liquid
+++ b/order-routing/javascript/rankers/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "order_routing_location_rule"
 api_version = "unstable"
 
 [build]

--- a/order-routing/rust/rankers/default/shopify.function.extension.toml.liquid
+++ b/order-routing/rust/rankers/default/shopify.function.extension.toml.liquid
@@ -1,5 +1,5 @@
 name = "{{name}}"
-type = "{{extensionType}}"
+type = "order_routing_location_rule"
 api_version = "unstable"
 
 [build]


### PR DESCRIPTION
Right now when you try to generate either a `Fulfillment constraints - Function` or a `Order routing location rule - Function` from the CLI versions `3.47.5` and lower, you receive an error like this

```
╭─ error ──────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Invalid extension type “order_routing_location_rule” in                     │
│  “extensions/closest-location-to-buyer/shopify.function.extension.toml”      │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```
the problem is that the current template for those functions does not set the type properly.

The  `Order routing location rule - Function` won't work without a hotfix that include this change https://github.com/Shopify/cli/pull/2529 in previous `stable` branches