### PR TITLE
Ignore sample-apps workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "private": true,
   "workspaces": [
-    "*/javascript/**",
-    "sample-apps/*/extensions/*-js"
+    "*/javascript/**"
   ]
 }


### PR DESCRIPTION
The Remix sample apps use workspaces themselves, which conflicts with the top-level workspace when running `typegen` in CI. Because we need to merge the Remix sample apps for Editions (tomorrow), we're removing this check for those apps for the sake of time.