### PR TITLE
[Functions] Update JS codegen config

### DIFF
--- a/checkout/javascript/cart-checkout-validation/default/package.json.liquid
+++ b/checkout/javascript/cart-checkout-validation/default/package.json.liquid
@@ -1,5 +1,5 @@
 {
-  "name": "{{handle}}",
+  "name": "{{name}}",
   "version": "0.0.1",
   "license": "UNLICENSED",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/checkout/javascript/cart-checkout-validation/default/src/index.liquid
+++ b/checkout/javascript/cart-checkout-validation/default/src/index.liquid
@@ -2,12 +2,12 @@
 // @ts-check
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  */
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
 (input) => {
@@ -24,12 +24,12 @@ export default /**
 };
 {%- elsif flavor contains "typescript" -%}
 import {
-  InputQuery,
+  Input,
   FunctionResult,
   FunctionError,
 } from "../generated/api";
 
-export default (input: InputQuery): FunctionResult => {
+export default (input: Input): FunctionResult => {
   const errors: FunctionError[] = input.cart.lines
     .filter(({ quantity }) => quantity > 1)
     .map(() => ({

--- a/checkout/javascript/cart-transform/default/package.json.liquid
+++ b/checkout/javascript/cart-transform/default/package.json.liquid
@@ -1,5 +1,5 @@
 {
-  "name": "{{handle}}",
+  "name": "{{name}}",
   "version": "0.0.1",
   "license": "UNLICENSED",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/checkout/javascript/cart-transform/default/src/index.liquid
+++ b/checkout/javascript/cart-transform/default/src/index.liquid
@@ -2,7 +2,7 @@
 // @ts-check
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  */
 
@@ -14,7 +14,7 @@ const NO_CHANGES = {
 };
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
 (input) => {
@@ -22,7 +22,7 @@ export default /**
 };
 {%- elsif flavor contains "typescript" -%}
 import type {
-  InputQuery,
+  Input,
   FunctionResult,
 } from "../generated/api";
 
@@ -30,7 +30,7 @@ const NO_CHANGES: FunctionResult = {
   operations: [],
 };
 
-export default (input: InputQuery): FunctionResult => {
+export default (input: Input): FunctionResult => {
   return NO_CHANGES;
 };
 {%- endif -%}

--- a/checkout/javascript/delivery-customization/default/package.json.liquid
+++ b/checkout/javascript/delivery-customization/default/package.json.liquid
@@ -1,5 +1,5 @@
 {
-  "name": "{{handle}}",
+  "name": "{{name}}",
   "version": "0.0.1",
   "license": "UNLICENSED",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/checkout/javascript/delivery-customization/default/src/index.liquid
+++ b/checkout/javascript/delivery-customization/default/src/index.liquid
@@ -2,7 +2,7 @@
 // @ts-check
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  */
 
@@ -14,7 +14,7 @@ const NO_CHANGES = {
 };
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
 (input) => {
@@ -26,7 +26,7 @@ export default /**
 };
 {%- elsif flavor contains "typescript" -%}
 import {
-  InputQuery,
+  Input,
   FunctionResult,
 } from "../generated/api";
 
@@ -36,7 +36,7 @@ const NO_CHANGES: FunctionResult = {
 
 type Configuration = {};
 
-export default (input: InputQuery): FunctionResult => {
+export default (input: Input): FunctionResult => {
   const configuration: Configuration = JSON.parse(
     input?.deliveryCustomization?.metafield?.value ?? "{}"
   );

--- a/checkout/javascript/payment-customization/default/package.json.liquid
+++ b/checkout/javascript/payment-customization/default/package.json.liquid
@@ -1,5 +1,5 @@
 {
-  "name": "{{handle}}",
+  "name": "{{name}}",
   "version": "0.0.1",
   "license": "UNLICENSED",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/checkout/javascript/payment-customization/default/src/index.liquid
+++ b/checkout/javascript/payment-customization/default/src/index.liquid
@@ -2,7 +2,7 @@
 // @ts-check
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  */
 
@@ -14,7 +14,7 @@ const NO_CHANGES = {
 };
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
 (input) => {
@@ -26,7 +26,7 @@ export default /**
 };
 {%- elsif flavor contains "typescript" -%}
 import {
-  InputQuery,
+  Input,
   FunctionResult,
 } from "../generated/api";
 
@@ -36,7 +36,7 @@ const NO_CHANGES: FunctionResult = {
 
 type Configuration = {};
 
-export default (input: InputQuery): FunctionResult => {
+export default (input: Input): FunctionResult => {
   const configuration: Configuration = JSON.parse(
     input?.paymentCustomization?.metafield?.value ?? "{}"
   );

--- a/discounts/javascript/order-discounts/default/package.json.liquid
+++ b/discounts/javascript/order-discounts/default/package.json.liquid
@@ -1,5 +1,5 @@
 {
-  "name": "{{handle}}",
+  "name": "{{name}}",
   "version": "0.0.1",
   "license": "UNLICENSED",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/discounts/javascript/order-discounts/default/src/index.liquid
+++ b/discounts/javascript/order-discounts/default/src/index.liquid
@@ -3,7 +3,7 @@
 import { DiscountApplicationStrategy } from "../generated/api";
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  */
 
@@ -16,7 +16,7 @@ const EMPTY_DISCOUNT = {
 };
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
 (input) => {
@@ -28,7 +28,7 @@ export default /**
 };
 {%- elsif flavor contains "typescript" -%}
 import {
-  InputQuery,
+  Input,
   FunctionResult,
   DiscountApplicationStrategy,
 } from "../generated/api";
@@ -40,7 +40,7 @@ const EMPTY_DISCOUNT: FunctionResult = {
 
 type Configuration = {};
 
-export default (input: InputQuery): FunctionResult => {
+export default (input: Input): FunctionResult => {
   const configuration: Configuration = JSON.parse(
     input?.discountNode?.metafield?.value ?? "{}"
   );

--- a/discounts/javascript/product-discounts/default/package.json.liquid
+++ b/discounts/javascript/product-discounts/default/package.json.liquid
@@ -1,5 +1,5 @@
 {
-  "name": "{{handle}}",
+  "name": "{{name}}",
   "version": "0.0.1",
   "license": "UNLICENSED",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/discounts/javascript/product-discounts/default/src/index.liquid
+++ b/discounts/javascript/product-discounts/default/src/index.liquid
@@ -3,7 +3,7 @@
 import { DiscountApplicationStrategy } from "../generated/api";
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  */
 
@@ -16,7 +16,7 @@ const EMPTY_DISCOUNT = {
 };
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
 (input) => {
@@ -28,7 +28,7 @@ export default /**
 };
 {%- elsif flavor contains "typescript" -%}
 import {
-  InputQuery,
+  Input,
   FunctionResult,
   DiscountApplicationStrategy,
 } from "../generated/api";
@@ -40,7 +40,7 @@ const EMPTY_DISCOUNT: FunctionResult = {
 
 type Configuration = {};
 
-export default (input: InputQuery): FunctionResult => {
+export default (input: Input): FunctionResult => {
   const configuration: Configuration = JSON.parse(
     input?.discountNode?.metafield?.value ?? "{}"
   );

--- a/discounts/javascript/shipping-discounts/default/package.json.liquid
+++ b/discounts/javascript/shipping-discounts/default/package.json.liquid
@@ -1,5 +1,5 @@
 {
-  "name": "{{handle}}",
+  "name": "{{name}}",
   "version": "0.0.1",
   "license": "UNLICENSED",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/discounts/javascript/shipping-discounts/default/src/index.liquid
+++ b/discounts/javascript/shipping-discounts/default/src/index.liquid
@@ -3,7 +3,7 @@
 import { DiscountApplicationStrategy } from "../generated/api";
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  */
 
@@ -16,7 +16,7 @@ const EMPTY_DISCOUNT = {
 };
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
 (input) => {
@@ -28,7 +28,7 @@ export default /**
 };
 {%- elsif flavor contains "typescript" -%}
 import {
-  InputQuery,
+  Input,
   FunctionResult,
   DiscountApplicationStrategy,
 } from "../generated/api";
@@ -40,7 +40,7 @@ const EMPTY_DISCOUNT: FunctionResult = {
 
 type Configuration = {};
 
-export default (input: InputQuery): FunctionResult => {
+export default (input: Input): FunctionResult => {
   const configuration: Configuration = JSON.parse(
     input?.discountNode?.metafield?.value ?? "{}"
   );

--- a/order-routing/javascript/fulfillment-constraints/default/package.json.liquid
+++ b/order-routing/javascript/fulfillment-constraints/default/package.json.liquid
@@ -1,5 +1,5 @@
 {
-  "name": "{{handle}}",
+  "name": "{{name}}",
   "version": "0.0.1",
   "license": "UNLICENSED",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/order-routing/javascript/fulfillment-constraints/default/src/index.liquid
+++ b/order-routing/javascript/fulfillment-constraints/default/src/index.liquid
@@ -2,7 +2,7 @@
 // @ts-check
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  */
 
@@ -14,7 +14,7 @@ const NO_CHANGES = {
 };
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
 (input) => {
@@ -26,7 +26,7 @@ export default /**
 };
 {%- elsif flavor contains "typescript" -%}
 import {
-  InputQuery,
+  Input,
   FunctionResult,
 } from "../generated/api";
 
@@ -36,7 +36,7 @@ const NO_CHANGES: FunctionResult = {
 
 type Configuration = {};
 
-export default (input: InputQuery): FunctionResult => {
+export default (input: Input): FunctionResult => {
   const configuration: Configuration = JSON.parse(
     input?.fulfillmentConstraintRule?.metafield?.value ?? "{}"
   );

--- a/order-routing/javascript/location-rules/default/package.json.liquid
+++ b/order-routing/javascript/location-rules/default/package.json.liquid
@@ -1,5 +1,5 @@
 {
-  "name": "{{handle}}",
+  "name": "{{name}}",
   "version": "0.0.1",
   "license": "UNLICENSED",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/order-routing/javascript/location-rules/default/src/index.liquid
+++ b/order-routing/javascript/location-rules/default/src/index.liquid
@@ -2,12 +2,12 @@
 // @ts-check
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  */
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
 (input) => {
@@ -29,13 +29,13 @@ export default /**
 };
 {%- elsif flavor contains "typescript" -%}
 import {
-  InputQuery,
+  Input,
   FunctionResult,
   Operation,
   RankedLocation,
 } from "../generated/api";
 
-export default (input: InputQuery): FunctionResult => {
+export default (input: Input): FunctionResult => {
   const operations: Operation[] = input.fulfillmentGroups.map((group) => {
     const rankings: RankedLocation[] = group.inventoryLocations?.map(
       (inventoryLocation) => ({

--- a/order-routing/javascript/rankers/default/package.json.liquid
+++ b/order-routing/javascript/rankers/default/package.json.liquid
@@ -1,5 +1,5 @@
 {
-  "name": "{{handle}}",
+  "name": "{{name}}",
   "version": "0.0.1",
   "license": "UNLICENSED",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/order-routing/javascript/rankers/default/src/index.liquid
+++ b/order-routing/javascript/rankers/default/src/index.liquid
@@ -2,12 +2,12 @@
 // @ts-check
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  */
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
 (input) => {
@@ -29,13 +29,13 @@ export default /**
 };
 {%- elsif flavor contains "typescript" -%}
 import {
-  InputQuery,
+  Input,
   FunctionResult,
   Operation,
   RankedLocation,
 } from "../generated/api";
 
-export default (input: InputQuery): FunctionResult => {
+export default (input: Input): FunctionResult => {
   const operations: Operation[] = input.fulfillmentGroups.map((group) => {
     const rankings: RankedLocation[] = group.inventoryLocations?.map(
       (inventoryLocation) => ({

--- a/sample-apps/bundles-cart-transform/extensions/cart-expand-js/package.json
+++ b/sample-apps/bundles-cart-transform/extensions/cart-expand-js/package.json
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/sample-apps/bundles-cart-transform/extensions/cart-expand-js/src/index.js
+++ b/sample-apps/bundles-cart-transform/extensions/cart-expand-js/src/index.js
@@ -10,7 +10,7 @@ will return an Expand operation containing the parts.
 */
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  * @typedef {import("../generated/api").CartOperation} CartOperation
  */
@@ -23,7 +23,7 @@ const NO_CHANGES = {
 };
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
 (input) => {

--- a/sample-apps/delivery-customizations/extensions/delivery-customization-js/package.json
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization-js/package.json
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/sample-apps/delivery-customizations/extensions/delivery-customization-js/src/index.js
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization-js/src/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  * @typedef {import("../generated/api").Operation} Operation
  */
@@ -14,7 +14,7 @@ const NO_CHANGES = {
 };
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
   (input) => {

--- a/sample-apps/discounts/extensions/product-discount-js/package.json
+++ b/sample-apps/discounts/extensions/product-discount-js/package.json
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/sample-apps/discounts/extensions/product-discount-js/src/index.js
+++ b/sample-apps/discounts/extensions/product-discount-js/src/index.js
@@ -2,7 +2,7 @@
 import { DiscountApplicationStrategy } from "../generated/api";
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  * @typedef {import("../generated/api").Target} Target
  * @typedef {import("../generated/api").ProductVariant} ProductVariant
@@ -17,7 +17,7 @@ const EMPTY_DISCOUNT = {
 };
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
   (input) => {

--- a/sample-apps/payment-customizations/extensions/payment-customization-js/package.json
+++ b/sample-apps/payment-customizations/extensions/payment-customization-js/package.json
@@ -11,7 +11,7 @@
   },
   "codegen": {
     "schema": "schema.graphql",
-    "documents": "input.graphql",
+    "documents": "*.graphql",
     "generates": {
       "./generated/api.ts": {
         "plugins": [
@@ -19,6 +19,9 @@
           "typescript-operations"
         ]
       }
+    },
+    "config": {
+      "omitOperationSuffix": true
     }
   },
   "devDependencies": {

--- a/sample-apps/payment-customizations/extensions/payment-customization-js/src/index.js
+++ b/sample-apps/payment-customizations/extensions/payment-customization-js/src/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @typedef {import("../generated/api").InputQuery} InputQuery
+ * @typedef {import("../generated/api").Input} Input
  * @typedef {import("../generated/api").FunctionResult} FunctionResult
  * @typedef {import("../generated/api").HideOperation} HideOperation
  */
@@ -14,7 +14,7 @@ const NO_CHANGES = {
 };
 
 export default /**
- * @param {InputQuery} input
+ * @param {Input} input
  * @returns {FunctionResult}
  */
 (input) => {


### PR DESCRIPTION
#gsd:34464
Closes https://github.com/Shopify/script-service/issues/7132

Make it easier to [codegen with targets](https://github.com/Shopify/script-service/issues/7132#issuecomment-1669922724) from the default JS template

```json
"config": {
  "omitOperationSuffix": true
}
```

This generates `Input` instead of `InputQuery`.