### PR TITLE
Update API versions for all stable APIs to 2023-07

### DIFF
--- a/checkout/javascript/cart-checkout-validation/default/schema.graphql
+++ b/checkout/javascript/cart-checkout-validation/default/schema.graphql
@@ -28,12 +28,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -227,6 +232,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -255,6 +266,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -264,7 +290,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -342,7 +368,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2453,6 +2479,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2492,6 +2523,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2569,7 +2610,7 @@ enum DeliveryMethod {
 }
 
 """
-A function error for a path.
+A Function error for a path.
 """
 input FunctionError {
   """
@@ -2614,6 +2655,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2633,7 +2689,7 @@ type Input {
   cart: Cart!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3356,6 +3412,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3419,6 +3480,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3464,11 +3590,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3488,10 +3614,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3499,14 +3635,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3532,6 +3678,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3579,6 +3730,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3607,6 +3763,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/checkout/javascript/cart-transform/default/schema.graphql
+++ b/checkout/javascript/cart-transform/default/schema.graphql
@@ -33,7 +33,7 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
@@ -43,7 +43,7 @@ type BuyerIdentity {
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -153,7 +153,7 @@ input CartLineInput {
   cartLineId: ID!
 
   """
-  The quantity of the cart line to be merged.The max quantity is 50.
+  The quantity of the cart line to be merged.The max quantity is 2000.
   """
   quantity: Int!
 }
@@ -1276,7 +1276,7 @@ input ExpandedItem {
   merchandiseId: ID!
 
   """
-  The quantity of the expanded item.The max quantity is 50.
+  The quantity of the expanded item.The max quantity is 2000.
   """
   quantity: Int!
 }
@@ -1429,11 +1429,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!

--- a/checkout/javascript/cart-transform/default/shopify.extension.toml.liquid
+++ b/checkout/javascript/cart-transform/default/shopify.extension.toml.liquid
@@ -1,7 +1,7 @@
 name = "{{name}}"
 type = "cart_transform"
 title = "cart transform"
-api_version = "unstable"
+api_version = "2023-07"
 
 [build]
 command = ""

--- a/checkout/javascript/delivery-customization/default/schema.graphql
+++ b/checkout/javascript/delivery-customization/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -208,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -236,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -245,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -323,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2434,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2473,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2600,6 +2641,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Request to hide a delivery option.
 """
 input HideOperation {
@@ -2629,7 +2685,7 @@ type Input {
   deliveryCustomization: DeliveryCustomization!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3352,6 +3408,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3415,6 +3476,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3475,11 +3601,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3519,10 +3645,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3530,14 +3666,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3563,6 +3709,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3610,6 +3761,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3653,6 +3809,74 @@ input RenameOperation {
   The new name for the delivery option.
   """
   title: String!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/checkout/javascript/delivery-customization/default/shopify.extension.toml.liquid
+++ b/checkout/javascript/delivery-customization/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "delivery_customization"
-api_version = "2023-04"
+api_version = "2023-07"
 
 [build]
 command = ""

--- a/checkout/javascript/payment-customization/default/schema.graphql
+++ b/checkout/javascript/payment-customization/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -208,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -236,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -245,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -323,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2434,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2473,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2580,6 +2621,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Request to hide a payment method.
 """
 input HideOperation {
@@ -2604,7 +2660,7 @@ type Input {
   cart: Cart!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3337,6 +3393,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3400,6 +3461,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3460,11 +3586,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3532,10 +3658,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3543,14 +3679,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3576,6 +3722,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3623,6 +3774,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3666,6 +3822,74 @@ input RenameOperation {
   The identifier of the payment method to rename.
   """
   paymentMethodId: ID!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/checkout/javascript/payment-customization/default/shopify.extension.toml.liquid
+++ b/checkout/javascript/payment-customization/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "payment_customization"
-api_version = "2023-04"
+api_version = "2023-07"
 
 [build]
 command = ""

--- a/checkout/rust/cart-checkout-validation/default/schema.graphql
+++ b/checkout/rust/cart-checkout-validation/default/schema.graphql
@@ -28,12 +28,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -227,6 +232,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -255,6 +266,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -264,7 +290,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -342,7 +368,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2453,6 +2479,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2492,6 +2523,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2569,7 +2610,7 @@ enum DeliveryMethod {
 }
 
 """
-A function error for a path.
+A Function error for a path.
 """
 input FunctionError {
   """
@@ -2614,6 +2655,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2633,7 +2689,7 @@ type Input {
   cart: Cart!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3356,6 +3412,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3419,6 +3480,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3464,11 +3590,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3488,10 +3614,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3499,14 +3635,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3532,6 +3678,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3579,6 +3730,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3607,6 +3763,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/checkout/rust/cart-transform/bundles/schema.graphql
+++ b/checkout/rust/cart-transform/bundles/schema.graphql
@@ -24,7 +24,7 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart. Only set when the buyer is logged in.
+Represents information about the buyer that is interacting with the cart.
 """
 type BuyerIdentity {
   """
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -68,114 +73,9 @@ type Cart {
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
-  """
-  cost: CartCost!
-
-  """
-  A list of lines containing information about the items that can be delivered.
-  """
-  deliverableLines: [DeliverableCartLine!]!
-
-  """
-  The delivery groups available for the cart based on the buyer's shipping address.
-  """
-  deliveryGroups: [CartDeliveryGroup!]!
-
-  """
   A list of lines containing information about the items the customer intends to purchase.
   """
   lines: [CartLine!]!
-}
-
-"""
-The cost that the buyer will pay at checkout.
-"""
-type CartCost {
-  """
-  The amount, before taxes and discounts, for the customer to pay.
-  """
-  subtotalAmount: MoneyV2!
-
-  """
-  The total amount for the customer to pay.
-  """
-  totalAmount: MoneyV2!
-
-  """
-  The duty amount for the customer to pay at checkout.
-  """
-  totalDutyAmount: MoneyV2
-
-  """
-  The tax amount for the customer to pay at checkout.
-  """
-  totalTaxAmount: MoneyV2
-}
-
-"""
-Information about the options available for one or more line items to be delivered to a specific address.
-"""
-type CartDeliveryGroup {
-  """
-  A list of cart lines for the delivery group.
-  """
-  cartLines: [CartLine!]!
-
-  """
-  The destination address for the delivery group.
-  """
-  deliveryAddress: MailingAddress
-
-  """
-  The delivery options available for the delivery group.
-  """
-  deliveryOptions: [CartDeliveryOption!]!
-
-  """
-  Unique identifier for the delivery group.
-  """
-  id: ID!
-
-  """
-  Information about the delivery option the buyer has selected.
-  """
-  selectedDeliveryOption: CartDeliveryOption
-}
-
-"""
-Information about a delivery option.
-"""
-type CartDeliveryOption {
-  """
-  The code of the delivery option.
-  """
-  code: String
-
-  """
-  The cost for the delivery option.
-  """
-  cost: MoneyV2!
-
-  """
-  The method for the delivery option.
-  """
-  deliveryMethodType: DeliveryMethod!
-
-  """
-  The description of the delivery option.
-  """
-  description: String
-
-  """
-  The unique identifier of the delivery option.
-  """
-  handle: String!
-
-  """
-  The title of the delivery option.
-  """
-  title: String
 }
 
 """
@@ -213,6 +113,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -247,7 +153,7 @@ input CartLineInput {
   cartLineId: ID!
 
   """
-  The quantity of the cart line.
+  The quantity of the cart line to be merged.The max quantity is 2000.
   """
   quantity: Int!
 }
@@ -281,6 +187,21 @@ type CartTransform implements HasMetafields {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -290,7 +211,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -368,7 +289,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -407,1239 +328,6 @@ type CompanyLocation implements HasMetafields {
   at which the company location was last modified.
   """
   updatedAt: DateTime!
-}
-
-"""
-The code designating a country/region, which generally follows ISO 3166-1 alpha-2 guidelines.
-If a territory doesn't have a country code value in the `CountryCode` enum, then it might be considered a subdivision
-of another country. For example, the territories associated with Spain are represented by the country code `ES`,
-and the territories associated with the United States of America are represented by the country code `US`.
-"""
-enum CountryCode {
-  """
-  Ascension Island.
-  """
-  AC
-
-  """
-  Andorra.
-  """
-  AD
-
-  """
-  United Arab Emirates.
-  """
-  AE
-
-  """
-  Afghanistan.
-  """
-  AF
-
-  """
-  Antigua & Barbuda.
-  """
-  AG
-
-  """
-  Anguilla.
-  """
-  AI
-
-  """
-  Albania.
-  """
-  AL
-
-  """
-  Armenia.
-  """
-  AM
-
-  """
-  Netherlands Antilles.
-  """
-  AN
-
-  """
-  Angola.
-  """
-  AO
-
-  """
-  Argentina.
-  """
-  AR
-
-  """
-  Austria.
-  """
-  AT
-
-  """
-  Australia.
-  """
-  AU
-
-  """
-  Aruba.
-  """
-  AW
-
-  """
-  Åland Islands.
-  """
-  AX
-
-  """
-  Azerbaijan.
-  """
-  AZ
-
-  """
-  Bosnia & Herzegovina.
-  """
-  BA
-
-  """
-  Barbados.
-  """
-  BB
-
-  """
-  Bangladesh.
-  """
-  BD
-
-  """
-  Belgium.
-  """
-  BE
-
-  """
-  Burkina Faso.
-  """
-  BF
-
-  """
-  Bulgaria.
-  """
-  BG
-
-  """
-  Bahrain.
-  """
-  BH
-
-  """
-  Burundi.
-  """
-  BI
-
-  """
-  Benin.
-  """
-  BJ
-
-  """
-  St. Barthélemy.
-  """
-  BL
-
-  """
-  Bermuda.
-  """
-  BM
-
-  """
-  Brunei.
-  """
-  BN
-
-  """
-  Bolivia.
-  """
-  BO
-
-  """
-  Caribbean Netherlands.
-  """
-  BQ
-
-  """
-  Brazil.
-  """
-  BR
-
-  """
-  Bahamas.
-  """
-  BS
-
-  """
-  Bhutan.
-  """
-  BT
-
-  """
-  Bouvet Island.
-  """
-  BV
-
-  """
-  Botswana.
-  """
-  BW
-
-  """
-  Belarus.
-  """
-  BY
-
-  """
-  Belize.
-  """
-  BZ
-
-  """
-  Canada.
-  """
-  CA
-
-  """
-  Cocos (Keeling) Islands.
-  """
-  CC
-
-  """
-  Congo - Kinshasa.
-  """
-  CD
-
-  """
-  Central African Republic.
-  """
-  CF
-
-  """
-  Congo - Brazzaville.
-  """
-  CG
-
-  """
-  Switzerland.
-  """
-  CH
-
-  """
-  Côte d’Ivoire.
-  """
-  CI
-
-  """
-  Cook Islands.
-  """
-  CK
-
-  """
-  Chile.
-  """
-  CL
-
-  """
-  Cameroon.
-  """
-  CM
-
-  """
-  China.
-  """
-  CN
-
-  """
-  Colombia.
-  """
-  CO
-
-  """
-  Costa Rica.
-  """
-  CR
-
-  """
-  Cuba.
-  """
-  CU
-
-  """
-  Cape Verde.
-  """
-  CV
-
-  """
-  Curaçao.
-  """
-  CW
-
-  """
-  Christmas Island.
-  """
-  CX
-
-  """
-  Cyprus.
-  """
-  CY
-
-  """
-  Czechia.
-  """
-  CZ
-
-  """
-  Germany.
-  """
-  DE
-
-  """
-  Djibouti.
-  """
-  DJ
-
-  """
-  Denmark.
-  """
-  DK
-
-  """
-  Dominica.
-  """
-  DM
-
-  """
-  Dominican Republic.
-  """
-  DO
-
-  """
-  Algeria.
-  """
-  DZ
-
-  """
-  Ecuador.
-  """
-  EC
-
-  """
-  Estonia.
-  """
-  EE
-
-  """
-  Egypt.
-  """
-  EG
-
-  """
-  Western Sahara.
-  """
-  EH
-
-  """
-  Eritrea.
-  """
-  ER
-
-  """
-  Spain.
-  """
-  ES
-
-  """
-  Ethiopia.
-  """
-  ET
-
-  """
-  Finland.
-  """
-  FI
-
-  """
-  Fiji.
-  """
-  FJ
-
-  """
-  Falkland Islands.
-  """
-  FK
-
-  """
-  Faroe Islands.
-  """
-  FO
-
-  """
-  France.
-  """
-  FR
-
-  """
-  Gabon.
-  """
-  GA
-
-  """
-  United Kingdom.
-  """
-  GB
-
-  """
-  Grenada.
-  """
-  GD
-
-  """
-  Georgia.
-  """
-  GE
-
-  """
-  French Guiana.
-  """
-  GF
-
-  """
-  Guernsey.
-  """
-  GG
-
-  """
-  Ghana.
-  """
-  GH
-
-  """
-  Gibraltar.
-  """
-  GI
-
-  """
-  Greenland.
-  """
-  GL
-
-  """
-  Gambia.
-  """
-  GM
-
-  """
-  Guinea.
-  """
-  GN
-
-  """
-  Guadeloupe.
-  """
-  GP
-
-  """
-  Equatorial Guinea.
-  """
-  GQ
-
-  """
-  Greece.
-  """
-  GR
-
-  """
-  South Georgia & South Sandwich Islands.
-  """
-  GS
-
-  """
-  Guatemala.
-  """
-  GT
-
-  """
-  Guinea-Bissau.
-  """
-  GW
-
-  """
-  Guyana.
-  """
-  GY
-
-  """
-  Hong Kong SAR.
-  """
-  HK
-
-  """
-  Heard & McDonald Islands.
-  """
-  HM
-
-  """
-  Honduras.
-  """
-  HN
-
-  """
-  Croatia.
-  """
-  HR
-
-  """
-  Haiti.
-  """
-  HT
-
-  """
-  Hungary.
-  """
-  HU
-
-  """
-  Indonesia.
-  """
-  ID
-
-  """
-  Ireland.
-  """
-  IE
-
-  """
-  Israel.
-  """
-  IL
-
-  """
-  Isle of Man.
-  """
-  IM
-
-  """
-  India.
-  """
-  IN
-
-  """
-  British Indian Ocean Territory.
-  """
-  IO
-
-  """
-  Iraq.
-  """
-  IQ
-
-  """
-  Iran.
-  """
-  IR
-
-  """
-  Iceland.
-  """
-  IS
-
-  """
-  Italy.
-  """
-  IT
-
-  """
-  Jersey.
-  """
-  JE
-
-  """
-  Jamaica.
-  """
-  JM
-
-  """
-  Jordan.
-  """
-  JO
-
-  """
-  Japan.
-  """
-  JP
-
-  """
-  Kenya.
-  """
-  KE
-
-  """
-  Kyrgyzstan.
-  """
-  KG
-
-  """
-  Cambodia.
-  """
-  KH
-
-  """
-  Kiribati.
-  """
-  KI
-
-  """
-  Comoros.
-  """
-  KM
-
-  """
-  St. Kitts & Nevis.
-  """
-  KN
-
-  """
-  North Korea.
-  """
-  KP
-
-  """
-  South Korea.
-  """
-  KR
-
-  """
-  Kuwait.
-  """
-  KW
-
-  """
-  Cayman Islands.
-  """
-  KY
-
-  """
-  Kazakhstan.
-  """
-  KZ
-
-  """
-  Laos.
-  """
-  LA
-
-  """
-  Lebanon.
-  """
-  LB
-
-  """
-  St. Lucia.
-  """
-  LC
-
-  """
-  Liechtenstein.
-  """
-  LI
-
-  """
-  Sri Lanka.
-  """
-  LK
-
-  """
-  Liberia.
-  """
-  LR
-
-  """
-  Lesotho.
-  """
-  LS
-
-  """
-  Lithuania.
-  """
-  LT
-
-  """
-  Luxembourg.
-  """
-  LU
-
-  """
-  Latvia.
-  """
-  LV
-
-  """
-  Libya.
-  """
-  LY
-
-  """
-  Morocco.
-  """
-  MA
-
-  """
-  Monaco.
-  """
-  MC
-
-  """
-  Moldova.
-  """
-  MD
-
-  """
-  Montenegro.
-  """
-  ME
-
-  """
-  St. Martin.
-  """
-  MF
-
-  """
-  Madagascar.
-  """
-  MG
-
-  """
-  North Macedonia.
-  """
-  MK
-
-  """
-  Mali.
-  """
-  ML
-
-  """
-  Myanmar (Burma).
-  """
-  MM
-
-  """
-  Mongolia.
-  """
-  MN
-
-  """
-  Macao SAR.
-  """
-  MO
-
-  """
-  Martinique.
-  """
-  MQ
-
-  """
-  Mauritania.
-  """
-  MR
-
-  """
-  Montserrat.
-  """
-  MS
-
-  """
-  Malta.
-  """
-  MT
-
-  """
-  Mauritius.
-  """
-  MU
-
-  """
-  Maldives.
-  """
-  MV
-
-  """
-  Malawi.
-  """
-  MW
-
-  """
-  Mexico.
-  """
-  MX
-
-  """
-  Malaysia.
-  """
-  MY
-
-  """
-  Mozambique.
-  """
-  MZ
-
-  """
-  Namibia.
-  """
-  NA
-
-  """
-  New Caledonia.
-  """
-  NC
-
-  """
-  Niger.
-  """
-  NE
-
-  """
-  Norfolk Island.
-  """
-  NF
-
-  """
-  Nigeria.
-  """
-  NG
-
-  """
-  Nicaragua.
-  """
-  NI
-
-  """
-  Netherlands.
-  """
-  NL
-
-  """
-  Norway.
-  """
-  NO
-
-  """
-  Nepal.
-  """
-  NP
-
-  """
-  Nauru.
-  """
-  NR
-
-  """
-  Niue.
-  """
-  NU
-
-  """
-  New Zealand.
-  """
-  NZ
-
-  """
-  Oman.
-  """
-  OM
-
-  """
-  Panama.
-  """
-  PA
-
-  """
-  Peru.
-  """
-  PE
-
-  """
-  French Polynesia.
-  """
-  PF
-
-  """
-  Papua New Guinea.
-  """
-  PG
-
-  """
-  Philippines.
-  """
-  PH
-
-  """
-  Pakistan.
-  """
-  PK
-
-  """
-  Poland.
-  """
-  PL
-
-  """
-  St. Pierre & Miquelon.
-  """
-  PM
-
-  """
-  Pitcairn Islands.
-  """
-  PN
-
-  """
-  Palestinian Territories.
-  """
-  PS
-
-  """
-  Portugal.
-  """
-  PT
-
-  """
-  Paraguay.
-  """
-  PY
-
-  """
-  Qatar.
-  """
-  QA
-
-  """
-  Réunion.
-  """
-  RE
-
-  """
-  Romania.
-  """
-  RO
-
-  """
-  Serbia.
-  """
-  RS
-
-  """
-  Russia.
-  """
-  RU
-
-  """
-  Rwanda.
-  """
-  RW
-
-  """
-  Saudi Arabia.
-  """
-  SA
-
-  """
-  Solomon Islands.
-  """
-  SB
-
-  """
-  Seychelles.
-  """
-  SC
-
-  """
-  Sudan.
-  """
-  SD
-
-  """
-  Sweden.
-  """
-  SE
-
-  """
-  Singapore.
-  """
-  SG
-
-  """
-  St. Helena.
-  """
-  SH
-
-  """
-  Slovenia.
-  """
-  SI
-
-  """
-  Svalbard & Jan Mayen.
-  """
-  SJ
-
-  """
-  Slovakia.
-  """
-  SK
-
-  """
-  Sierra Leone.
-  """
-  SL
-
-  """
-  San Marino.
-  """
-  SM
-
-  """
-  Senegal.
-  """
-  SN
-
-  """
-  Somalia.
-  """
-  SO
-
-  """
-  Suriname.
-  """
-  SR
-
-  """
-  South Sudan.
-  """
-  SS
-
-  """
-  São Tomé & Príncipe.
-  """
-  ST
-
-  """
-  El Salvador.
-  """
-  SV
-
-  """
-  Sint Maarten.
-  """
-  SX
-
-  """
-  Syria.
-  """
-  SY
-
-  """
-  Eswatini.
-  """
-  SZ
-
-  """
-  Tristan da Cunha.
-  """
-  TA
-
-  """
-  Turks & Caicos Islands.
-  """
-  TC
-
-  """
-  Chad.
-  """
-  TD
-
-  """
-  French Southern Territories.
-  """
-  TF
-
-  """
-  Togo.
-  """
-  TG
-
-  """
-  Thailand.
-  """
-  TH
-
-  """
-  Tajikistan.
-  """
-  TJ
-
-  """
-  Tokelau.
-  """
-  TK
-
-  """
-  Timor-Leste.
-  """
-  TL
-
-  """
-  Turkmenistan.
-  """
-  TM
-
-  """
-  Tunisia.
-  """
-  TN
-
-  """
-  Tonga.
-  """
-  TO
-
-  """
-  Turkey.
-  """
-  TR
-
-  """
-  Trinidad & Tobago.
-  """
-  TT
-
-  """
-  Tuvalu.
-  """
-  TV
-
-  """
-  Taiwan.
-  """
-  TW
-
-  """
-  Tanzania.
-  """
-  TZ
-
-  """
-  Ukraine.
-  """
-  UA
-
-  """
-  Uganda.
-  """
-  UG
-
-  """
-  U.S. Outlying Islands.
-  """
-  UM
-
-  """
-  United States.
-  """
-  US
-
-  """
-  Uruguay.
-  """
-  UY
-
-  """
-  Uzbekistan.
-  """
-  UZ
-
-  """
-  Vatican City.
-  """
-  VA
-
-  """
-  St. Vincent & Grenadines.
-  """
-  VC
-
-  """
-  Venezuela.
-  """
-  VE
-
-  """
-  British Virgin Islands.
-  """
-  VG
-
-  """
-  Vietnam.
-  """
-  VN
-
-  """
-  Vanuatu.
-  """
-  VU
-
-  """
-  Wallis & Futuna.
-  """
-  WF
-
-  """
-  Samoa.
-  """
-  WS
-
-  """
-  Kosovo.
-  """
-  XK
-
-  """
-  Yemen.
-  """
-  YE
-
-  """
-  Mayotte.
-  """
-  YT
-
-  """
-  South Africa.
-  """
-  ZA
-
-  """
-  Zambia.
-  """
-  ZM
-
-  """
-  Zimbabwe.
-  """
-  ZW
-
-  """
-  Unknown Region.
-  """
-  ZZ
 }
 
 """
@@ -1771,10 +459,7 @@ enum CurrencyCode {
   """
   Belarusian Ruble (BYR).
   """
-  BYR
-    @deprecated(
-      reason: "`BYR` is deprecated. Use `BYN` available from version `2021-01` onwards instead."
-    )
+  BYR @deprecated(reason: "`BYR` is deprecated. Use `BYN` available from version `2021-01` onwards instead.")
 
   """
   Belize Dollar (BZD).
@@ -2299,10 +984,7 @@ enum CurrencyCode {
   """
   Sao Tome And Principe Dobra (STD).
   """
-  STD
-    @deprecated(
-      reason: "`STD` is deprecated. Use `STN` available from version `2022-07` onwards instead."
-    )
+  STD @deprecated(reason: "`STD` is deprecated. Use `STN` available from version `2022-07` onwards instead.")
 
   """
   Sao Tome And Principe Dobra (STN).
@@ -2397,10 +1079,7 @@ enum CurrencyCode {
   """
   Venezuelan Bolivares (VEF).
   """
-  VEF
-    @deprecated(
-      reason: "`VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead."
-    )
+  VEF @deprecated(reason: "`VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead.")
 
   """
   Venezuelan Bolivares (VES).
@@ -2478,6 +1157,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2519,6 +1203,16 @@ type Customer implements HasMetafields {
   ): Boolean!
 
   """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
+
+  """
   A unique identifier for the customer.
   """
   id: ID!
@@ -2558,73 +1252,6 @@ Example values: `"29.99"`, `"29.999"`.
 """
 scalar Decimal
 
-"""
-Represents information about the merchandise in the cart.
-"""
-type DeliverableCartLine {
-  """
-  Retrieve a cart line attribute by key.
-
-  Cart line attributes are also known as line item properties in Liquid.
-  """
-  attribute(
-    """
-    The key of the attribute to retrieve.
-    """
-    key: String
-  ): Attribute
-
-  """
-  The ID of the cart line.
-  """
-  id: ID!
-
-  """
-  The merchandise that the buyer intends to purchase.
-  """
-  merchandise: Merchandise!
-
-  """
-  The quantity of the merchandise that the customer intends to purchase.
-  """
-  quantity: Int!
-}
-
-"""
-List of different delivery method types.
-"""
-enum DeliveryMethod {
-  """
-  Local Delivery.
-  """
-  LOCAL
-
-  """
-  None.
-  """
-  NONE
-
-  """
-  Shipping to a Pickup Point.
-  """
-  PICKUP_POINT
-
-  """
-  Local Pickup.
-  """
-  PICK_UP
-
-  """
-  Retail.
-  """
-  RETAIL
-
-  """
-  Shipping.
-  """
-  SHIPPING
-}
-
 input ExpandOperation {
   """
   The cart line id to expand.
@@ -2649,7 +1276,7 @@ input ExpandedItem {
   merchandiseId: ID!
 
   """
-  The quantity of the expanded item.
+  The quantity of the expanded item.The max quantity is 2000.
   """
   quantity: Int!
 }
@@ -2661,67 +1288,7 @@ input FunctionResult {
   """
   Cart operations to run on Cart.
   """
-  operations: [CartOperation!]
-}
-
-"""
-Represents a gate configuration.
-"""
-type GateConfiguration implements HasMetafields {
-  """
-  An optional string identifier.
-  """
-  appId: String
-
-  """
-  The ID of the gate configuration.
-  """
-  id: ID!
-
-  """
-  Returns a metafield by namespace and key that belongs to the resource.
-  """
-  metafield(
-    """
-    The key for the metafield.
-    """
-    key: String!
-
-    """
-    The namespace for the metafield.
-    """
-    namespace: String!
-  ): Metafield
-}
-
-"""
-Represents a connection from a subject to a gate configuration.
-"""
-type GateSubject {
-  """
-  The bound gate configuration.
-  """
-  configuration(
-    """
-    The appId of the gate configurations to search for.
-    """
-    appId: String
-  ): GateConfiguration!
-
-  """
-  The ID of the gate subject.
-  """
-  id: ID!
-}
-
-"""
-Gate subjects associated to the specified resource.
-"""
-interface HasGates {
-  """
-  Returns active gate subjects bound to the resource.
-  """
-  gates: [GateSubject!]!
+  operations: [CartOperation!]!
 }
 
 """
@@ -2742,6 +1309,21 @@ interface HasMetafields {
     """
     namespace: String!
   ): Metafield
+}
+
+"""
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
 }
 
 """
@@ -2772,66 +1354,6 @@ type Input {
   The CartTransform containing the function.
   """
   cartTransform: CartTransform!
-}
-
-"""
-Represents a mailing address.
-"""
-type MailingAddress {
-  """
-  The first line of the address. Typically the street address or PO Box number.
-  """
-  address1: String
-
-  """
-  The second line of the address. Typically the number of the apartment, suite, or unit.
-  """
-  address2: String
-
-  """
-  The name of the city, district, village, or town.
-  """
-  city: String
-
-  """
-  The name of the customer's company or organization.
-  """
-  company: String
-
-  """
-  The two-letter code for the country of the address. For example, US.
-  """
-  countryCode: CountryCode
-
-  """
-  The first name of the customer.
-  """
-  firstName: String
-
-  """
-  The last name of the customer.
-  """
-  lastName: String
-
-  """
-  The full name of the customer, based on firstName and lastName.
-  """
-  name: String
-
-  """
-  A unique phone number for the customer. Formatted using E.164 standard. For example, +16135551111.
-  """
-  phone: String
-
-  """
-  The two-letter code for the region. For example, ON.
-  """
-  provinceCode: String
-
-  """
-  The zip or postal code of the address.
-  """
-  zip: String
 }
 
 """
@@ -2907,11 +1429,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -2934,12 +1456,7 @@ input PriceAdjustmentValue {
 """
 Represents a product.
 """
-type Product implements HasGates & HasMetafields {
-  """
-  Returns active gate subjects bound to the resource.
-  """
-  gates: [GateSubject!]!
-
+type Product implements HasMetafields {
   """
   A unique human-friendly string of the product's title.
   """
@@ -2950,10 +1467,20 @@ type Product implements HasGates & HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -2961,14 +1488,24 @@ type Product implements HasGates & HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -2994,6 +1531,11 @@ type Product implements HasGates & HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3041,6 +1583,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3069,6 +1616,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/checkout/rust/cart-transform/bundles/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-transform/bundles/shopify.extension.toml.liquid
@@ -1,7 +1,7 @@
 name = "bundles cart transform"
 type = "cart_transform"
 title = "bundles cart transform"
-api_version = "unstable"
+api_version = "2023-07"
 
 [build]
 command = "cargo wasi build --release"

--- a/checkout/rust/cart-transform/bundles/src/main.rs
+++ b/checkout/rust/cart-transform/bundles/src/main.rs
@@ -58,7 +58,7 @@ fn function(input: input::ResponseData) -> Result<output::FunctionResult> {
         .collect();
 
     Ok(output::FunctionResult {
-        operations: Some(cart_operations),
+        operations: cart_operations,
     })
 }
 

--- a/checkout/rust/cart-transform/default/schema.graphql
+++ b/checkout/rust/cart-transform/default/schema.graphql
@@ -33,7 +33,7 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
@@ -43,7 +43,7 @@ type BuyerIdentity {
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -153,7 +153,7 @@ input CartLineInput {
   cartLineId: ID!
 
   """
-  The quantity of the cart line to be merged.The max quantity is 50.
+  The quantity of the cart line to be merged.The max quantity is 2000.
   """
   quantity: Int!
 }
@@ -1276,7 +1276,7 @@ input ExpandedItem {
   merchandiseId: ID!
 
   """
-  The quantity of the expanded item.The max quantity is 50.
+  The quantity of the expanded item.The max quantity is 2000.
   """
   quantity: Int!
 }
@@ -1429,11 +1429,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!

--- a/checkout/rust/cart-transform/default/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-transform/default/shopify.extension.toml.liquid
@@ -1,7 +1,7 @@
 name = "{{name}}"
 type = "cart_transform"
 title = "cart transform"
-api_version = "unstable"
+api_version = "2023-07"
 
 [build]
 command = "cargo wasi build --release"

--- a/checkout/rust/delivery-customization/default/schema.graphql
+++ b/checkout/rust/delivery-customization/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -208,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -236,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -245,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -323,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2434,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2473,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2600,6 +2641,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Request to hide a delivery option.
 """
 input HideOperation {
@@ -2629,7 +2685,7 @@ type Input {
   deliveryCustomization: DeliveryCustomization!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3352,6 +3408,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3415,6 +3476,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3475,11 +3601,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3519,10 +3645,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3530,14 +3666,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3563,6 +3709,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3610,6 +3761,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3653,6 +3809,74 @@ input RenameOperation {
   The new name for the delivery option.
   """
   title: String!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/checkout/rust/delivery-customization/default/shopify.extension.toml.liquid
+++ b/checkout/rust/delivery-customization/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "delivery_customization"
-api_version = "2023-04"
+api_version = "2023-07"
 
 [build]
 command = "cargo wasi build --release"

--- a/checkout/rust/payment-customization/default/schema.graphql
+++ b/checkout/rust/payment-customization/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -208,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -236,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -245,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -323,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2434,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2473,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2580,6 +2621,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Request to hide a payment method.
 """
 input HideOperation {
@@ -2604,7 +2660,7 @@ type Input {
   cart: Cart!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3337,6 +3393,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3400,6 +3461,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3460,11 +3586,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3532,10 +3658,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3543,14 +3679,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3576,6 +3722,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3623,6 +3774,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3666,6 +3822,74 @@ input RenameOperation {
   The identifier of the payment method to rename.
   """
   paymentMethodId: ID!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/checkout/rust/payment-customization/default/shopify.extension.toml.liquid
+++ b/checkout/rust/payment-customization/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "payment_customization"
-api_version = "2023-04"
+api_version = "2023-07"
 
 [build]
 command = "cargo wasi build --release"

--- a/checkout/wasm/cart-checkout-validation/default/schema.graphql
+++ b/checkout/wasm/cart-checkout-validation/default/schema.graphql
@@ -28,12 +28,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -52,19 +57,19 @@ Different steps in the buyer journey.
 """
 enum BuyerJourneyStep {
   """
-  Buyer is in cart.
+  Buyer is interacting with the cart.
   """
-  CART
+  CART_INTERACTION
 
   """
-  Buyer completed checkout.
+  Buyer is completing the checkout.
   """
-  CHECKOUT_COMPLETE
+  CHECKOUT_COMPLETION
 
   """
-  Buyer is in the process of checking out.
+  Buyer is interacting with the checkout.
   """
-  CHECKOUT_PROGRESS
+  CHECKOUT_INTERACTION
 }
 
 """
@@ -227,6 +232,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -255,6 +266,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -264,7 +290,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -342,7 +368,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -1755,10 +1781,7 @@ enum CurrencyCode {
   """
   Belarusian Ruble (BYR).
   """
-  BYR
-    @deprecated(
-      reason: "`BYR` is deprecated. Use `BYN` available from version `2021-01` onwards instead."
-    )
+  BYR @deprecated(reason: "`BYR` is deprecated. Use `BYN` available from version `2021-01` onwards instead.")
 
   """
   Belize Dollar (BZD).
@@ -2283,10 +2306,7 @@ enum CurrencyCode {
   """
   Sao Tome And Principe Dobra (STD).
   """
-  STD
-    @deprecated(
-      reason: "`STD` is deprecated. Use `STN` available from version `2022-07` onwards instead."
-    )
+  STD @deprecated(reason: "`STD` is deprecated. Use `STN` available from version `2022-07` onwards instead.")
 
   """
   Sao Tome And Principe Dobra (STN).
@@ -2381,10 +2401,7 @@ enum CurrencyCode {
   """
   Venezuelan Bolivares (VEF).
   """
-  VEF
-    @deprecated(
-      reason: "`VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead."
-    )
+  VEF @deprecated(reason: "`VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead.")
 
   """
   Venezuelan Bolivares (VES).
@@ -2462,6 +2479,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2501,6 +2523,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2578,7 +2610,7 @@ enum DeliveryMethod {
 }
 
 """
-A function error for a path.
+A Function error for a path.
 """
 input FunctionError {
   """
@@ -2603,61 +2635,6 @@ input FunctionResult {
 }
 
 """
-Represents a gate configuration.
-"""
-type GateConfiguration implements HasMetafields {
-  """
-  An optional string identifier.
-  """
-  appId: String
-
-  """
-  The ID of the gate configuration.
-  """
-  id: ID!
-
-  """
-  Returns a metafield by namespace and key that belongs to the resource.
-  """
-  metafield(
-    """
-    The key for the metafield.
-    """
-    key: String!
-
-    """
-    The namespace for the metafield.
-    """
-    namespace: String!
-  ): Metafield
-}
-
-"""
-Represents a connection from a subject to a gate configuration.
-"""
-type GateSubject {
-  """
-  The bound gate configuration.
-  """
-  configuration: GateConfiguration!
-
-  """
-  The ID of the gate subject.
-  """
-  id: ID!
-}
-
-"""
-Gate subjects associated to the specified resource.
-"""
-interface HasGates {
-  """
-  Returns active gate subjects bound to the resource.
-  """
-  gates: [GateSubject!]!
-}
-
-"""
 Represents information about the metafields associated to the specified resource.
 """
 interface HasMetafields {
@@ -2678,6 +2655,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2689,7 +2681,7 @@ type Input {
   """
   The buyer journey step.
   """
-  buyerJourney: BuyerJourney
+  buyerJourney: BuyerJourney!
 
   """
   The cart.
@@ -2697,7 +2689,7 @@ type Input {
   cart: Cart!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -2797,11 +2789,6 @@ enum LanguageCode {
   CE
 
   """
-  Central Kurdish.
-  """
-  CKB
-
-  """
   Czech.
   """
   CS
@@ -2880,11 +2867,6 @@ enum LanguageCode {
   Finnish.
   """
   FI
-
-  """
-  Filipino.
-  """
-  FIL
 
   """
   Faroese.
@@ -3237,16 +3219,6 @@ enum LanguageCode {
   RW
 
   """
-  Sanskrit.
-  """
-  SA
-
-  """
-  Sardinian.
-  """
-  SC
-
-  """
   Sindhi.
   """
   SD
@@ -3440,6 +3412,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3503,6 +3480,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3548,11 +3590,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3561,12 +3603,7 @@ type MutationRoot {
 """
 Represents a product.
 """
-type Product implements HasGates & HasMetafields {
-  """
-  Returns active gate subjects bound to the resource.
-  """
-  gates: [GateSubject!]!
-
+type Product implements HasMetafields {
   """
   A unique human-friendly string of the product's title.
   """
@@ -3577,10 +3614,20 @@ type Product implements HasGates & HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3588,14 +3635,24 @@ type Product implements HasGates & HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3621,6 +3678,11 @@ type Product implements HasGates & HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3668,6 +3730,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3696,6 +3763,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/checkout/wasm/cart-checkout-validation/default/shopify.extension.toml.liquid
+++ b/checkout/wasm/cart-checkout-validation/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "cart_checkout_validation"
-api_version = "unstable"
+api_version = "2023-07"
 
 [build]
 command = "echo 'build the wasm'"

--- a/checkout/wasm/cart-transform/default/schema.graphql
+++ b/checkout/wasm/cart-transform/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -68,109 +73,9 @@ type Cart {
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
-  """
-  cost: CartCost!
-
-  """
-  The delivery groups available for the cart based on the buyer's shipping address.
-  """
-  deliveryGroups: [CartDeliveryGroup!]!
-
-  """
   A list of lines containing information about the items the customer intends to purchase.
   """
   lines: [CartLine!]!
-}
-
-"""
-The cost that the buyer will pay at checkout.
-"""
-type CartCost {
-  """
-  The amount, before taxes and discounts, for the customer to pay.
-  """
-  subtotalAmount: MoneyV2!
-
-  """
-  The total amount for the customer to pay.
-  """
-  totalAmount: MoneyV2!
-
-  """
-  The duty amount for the customer to pay at checkout.
-  """
-  totalDutyAmount: MoneyV2
-
-  """
-  The tax amount for the customer to pay at checkout.
-  """
-  totalTaxAmount: MoneyV2
-}
-
-"""
-Information about the options available for one or more line items to be delivered to a specific address.
-"""
-type CartDeliveryGroup {
-  """
-  A list of cart lines for the delivery group.
-  """
-  cartLines: [CartLine!]!
-
-  """
-  The destination address for the delivery group.
-  """
-  deliveryAddress: MailingAddress
-
-  """
-  The delivery options available for the delivery group.
-  """
-  deliveryOptions: [CartDeliveryOption!]!
-
-  """
-  Unique identifier for the delivery group.
-  """
-  id: ID!
-
-  """
-  Information about the delivery option the buyer has selected.
-  """
-  selectedDeliveryOption: CartDeliveryOption
-}
-
-"""
-Information about a delivery option.
-"""
-type CartDeliveryOption {
-  """
-  The code of the delivery option.
-  """
-  code: String
-
-  """
-  The cost for the delivery option.
-  """
-  cost: MoneyV2!
-
-  """
-  The method for the delivery option.
-  """
-  deliveryMethodType: DeliveryMethod!
-
-  """
-  The description of the delivery option.
-  """
-  description: String
-
-  """
-  The unique identifier of the delivery option.
-  """
-  handle: String!
-
-  """
-  The title of the delivery option.
-  """
-  title: String
 }
 
 """
@@ -208,6 +113,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -242,7 +153,7 @@ input CartLineInput {
   cartLineId: ID!
 
   """
-  The quantity of the cart line.
+  The quantity of the cart line to be merged.The max quantity is 2000.
   """
   quantity: Int!
 }
@@ -256,6 +167,41 @@ input CartOperation @oneOf {
 }
 
 """
+A customization which applies cart transformations to the merchandise lines.
+"""
+type CartTransform implements HasMetafields {
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+}
+
+"""
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -265,7 +211,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -343,7 +289,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -382,1239 +328,6 @@ type CompanyLocation implements HasMetafields {
   at which the company location was last modified.
   """
   updatedAt: DateTime!
-}
-
-"""
-The code designating a country/region, which generally follows ISO 3166-1 alpha-2 guidelines.
-If a territory doesn't have a country code value in the `CountryCode` enum, then it might be considered a subdivision
-of another country. For example, the territories associated with Spain are represented by the country code `ES`,
-and the territories associated with the United States of America are represented by the country code `US`.
-"""
-enum CountryCode {
-  """
-  Ascension Island.
-  """
-  AC
-
-  """
-  Andorra.
-  """
-  AD
-
-  """
-  United Arab Emirates.
-  """
-  AE
-
-  """
-  Afghanistan.
-  """
-  AF
-
-  """
-  Antigua & Barbuda.
-  """
-  AG
-
-  """
-  Anguilla.
-  """
-  AI
-
-  """
-  Albania.
-  """
-  AL
-
-  """
-  Armenia.
-  """
-  AM
-
-  """
-  Netherlands Antilles.
-  """
-  AN
-
-  """
-  Angola.
-  """
-  AO
-
-  """
-  Argentina.
-  """
-  AR
-
-  """
-  Austria.
-  """
-  AT
-
-  """
-  Australia.
-  """
-  AU
-
-  """
-  Aruba.
-  """
-  AW
-
-  """
-  Åland Islands.
-  """
-  AX
-
-  """
-  Azerbaijan.
-  """
-  AZ
-
-  """
-  Bosnia & Herzegovina.
-  """
-  BA
-
-  """
-  Barbados.
-  """
-  BB
-
-  """
-  Bangladesh.
-  """
-  BD
-
-  """
-  Belgium.
-  """
-  BE
-
-  """
-  Burkina Faso.
-  """
-  BF
-
-  """
-  Bulgaria.
-  """
-  BG
-
-  """
-  Bahrain.
-  """
-  BH
-
-  """
-  Burundi.
-  """
-  BI
-
-  """
-  Benin.
-  """
-  BJ
-
-  """
-  St. Barthélemy.
-  """
-  BL
-
-  """
-  Bermuda.
-  """
-  BM
-
-  """
-  Brunei.
-  """
-  BN
-
-  """
-  Bolivia.
-  """
-  BO
-
-  """
-  Caribbean Netherlands.
-  """
-  BQ
-
-  """
-  Brazil.
-  """
-  BR
-
-  """
-  Bahamas.
-  """
-  BS
-
-  """
-  Bhutan.
-  """
-  BT
-
-  """
-  Bouvet Island.
-  """
-  BV
-
-  """
-  Botswana.
-  """
-  BW
-
-  """
-  Belarus.
-  """
-  BY
-
-  """
-  Belize.
-  """
-  BZ
-
-  """
-  Canada.
-  """
-  CA
-
-  """
-  Cocos (Keeling) Islands.
-  """
-  CC
-
-  """
-  Congo - Kinshasa.
-  """
-  CD
-
-  """
-  Central African Republic.
-  """
-  CF
-
-  """
-  Congo - Brazzaville.
-  """
-  CG
-
-  """
-  Switzerland.
-  """
-  CH
-
-  """
-  Côte d’Ivoire.
-  """
-  CI
-
-  """
-  Cook Islands.
-  """
-  CK
-
-  """
-  Chile.
-  """
-  CL
-
-  """
-  Cameroon.
-  """
-  CM
-
-  """
-  China.
-  """
-  CN
-
-  """
-  Colombia.
-  """
-  CO
-
-  """
-  Costa Rica.
-  """
-  CR
-
-  """
-  Cuba.
-  """
-  CU
-
-  """
-  Cape Verde.
-  """
-  CV
-
-  """
-  Curaçao.
-  """
-  CW
-
-  """
-  Christmas Island.
-  """
-  CX
-
-  """
-  Cyprus.
-  """
-  CY
-
-  """
-  Czechia.
-  """
-  CZ
-
-  """
-  Germany.
-  """
-  DE
-
-  """
-  Djibouti.
-  """
-  DJ
-
-  """
-  Denmark.
-  """
-  DK
-
-  """
-  Dominica.
-  """
-  DM
-
-  """
-  Dominican Republic.
-  """
-  DO
-
-  """
-  Algeria.
-  """
-  DZ
-
-  """
-  Ecuador.
-  """
-  EC
-
-  """
-  Estonia.
-  """
-  EE
-
-  """
-  Egypt.
-  """
-  EG
-
-  """
-  Western Sahara.
-  """
-  EH
-
-  """
-  Eritrea.
-  """
-  ER
-
-  """
-  Spain.
-  """
-  ES
-
-  """
-  Ethiopia.
-  """
-  ET
-
-  """
-  Finland.
-  """
-  FI
-
-  """
-  Fiji.
-  """
-  FJ
-
-  """
-  Falkland Islands.
-  """
-  FK
-
-  """
-  Faroe Islands.
-  """
-  FO
-
-  """
-  France.
-  """
-  FR
-
-  """
-  Gabon.
-  """
-  GA
-
-  """
-  United Kingdom.
-  """
-  GB
-
-  """
-  Grenada.
-  """
-  GD
-
-  """
-  Georgia.
-  """
-  GE
-
-  """
-  French Guiana.
-  """
-  GF
-
-  """
-  Guernsey.
-  """
-  GG
-
-  """
-  Ghana.
-  """
-  GH
-
-  """
-  Gibraltar.
-  """
-  GI
-
-  """
-  Greenland.
-  """
-  GL
-
-  """
-  Gambia.
-  """
-  GM
-
-  """
-  Guinea.
-  """
-  GN
-
-  """
-  Guadeloupe.
-  """
-  GP
-
-  """
-  Equatorial Guinea.
-  """
-  GQ
-
-  """
-  Greece.
-  """
-  GR
-
-  """
-  South Georgia & South Sandwich Islands.
-  """
-  GS
-
-  """
-  Guatemala.
-  """
-  GT
-
-  """
-  Guinea-Bissau.
-  """
-  GW
-
-  """
-  Guyana.
-  """
-  GY
-
-  """
-  Hong Kong SAR.
-  """
-  HK
-
-  """
-  Heard & McDonald Islands.
-  """
-  HM
-
-  """
-  Honduras.
-  """
-  HN
-
-  """
-  Croatia.
-  """
-  HR
-
-  """
-  Haiti.
-  """
-  HT
-
-  """
-  Hungary.
-  """
-  HU
-
-  """
-  Indonesia.
-  """
-  ID
-
-  """
-  Ireland.
-  """
-  IE
-
-  """
-  Israel.
-  """
-  IL
-
-  """
-  Isle of Man.
-  """
-  IM
-
-  """
-  India.
-  """
-  IN
-
-  """
-  British Indian Ocean Territory.
-  """
-  IO
-
-  """
-  Iraq.
-  """
-  IQ
-
-  """
-  Iran.
-  """
-  IR
-
-  """
-  Iceland.
-  """
-  IS
-
-  """
-  Italy.
-  """
-  IT
-
-  """
-  Jersey.
-  """
-  JE
-
-  """
-  Jamaica.
-  """
-  JM
-
-  """
-  Jordan.
-  """
-  JO
-
-  """
-  Japan.
-  """
-  JP
-
-  """
-  Kenya.
-  """
-  KE
-
-  """
-  Kyrgyzstan.
-  """
-  KG
-
-  """
-  Cambodia.
-  """
-  KH
-
-  """
-  Kiribati.
-  """
-  KI
-
-  """
-  Comoros.
-  """
-  KM
-
-  """
-  St. Kitts & Nevis.
-  """
-  KN
-
-  """
-  North Korea.
-  """
-  KP
-
-  """
-  South Korea.
-  """
-  KR
-
-  """
-  Kuwait.
-  """
-  KW
-
-  """
-  Cayman Islands.
-  """
-  KY
-
-  """
-  Kazakhstan.
-  """
-  KZ
-
-  """
-  Laos.
-  """
-  LA
-
-  """
-  Lebanon.
-  """
-  LB
-
-  """
-  St. Lucia.
-  """
-  LC
-
-  """
-  Liechtenstein.
-  """
-  LI
-
-  """
-  Sri Lanka.
-  """
-  LK
-
-  """
-  Liberia.
-  """
-  LR
-
-  """
-  Lesotho.
-  """
-  LS
-
-  """
-  Lithuania.
-  """
-  LT
-
-  """
-  Luxembourg.
-  """
-  LU
-
-  """
-  Latvia.
-  """
-  LV
-
-  """
-  Libya.
-  """
-  LY
-
-  """
-  Morocco.
-  """
-  MA
-
-  """
-  Monaco.
-  """
-  MC
-
-  """
-  Moldova.
-  """
-  MD
-
-  """
-  Montenegro.
-  """
-  ME
-
-  """
-  St. Martin.
-  """
-  MF
-
-  """
-  Madagascar.
-  """
-  MG
-
-  """
-  North Macedonia.
-  """
-  MK
-
-  """
-  Mali.
-  """
-  ML
-
-  """
-  Myanmar (Burma).
-  """
-  MM
-
-  """
-  Mongolia.
-  """
-  MN
-
-  """
-  Macao SAR.
-  """
-  MO
-
-  """
-  Martinique.
-  """
-  MQ
-
-  """
-  Mauritania.
-  """
-  MR
-
-  """
-  Montserrat.
-  """
-  MS
-
-  """
-  Malta.
-  """
-  MT
-
-  """
-  Mauritius.
-  """
-  MU
-
-  """
-  Maldives.
-  """
-  MV
-
-  """
-  Malawi.
-  """
-  MW
-
-  """
-  Mexico.
-  """
-  MX
-
-  """
-  Malaysia.
-  """
-  MY
-
-  """
-  Mozambique.
-  """
-  MZ
-
-  """
-  Namibia.
-  """
-  NA
-
-  """
-  New Caledonia.
-  """
-  NC
-
-  """
-  Niger.
-  """
-  NE
-
-  """
-  Norfolk Island.
-  """
-  NF
-
-  """
-  Nigeria.
-  """
-  NG
-
-  """
-  Nicaragua.
-  """
-  NI
-
-  """
-  Netherlands.
-  """
-  NL
-
-  """
-  Norway.
-  """
-  NO
-
-  """
-  Nepal.
-  """
-  NP
-
-  """
-  Nauru.
-  """
-  NR
-
-  """
-  Niue.
-  """
-  NU
-
-  """
-  New Zealand.
-  """
-  NZ
-
-  """
-  Oman.
-  """
-  OM
-
-  """
-  Panama.
-  """
-  PA
-
-  """
-  Peru.
-  """
-  PE
-
-  """
-  French Polynesia.
-  """
-  PF
-
-  """
-  Papua New Guinea.
-  """
-  PG
-
-  """
-  Philippines.
-  """
-  PH
-
-  """
-  Pakistan.
-  """
-  PK
-
-  """
-  Poland.
-  """
-  PL
-
-  """
-  St. Pierre & Miquelon.
-  """
-  PM
-
-  """
-  Pitcairn Islands.
-  """
-  PN
-
-  """
-  Palestinian Territories.
-  """
-  PS
-
-  """
-  Portugal.
-  """
-  PT
-
-  """
-  Paraguay.
-  """
-  PY
-
-  """
-  Qatar.
-  """
-  QA
-
-  """
-  Réunion.
-  """
-  RE
-
-  """
-  Romania.
-  """
-  RO
-
-  """
-  Serbia.
-  """
-  RS
-
-  """
-  Russia.
-  """
-  RU
-
-  """
-  Rwanda.
-  """
-  RW
-
-  """
-  Saudi Arabia.
-  """
-  SA
-
-  """
-  Solomon Islands.
-  """
-  SB
-
-  """
-  Seychelles.
-  """
-  SC
-
-  """
-  Sudan.
-  """
-  SD
-
-  """
-  Sweden.
-  """
-  SE
-
-  """
-  Singapore.
-  """
-  SG
-
-  """
-  St. Helena.
-  """
-  SH
-
-  """
-  Slovenia.
-  """
-  SI
-
-  """
-  Svalbard & Jan Mayen.
-  """
-  SJ
-
-  """
-  Slovakia.
-  """
-  SK
-
-  """
-  Sierra Leone.
-  """
-  SL
-
-  """
-  San Marino.
-  """
-  SM
-
-  """
-  Senegal.
-  """
-  SN
-
-  """
-  Somalia.
-  """
-  SO
-
-  """
-  Suriname.
-  """
-  SR
-
-  """
-  South Sudan.
-  """
-  SS
-
-  """
-  São Tomé & Príncipe.
-  """
-  ST
-
-  """
-  El Salvador.
-  """
-  SV
-
-  """
-  Sint Maarten.
-  """
-  SX
-
-  """
-  Syria.
-  """
-  SY
-
-  """
-  Eswatini.
-  """
-  SZ
-
-  """
-  Tristan da Cunha.
-  """
-  TA
-
-  """
-  Turks & Caicos Islands.
-  """
-  TC
-
-  """
-  Chad.
-  """
-  TD
-
-  """
-  French Southern Territories.
-  """
-  TF
-
-  """
-  Togo.
-  """
-  TG
-
-  """
-  Thailand.
-  """
-  TH
-
-  """
-  Tajikistan.
-  """
-  TJ
-
-  """
-  Tokelau.
-  """
-  TK
-
-  """
-  Timor-Leste.
-  """
-  TL
-
-  """
-  Turkmenistan.
-  """
-  TM
-
-  """
-  Tunisia.
-  """
-  TN
-
-  """
-  Tonga.
-  """
-  TO
-
-  """
-  Turkey.
-  """
-  TR
-
-  """
-  Trinidad & Tobago.
-  """
-  TT
-
-  """
-  Tuvalu.
-  """
-  TV
-
-  """
-  Taiwan.
-  """
-  TW
-
-  """
-  Tanzania.
-  """
-  TZ
-
-  """
-  Ukraine.
-  """
-  UA
-
-  """
-  Uganda.
-  """
-  UG
-
-  """
-  U.S. Outlying Islands.
-  """
-  UM
-
-  """
-  United States.
-  """
-  US
-
-  """
-  Uruguay.
-  """
-  UY
-
-  """
-  Uzbekistan.
-  """
-  UZ
-
-  """
-  Vatican City.
-  """
-  VA
-
-  """
-  St. Vincent & Grenadines.
-  """
-  VC
-
-  """
-  Venezuela.
-  """
-  VE
-
-  """
-  British Virgin Islands.
-  """
-  VG
-
-  """
-  Vietnam.
-  """
-  VN
-
-  """
-  Vanuatu.
-  """
-  VU
-
-  """
-  Wallis & Futuna.
-  """
-  WF
-
-  """
-  Samoa.
-  """
-  WS
-
-  """
-  Kosovo.
-  """
-  XK
-
-  """
-  Yemen.
-  """
-  YE
-
-  """
-  Mayotte.
-  """
-  YT
-
-  """
-  South Africa.
-  """
-  ZA
-
-  """
-  Zambia.
-  """
-  ZM
-
-  """
-  Zimbabwe.
-  """
-  ZW
-
-  """
-  Unknown Region.
-  """
-  ZZ
 }
 
 """
@@ -1746,10 +459,7 @@ enum CurrencyCode {
   """
   Belarusian Ruble (BYR).
   """
-  BYR
-    @deprecated(
-      reason: "`BYR` is deprecated. Use `BYN` available from version `2021-01` onwards instead."
-    )
+  BYR @deprecated(reason: "`BYR` is deprecated. Use `BYN` available from version `2021-01` onwards instead.")
 
   """
   Belize Dollar (BZD).
@@ -2274,10 +984,7 @@ enum CurrencyCode {
   """
   Sao Tome And Principe Dobra (STD).
   """
-  STD
-    @deprecated(
-      reason: "`STD` is deprecated. Use `STN` available from version `2022-07` onwards instead."
-    )
+  STD @deprecated(reason: "`STD` is deprecated. Use `STN` available from version `2022-07` onwards instead.")
 
   """
   Sao Tome And Principe Dobra (STN).
@@ -2372,10 +1079,7 @@ enum CurrencyCode {
   """
   Venezuelan Bolivares (VEF).
   """
-  VEF
-    @deprecated(
-      reason: "`VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead."
-    )
+  VEF @deprecated(reason: "`VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead.")
 
   """
   Venezuelan Bolivares (VES).
@@ -2453,6 +1157,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2494,6 +1203,16 @@ type Customer implements HasMetafields {
   ): Boolean!
 
   """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
+
+  """
   A unique identifier for the customer.
   """
   id: ID!
@@ -2533,41 +1252,6 @@ Example values: `"29.99"`, `"29.999"`.
 """
 scalar Decimal
 
-"""
-List of different delivery method types.
-"""
-enum DeliveryMethod {
-  """
-  Local Delivery.
-  """
-  LOCAL
-
-  """
-  None.
-  """
-  NONE
-
-  """
-  Shipping to a Pickup Point.
-  """
-  PICKUP_POINT
-
-  """
-  Local Pickup.
-  """
-  PICK_UP
-
-  """
-  Retail.
-  """
-  RETAIL
-
-  """
-  Shipping.
-  """
-  SHIPPING
-}
-
 input ExpandOperation {
   """
   The cart line id to expand.
@@ -2592,7 +1276,7 @@ input ExpandedItem {
   merchandiseId: ID!
 
   """
-  The quantity of the expanded item.
+  The quantity of the expanded item.The max quantity is 2000.
   """
   quantity: Int!
 }
@@ -2604,67 +1288,7 @@ input FunctionResult {
   """
   Cart operations to run on Cart.
   """
-  operations: [CartOperation!]
-}
-
-"""
-Represents a gate configuration.
-"""
-type GateConfiguration implements HasMetafields {
-  """
-  An optional string identifier.
-  """
-  appId: String
-
-  """
-  The ID of the gate configuration.
-  """
-  id: ID!
-
-  """
-  Returns a metafield by namespace and key that belongs to the resource.
-  """
-  metafield(
-    """
-    The key for the metafield.
-    """
-    key: String!
-
-    """
-    The namespace for the metafield.
-    """
-    namespace: String!
-  ): Metafield
-}
-
-"""
-Represents a connection from a subject to a gate configuration.
-"""
-type GateSubject {
-  """
-  The bound gate configuration.
-  """
-  configuration(
-    """
-    The appId of the gate configurations to search for.
-    """
-    appId: String
-  ): GateConfiguration!
-
-  """
-  The ID of the gate subject.
-  """
-  id: ID!
-}
-
-"""
-Gate subjects associated to the specified resource.
-"""
-interface HasGates {
-  """
-  Returns active gate subjects bound to the resource.
-  """
-  gates: [GateSubject!]!
+  operations: [CartOperation!]!
 }
 
 """
@@ -2685,6 +1309,21 @@ interface HasMetafields {
     """
     namespace: String!
   ): Metafield
+}
+
+"""
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
 }
 
 """
@@ -2710,66 +1349,11 @@ type Input {
   The cart.
   """
   cart: Cart!
-}
-
-"""
-Represents a mailing address.
-"""
-type MailingAddress {
-  """
-  The first line of the address. Typically the street address or PO Box number.
-  """
-  address1: String
 
   """
-  The second line of the address. Typically the number of the apartment, suite, or unit.
+  The CartTransform containing the function.
   """
-  address2: String
-
-  """
-  The name of the city, district, village, or town.
-  """
-  city: String
-
-  """
-  The name of the customer's company or organization.
-  """
-  company: String
-
-  """
-  The two-letter code for the country of the address. For example, US.
-  """
-  countryCode: CountryCode
-
-  """
-  The first name of the customer.
-  """
-  firstName: String
-
-  """
-  The last name of the customer.
-  """
-  lastName: String
-
-  """
-  The full name of the customer, based on firstName and lastName.
-  """
-  name: String
-
-  """
-  A unique phone number for the customer. Formatted using E.164 standard. For example, +16135551111.
-  """
-  phone: String
-
-  """
-  The two-letter code for the region. For example, ON.
-  """
-  provinceCode: String
-
-  """
-  The zip or postal code of the address.
-  """
-  zip: String
+  cartTransform: CartTransform!
 }
 
 """
@@ -2845,11 +1429,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -2872,12 +1456,7 @@ input PriceAdjustmentValue {
 """
 Represents a product.
 """
-type Product implements HasGates & HasMetafields {
-  """
-  Returns active gate subjects bound to the resource.
-  """
-  gates: [GateSubject!]!
-
+type Product implements HasMetafields {
   """
   A unique human-friendly string of the product's title.
   """
@@ -2888,10 +1467,20 @@ type Product implements HasGates & HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -2899,14 +1488,24 @@ type Product implements HasGates & HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -2932,6 +1531,11 @@ type Product implements HasGates & HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -2979,6 +1583,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3007,6 +1616,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/checkout/wasm/cart-transform/default/shopify.extension.toml.liquid
+++ b/checkout/wasm/cart-transform/default/shopify.extension.toml.liquid
@@ -1,9 +1,7 @@
 name = "cart transform"
 type = "cart_transform"
 title = "cart transform"
-api_version = "unstable"
+api_version = "2023-07"
 
 [build]
-command = "cargo wasi build --release"
-path = "target/wasm32-wasi/release/cart_transform.wasm"
-watch = [ "src/**/*.rs" ]
+command = "echo 'build the wasm'"

--- a/checkout/wasm/delivery-customization/default/schema.graphql
+++ b/checkout/wasm/delivery-customization/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -208,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -236,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -245,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -323,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2434,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2473,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2600,6 +2641,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Request to hide a delivery option.
 """
 input HideOperation {
@@ -2629,7 +2685,7 @@ type Input {
   deliveryCustomization: DeliveryCustomization!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3352,6 +3408,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3415,6 +3476,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3475,11 +3601,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3519,10 +3645,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3530,14 +3666,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3563,6 +3709,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3610,6 +3761,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3653,6 +3809,74 @@ input RenameOperation {
   The new name for the delivery option.
   """
   title: String!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/checkout/wasm/delivery-customization/default/shopify.extension.toml.liquid
+++ b/checkout/wasm/delivery-customization/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "delivery_customization"
-api_version = "2023-04"
+api_version = "2023-07"
 
 [build]
 command = "echo 'build the wasm'"

--- a/checkout/wasm/payment-customization/default/schema.graphql
+++ b/checkout/wasm/payment-customization/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -208,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -236,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -245,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -323,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2434,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2473,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2580,6 +2621,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Request to hide a payment method.
 """
 input HideOperation {
@@ -2604,7 +2660,7 @@ type Input {
   cart: Cart!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3337,6 +3393,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3400,6 +3461,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3460,11 +3586,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3532,10 +3658,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3543,14 +3679,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3576,6 +3722,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3623,6 +3774,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3666,6 +3822,74 @@ input RenameOperation {
   The identifier of the payment method to rename.
   """
   paymentMethodId: ID!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/checkout/wasm/payment-customization/default/shopify.extension.toml.liquid
+++ b/checkout/wasm/payment-customization/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "payment_customization"
-api_version = "2023-04"
+api_version = "2023-07"
 
 [build]
 command = "echo 'build the wasm'"

--- a/discounts/javascript/order-discounts/default/schema.graphql
+++ b/discounts/javascript/order-discounts/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2449,6 +2480,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2488,6 +2524,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2675,6 +2721,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2687,7 +2748,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2697,7 +2758,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3420,6 +3481,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3483,6 +3549,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3528,11 +3659,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3596,10 +3727,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3607,14 +3748,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3640,6 +3791,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3731,6 +3887,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3777,6 +3938,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/discounts/javascript/order-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/javascript/order-discounts/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "order_discounts"
-api_version = "2023-01"
+api_version = "2023-07"
 
 [build]
 command = ""

--- a/discounts/javascript/product-discounts/default/schema.graphql
+++ b/discounts/javascript/product-discounts/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2429,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2468,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2655,6 +2701,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2667,7 +2728,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2677,7 +2738,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3400,6 +3461,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3463,6 +3529,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3508,11 +3639,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3544,10 +3675,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3555,14 +3696,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3588,6 +3739,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3633,6 +3789,11 @@ type ProductVariant implements HasMetafields {
   An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
   """
   sku: String
+
+  """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
 
   """
   The weight of the product variant in the unit system specified with `weight_unit`.
@@ -3681,6 +3842,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/discounts/javascript/shipping-discounts/default/schema.graphql
+++ b/discounts/javascript/shipping-discounts/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2429,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2468,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2657,6 +2703,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2669,7 +2730,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2679,7 +2740,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3402,6 +3463,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3465,6 +3531,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3510,11 +3641,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3546,10 +3677,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3557,14 +3698,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3590,6 +3741,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3637,6 +3793,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3665,6 +3826,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/discounts/javascript/shipping-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/javascript/shipping-discounts/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "shipping_discounts"
-api_version = "2023-01"
+api_version = "2023-07"
 
 [build]
 command = ""

--- a/discounts/rust/order-discounts/default/schema.graphql
+++ b/discounts/rust/order-discounts/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2449,6 +2480,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2488,6 +2524,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2675,6 +2721,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2687,7 +2748,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2697,7 +2758,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3420,6 +3481,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3483,6 +3549,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3528,11 +3659,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3596,10 +3727,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3607,14 +3748,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3640,6 +3791,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3731,6 +3887,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3777,6 +3938,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/discounts/rust/order-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/order-discounts/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "order_discounts"
-api_version = "2023-01"
+api_version = "2023-07"
 
 [build]
 command = "cargo wasi build --release"

--- a/discounts/rust/order-discounts/fixed-amount/schema.graphql
+++ b/discounts/rust/order-discounts/fixed-amount/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2449,6 +2480,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2488,6 +2524,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2675,6 +2721,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2687,7 +2748,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2697,7 +2758,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3420,6 +3481,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3483,6 +3549,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3528,11 +3659,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3596,10 +3727,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3607,14 +3748,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3640,6 +3791,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3731,6 +3887,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3777,6 +3938,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/discounts/rust/order-discounts/fixed-amount/shopify.extension.toml.liquid
+++ b/discounts/rust/order-discounts/fixed-amount/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "Fixed Amount Off Order"
 type = "order_discounts"
-api_version = "2023-01"
+api_version = "2023-07"
 
 [build]
 command = "cargo wasi build --release"

--- a/discounts/rust/product-discounts/default/schema.graphql
+++ b/discounts/rust/product-discounts/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2429,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2468,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2655,6 +2701,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2667,7 +2728,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2677,7 +2738,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3400,6 +3461,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3463,6 +3529,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3508,11 +3639,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3544,10 +3675,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3555,14 +3696,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3588,6 +3739,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3633,6 +3789,11 @@ type ProductVariant implements HasMetafields {
   An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
   """
   sku: String
+
+  """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
 
   """
   The weight of the product variant in the unit system specified with `weight_unit`.
@@ -3681,6 +3842,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/discounts/rust/product-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/product-discounts/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "product_discounts"
-api_version = "2023-01"
+api_version = "2023-07"
 
 [build]
 command = "cargo wasi build --release"

--- a/discounts/rust/product-discounts/fixed-amount/schema.graphql
+++ b/discounts/rust/product-discounts/fixed-amount/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2429,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2468,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2655,6 +2701,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2667,7 +2728,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2677,7 +2738,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3400,6 +3461,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3463,6 +3529,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3508,11 +3639,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3544,10 +3675,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3555,14 +3696,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3588,6 +3739,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3633,6 +3789,11 @@ type ProductVariant implements HasMetafields {
   An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
   """
   sku: String
+
+  """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
 
   """
   The weight of the product variant in the unit system specified with `weight_unit`.
@@ -3681,6 +3842,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/discounts/rust/product-discounts/fixed-amount/shopify.extension.toml.liquid
+++ b/discounts/rust/product-discounts/fixed-amount/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "Fixed Amount"
 type = "product_discounts"
-api_version = "2023-01"
+api_version = "2023-07"
 
 [build]
 command = "cargo wasi build --release"

--- a/discounts/rust/shipping-discounts/default/schema.graphql
+++ b/discounts/rust/shipping-discounts/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2429,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2468,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2657,6 +2703,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2669,7 +2730,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2679,7 +2740,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3402,6 +3463,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3465,6 +3531,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3510,11 +3641,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3546,10 +3677,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3557,14 +3698,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3590,6 +3741,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3637,6 +3793,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3665,6 +3826,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/discounts/rust/shipping-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/shipping-discounts/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "shipping_discounts"
-api_version = "2023-01"
+api_version = "2023-07"
 
 [build]
 command = "cargo wasi build --release"

--- a/discounts/rust/shipping-discounts/fixed-amount/schema.graphql
+++ b/discounts/rust/shipping-discounts/fixed-amount/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2429,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2468,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2657,6 +2703,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2669,7 +2730,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2679,7 +2740,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3402,6 +3463,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3465,6 +3531,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3510,11 +3641,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3546,10 +3677,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3557,14 +3698,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3590,6 +3741,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3637,6 +3793,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3665,6 +3826,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/discounts/wasm/order-discounts/default/schema.graphql
+++ b/discounts/wasm/order-discounts/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2449,6 +2480,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2488,6 +2524,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2675,6 +2721,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2687,7 +2748,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2697,7 +2758,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3420,6 +3481,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3483,6 +3549,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3528,11 +3659,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3596,10 +3727,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3607,14 +3748,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3640,6 +3791,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3731,6 +3887,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3777,6 +3938,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/discounts/wasm/order-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/wasm/order-discounts/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "order_discounts"
-api_version = "2023-01"
+api_version = "2023-07"
 
 [build]
 command = "echo 'build the wasm'"

--- a/discounts/wasm/product-discounts/default/schema.graphql
+++ b/discounts/wasm/product-discounts/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2429,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2468,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2655,6 +2701,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2667,7 +2728,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2677,7 +2738,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3400,6 +3461,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3463,6 +3529,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3508,11 +3639,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3544,10 +3675,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3555,14 +3696,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3588,6 +3739,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3633,6 +3789,11 @@ type ProductVariant implements HasMetafields {
   An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
   """
   sku: String
+
+  """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
 
   """
   The weight of the product variant in the unit system specified with `weight_unit`.
@@ -3681,6 +3842,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/discounts/wasm/product-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/wasm/product-discounts/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "product_discounts"
-api_version = "2023-01"
+api_version = "2023-07"
 
 [build]
 command = "echo 'build the wasm'"

--- a/discounts/wasm/shipping-discounts/default/schema.graphql
+++ b/discounts/wasm/shipping-discounts/default/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2429,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2468,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2657,6 +2703,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2669,7 +2730,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2679,7 +2740,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3402,6 +3463,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3465,6 +3531,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3510,11 +3641,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3546,10 +3677,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3557,14 +3698,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3590,6 +3741,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3637,6 +3793,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3665,6 +3826,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/discounts/wasm/shipping-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/wasm/shipping-discounts/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "shipping_discounts"
-api_version = "2023-01"
+api_version = "2023-07"
 
 [build]
 command = "echo 'build the wasm'"

--- a/order-routing/javascript/fulfillment-constraints/default/schema.graphql
+++ b/order-routing/javascript/fulfillment-constraints/default/schema.graphql
@@ -1,10 +1,3 @@
-# This file is auto-generated from the current state of the GraphQL API. Instead of editing this file,
-# please edit the ruby definition files and run `bin/rails graphql:schema:dump` to regenerate the schema.
-#
-# If you're just looking to browse, you may find it friendlier to use the graphiql browser which is
-# available in services-internal at https://app.shopify.com/services/internal/shops/14168/graphql.
-# Check out the "Docs" tab in the top right.
-
 schema {
   query: Input
   mutation: MutationRoot
@@ -40,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -220,6 +218,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -291,9 +295,9 @@ type Company implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 
   """
@@ -374,9 +378,9 @@ type CompanyLocation implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 
   """
@@ -389,6 +393,16 @@ type CompanyLocation implements HasMetafields {
   at which the company location was last modified.
   """
   updatedAt: DateTime!
+}
+
+"""
+A country.
+"""
+type Country {
+  """
+  The ISO code of the country.
+  """
+  isoCode: CountryCode!
 }
 
 """
@@ -2451,6 +2465,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2492,6 +2511,16 @@ type Customer implements HasMetafields {
   ): Boolean!
 
   """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
+
+  """
   A unique identifier for the customer.
   """
   id: ID!
@@ -2506,9 +2535,9 @@ type Customer implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 
   """
@@ -2612,9 +2641,9 @@ type FulfillmentConstraintRule implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 }
 
@@ -2657,9 +2686,9 @@ type GateConfiguration implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 }
 
@@ -2712,9 +2741,9 @@ interface HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 }
 
@@ -2756,6 +2785,11 @@ type Input {
   fulfillmentConstraintRule: FulfillmentConstraintRule!
 
   """
+  The localization of the Function execution context.
+  """
+  localization: Localization!
+
+  """
   The locations where the inventory items on this cart are stocked.
   """
   locations(
@@ -2769,6 +2803,746 @@ type Input {
     """
     names: [String!]
   ): [Location!]!
+}
+
+"""
+A language.
+"""
+type Language {
+  """
+  The ISO code.
+  """
+  isoCode: LanguageCode!
+}
+
+"""
+ISO 639-1 language codes supported by Shopify.
+"""
+enum LanguageCode {
+  """
+  Afrikaans.
+  """
+  AF
+
+  """
+  Akan.
+  """
+  AK
+
+  """
+  Amharic.
+  """
+  AM
+
+  """
+  Arabic.
+  """
+  AR
+
+  """
+  Assamese.
+  """
+  AS
+
+  """
+  Azerbaijani.
+  """
+  AZ
+
+  """
+  Belarusian.
+  """
+  BE
+
+  """
+  Bulgarian.
+  """
+  BG
+
+  """
+  Bambara.
+  """
+  BM
+
+  """
+  Bangla.
+  """
+  BN
+
+  """
+  Tibetan.
+  """
+  BO
+
+  """
+  Breton.
+  """
+  BR
+
+  """
+  Bosnian.
+  """
+  BS
+
+  """
+  Catalan.
+  """
+  CA
+
+  """
+  Chechen.
+  """
+  CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
+
+  """
+  Czech.
+  """
+  CS
+
+  """
+  Church Slavic.
+  """
+  CU
+
+  """
+  Welsh.
+  """
+  CY
+
+  """
+  Danish.
+  """
+  DA
+
+  """
+  German.
+  """
+  DE
+
+  """
+  Dzongkha.
+  """
+  DZ
+
+  """
+  Ewe.
+  """
+  EE
+
+  """
+  Greek.
+  """
+  EL
+
+  """
+  English.
+  """
+  EN
+
+  """
+  Esperanto.
+  """
+  EO
+
+  """
+  Spanish.
+  """
+  ES
+
+  """
+  Estonian.
+  """
+  ET
+
+  """
+  Basque.
+  """
+  EU
+
+  """
+  Persian.
+  """
+  FA
+
+  """
+  Fulah.
+  """
+  FF
+
+  """
+  Finnish.
+  """
+  FI
+
+  """
+  Filipino.
+  """
+  FIL
+
+  """
+  Faroese.
+  """
+  FO
+
+  """
+  French.
+  """
+  FR
+
+  """
+  Western Frisian.
+  """
+  FY
+
+  """
+  Irish.
+  """
+  GA
+
+  """
+  Scottish Gaelic.
+  """
+  GD
+
+  """
+  Galician.
+  """
+  GL
+
+  """
+  Gujarati.
+  """
+  GU
+
+  """
+  Manx.
+  """
+  GV
+
+  """
+  Hausa.
+  """
+  HA
+
+  """
+  Hebrew.
+  """
+  HE
+
+  """
+  Hindi.
+  """
+  HI
+
+  """
+  Croatian.
+  """
+  HR
+
+  """
+  Hungarian.
+  """
+  HU
+
+  """
+  Armenian.
+  """
+  HY
+
+  """
+  Interlingua.
+  """
+  IA
+
+  """
+  Indonesian.
+  """
+  ID
+
+  """
+  Igbo.
+  """
+  IG
+
+  """
+  Sichuan Yi.
+  """
+  II
+
+  """
+  Icelandic.
+  """
+  IS
+
+  """
+  Italian.
+  """
+  IT
+
+  """
+  Japanese.
+  """
+  JA
+
+  """
+  Javanese.
+  """
+  JV
+
+  """
+  Georgian.
+  """
+  KA
+
+  """
+  Kikuyu.
+  """
+  KI
+
+  """
+  Kazakh.
+  """
+  KK
+
+  """
+  Kalaallisut.
+  """
+  KL
+
+  """
+  Khmer.
+  """
+  KM
+
+  """
+  Kannada.
+  """
+  KN
+
+  """
+  Korean.
+  """
+  KO
+
+  """
+  Kashmiri.
+  """
+  KS
+
+  """
+  Kurdish.
+  """
+  KU
+
+  """
+  Cornish.
+  """
+  KW
+
+  """
+  Kyrgyz.
+  """
+  KY
+
+  """
+  Luxembourgish.
+  """
+  LB
+
+  """
+  Ganda.
+  """
+  LG
+
+  """
+  Lingala.
+  """
+  LN
+
+  """
+  Lao.
+  """
+  LO
+
+  """
+  Lithuanian.
+  """
+  LT
+
+  """
+  Luba-Katanga.
+  """
+  LU
+
+  """
+  Latvian.
+  """
+  LV
+
+  """
+  Malagasy.
+  """
+  MG
+
+  """
+  Māori.
+  """
+  MI
+
+  """
+  Macedonian.
+  """
+  MK
+
+  """
+  Malayalam.
+  """
+  ML
+
+  """
+  Mongolian.
+  """
+  MN
+
+  """
+  Marathi.
+  """
+  MR
+
+  """
+  Malay.
+  """
+  MS
+
+  """
+  Maltese.
+  """
+  MT
+
+  """
+  Burmese.
+  """
+  MY
+
+  """
+  Norwegian (Bokmål).
+  """
+  NB
+
+  """
+  North Ndebele.
+  """
+  ND
+
+  """
+  Nepali.
+  """
+  NE
+
+  """
+  Dutch.
+  """
+  NL
+
+  """
+  Norwegian Nynorsk.
+  """
+  NN
+
+  """
+  Norwegian.
+  """
+  NO
+
+  """
+  Oromo.
+  """
+  OM
+
+  """
+  Odia.
+  """
+  OR
+
+  """
+  Ossetic.
+  """
+  OS
+
+  """
+  Punjabi.
+  """
+  PA
+
+  """
+  Polish.
+  """
+  PL
+
+  """
+  Pashto.
+  """
+  PS
+
+  """
+  Portuguese.
+  """
+  PT
+
+  """
+  Portuguese (Brazil).
+  """
+  PT_BR
+
+  """
+  Portuguese (Portugal).
+  """
+  PT_PT
+
+  """
+  Quechua.
+  """
+  QU
+
+  """
+  Romansh.
+  """
+  RM
+
+  """
+  Rundi.
+  """
+  RN
+
+  """
+  Romanian.
+  """
+  RO
+
+  """
+  Russian.
+  """
+  RU
+
+  """
+  Kinyarwanda.
+  """
+  RW
+
+  """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
+  Sindhi.
+  """
+  SD
+
+  """
+  Northern Sami.
+  """
+  SE
+
+  """
+  Sango.
+  """
+  SG
+
+  """
+  Sinhala.
+  """
+  SI
+
+  """
+  Slovak.
+  """
+  SK
+
+  """
+  Slovenian.
+  """
+  SL
+
+  """
+  Shona.
+  """
+  SN
+
+  """
+  Somali.
+  """
+  SO
+
+  """
+  Albanian.
+  """
+  SQ
+
+  """
+  Serbian.
+  """
+  SR
+
+  """
+  Sundanese.
+  """
+  SU
+
+  """
+  Swedish.
+  """
+  SV
+
+  """
+  Swahili.
+  """
+  SW
+
+  """
+  Tamil.
+  """
+  TA
+
+  """
+  Telugu.
+  """
+  TE
+
+  """
+  Tajik.
+  """
+  TG
+
+  """
+  Thai.
+  """
+  TH
+
+  """
+  Tigrinya.
+  """
+  TI
+
+  """
+  Turkmen.
+  """
+  TK
+
+  """
+  Tongan.
+  """
+  TO
+
+  """
+  Turkish.
+  """
+  TR
+
+  """
+  Tatar.
+  """
+  TT
+
+  """
+  Uyghur.
+  """
+  UG
+
+  """
+  Ukrainian.
+  """
+  UK
+
+  """
+  Urdu.
+  """
+  UR
+
+  """
+  Uzbek.
+  """
+  UZ
+
+  """
+  Vietnamese.
+  """
+  VI
+
+  """
+  Volapük.
+  """
+  VO
+
+  """
+  Wolof.
+  """
+  WO
+
+  """
+  Xhosa.
+  """
+  XH
+
+  """
+  Yiddish.
+  """
+  YI
+
+  """
+  Yoruba.
+  """
+  YO
+
+  """
+  Chinese.
+  """
+  ZH
+
+  """
+  Chinese (Simplified).
+  """
+  ZH_CN
+
+  """
+  Chinese (Traditional).
+  """
+  ZH_TW
+
+  """
+  Zulu.
+  """
+  ZU
+}
+
+"""
+Information about the localized experiences configured for the shop.
+"""
+type Localization {
+  """
+  The country of the active localized experience.
+  """
+  country: Country!
+
+  """
+  The language of the active localized experience.
+  """
+  language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -2795,9 +3569,9 @@ type Location implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 
   """
@@ -2921,6 +3695,11 @@ type MailingAddress {
   longitude: Float
 
   """
+  The market of the address.
+  """
+  market: Market
+
+  """
   The full name of the customer, based on firstName and lastName.
   """
   name: String
@@ -2939,6 +3718,71 @@ type MailingAddress {
   The zip or postal code of the address.
   """
   zip: String
+}
+
+"""
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
 }
 
 """
@@ -2989,12 +3833,12 @@ completing checkout will be blocked.
 """
 input MustFulfillFrom {
   """
-  Ids of the deliverable lines for which the constraint is applied.
+  The IDs of the deliverable lines for which the constraint is applied.
   """
   deliverableLineIds: [ID!]!
 
   """
-  Ids of the locations for which the cart lines must fulfill from.
+  The IDs of the locations for which the cart lines must fulfill from.
   """
   locationIds: [ID!]!
 }
@@ -3006,7 +3850,7 @@ then checkout won't return any shipping rates and completing checkout will be bl
 """
 input MustFulfillFromSameLocation {
   """
-  Ids of the deliverable lines for which the constraint is applied.
+  The IDs of the deliverable lines for which the constraint is applied.
   """
   deliverableLineIds: [ID!]!
 }
@@ -3016,11 +3860,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3124,15 +3968,20 @@ type Product implements HasGates & HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 
   """
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3159,9 +4008,9 @@ type ProductVariant implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 
   """
@@ -3178,6 +4027,11 @@ type ProductVariant implements HasMetafields {
   An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
   """
   sku: String
+
+  """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
 
   """
   The weight of the product variant in the unit system specified with `weight_unit`.
@@ -3208,6 +4062,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/order-routing/javascript/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/javascript/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "fulfillment_constraints"
-api_version = "unstable"
+api_version = "2023-07"
 
 [build]
 command = ""

--- a/order-routing/javascript/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/javascript/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "fulfillment_constraints"
-api_version = "2023-07"
+api_version = "unstable"
 
 [build]
 command = ""

--- a/order-routing/javascript/location-rules/default/schema.graphql
+++ b/order-routing/javascript/location-rules/default/schema.graphql
@@ -1,10 +1,3 @@
-# This file is auto-generated from the current state of the GraphQL API. Instead of editing this file,
-# please edit the ruby definition files and run `bin/rails graphql:schema:dump` to regenerate the schema.
-#
-# If you're just looking to browse, you may find it friendlier to use the graphiql browser which is
-# available in services-internal at https://app.shopify.com/services/internal/shops/14168/graphql.
-# Check out the "Docs" tab in the top right.
-
 schema {
   query: Input
   mutation: MutationRoot
@@ -35,7 +28,7 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
@@ -45,7 +38,7 @@ type BuyerIdentity {
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -3098,11 +3091,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!

--- a/order-routing/rust/fulfillment-constraints/default/schema.graphql
+++ b/order-routing/rust/fulfillment-constraints/default/schema.graphql
@@ -1,10 +1,3 @@
-# This file is auto-generated from the current state of the GraphQL API. Instead of editing this file,
-# please edit the ruby definition files and run `bin/rails graphql:schema:dump` to regenerate the schema.
-#
-# If you're just looking to browse, you may find it friendlier to use the graphiql browser which is
-# available in services-internal at https://app.shopify.com/services/internal/shops/14168/graphql.
-# Check out the "Docs" tab in the top right.
-
 schema {
   query: Input
   mutation: MutationRoot
@@ -40,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -220,6 +218,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -291,9 +295,9 @@ type Company implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 
   """
@@ -374,9 +378,9 @@ type CompanyLocation implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 
   """
@@ -389,6 +393,16 @@ type CompanyLocation implements HasMetafields {
   at which the company location was last modified.
   """
   updatedAt: DateTime!
+}
+
+"""
+A country.
+"""
+type Country {
+  """
+  The ISO code of the country.
+  """
+  isoCode: CountryCode!
 }
 
 """
@@ -2451,6 +2465,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2492,6 +2511,16 @@ type Customer implements HasMetafields {
   ): Boolean!
 
   """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
+
+  """
   A unique identifier for the customer.
   """
   id: ID!
@@ -2506,9 +2535,9 @@ type Customer implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 
   """
@@ -2612,9 +2641,9 @@ type FulfillmentConstraintRule implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 }
 
@@ -2657,9 +2686,9 @@ type GateConfiguration implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 }
 
@@ -2712,9 +2741,9 @@ interface HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 }
 
@@ -2756,6 +2785,11 @@ type Input {
   fulfillmentConstraintRule: FulfillmentConstraintRule!
 
   """
+  The localization of the Function execution context.
+  """
+  localization: Localization!
+
+  """
   The locations where the inventory items on this cart are stocked.
   """
   locations(
@@ -2769,6 +2803,746 @@ type Input {
     """
     names: [String!]
   ): [Location!]!
+}
+
+"""
+A language.
+"""
+type Language {
+  """
+  The ISO code.
+  """
+  isoCode: LanguageCode!
+}
+
+"""
+ISO 639-1 language codes supported by Shopify.
+"""
+enum LanguageCode {
+  """
+  Afrikaans.
+  """
+  AF
+
+  """
+  Akan.
+  """
+  AK
+
+  """
+  Amharic.
+  """
+  AM
+
+  """
+  Arabic.
+  """
+  AR
+
+  """
+  Assamese.
+  """
+  AS
+
+  """
+  Azerbaijani.
+  """
+  AZ
+
+  """
+  Belarusian.
+  """
+  BE
+
+  """
+  Bulgarian.
+  """
+  BG
+
+  """
+  Bambara.
+  """
+  BM
+
+  """
+  Bangla.
+  """
+  BN
+
+  """
+  Tibetan.
+  """
+  BO
+
+  """
+  Breton.
+  """
+  BR
+
+  """
+  Bosnian.
+  """
+  BS
+
+  """
+  Catalan.
+  """
+  CA
+
+  """
+  Chechen.
+  """
+  CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
+
+  """
+  Czech.
+  """
+  CS
+
+  """
+  Church Slavic.
+  """
+  CU
+
+  """
+  Welsh.
+  """
+  CY
+
+  """
+  Danish.
+  """
+  DA
+
+  """
+  German.
+  """
+  DE
+
+  """
+  Dzongkha.
+  """
+  DZ
+
+  """
+  Ewe.
+  """
+  EE
+
+  """
+  Greek.
+  """
+  EL
+
+  """
+  English.
+  """
+  EN
+
+  """
+  Esperanto.
+  """
+  EO
+
+  """
+  Spanish.
+  """
+  ES
+
+  """
+  Estonian.
+  """
+  ET
+
+  """
+  Basque.
+  """
+  EU
+
+  """
+  Persian.
+  """
+  FA
+
+  """
+  Fulah.
+  """
+  FF
+
+  """
+  Finnish.
+  """
+  FI
+
+  """
+  Filipino.
+  """
+  FIL
+
+  """
+  Faroese.
+  """
+  FO
+
+  """
+  French.
+  """
+  FR
+
+  """
+  Western Frisian.
+  """
+  FY
+
+  """
+  Irish.
+  """
+  GA
+
+  """
+  Scottish Gaelic.
+  """
+  GD
+
+  """
+  Galician.
+  """
+  GL
+
+  """
+  Gujarati.
+  """
+  GU
+
+  """
+  Manx.
+  """
+  GV
+
+  """
+  Hausa.
+  """
+  HA
+
+  """
+  Hebrew.
+  """
+  HE
+
+  """
+  Hindi.
+  """
+  HI
+
+  """
+  Croatian.
+  """
+  HR
+
+  """
+  Hungarian.
+  """
+  HU
+
+  """
+  Armenian.
+  """
+  HY
+
+  """
+  Interlingua.
+  """
+  IA
+
+  """
+  Indonesian.
+  """
+  ID
+
+  """
+  Igbo.
+  """
+  IG
+
+  """
+  Sichuan Yi.
+  """
+  II
+
+  """
+  Icelandic.
+  """
+  IS
+
+  """
+  Italian.
+  """
+  IT
+
+  """
+  Japanese.
+  """
+  JA
+
+  """
+  Javanese.
+  """
+  JV
+
+  """
+  Georgian.
+  """
+  KA
+
+  """
+  Kikuyu.
+  """
+  KI
+
+  """
+  Kazakh.
+  """
+  KK
+
+  """
+  Kalaallisut.
+  """
+  KL
+
+  """
+  Khmer.
+  """
+  KM
+
+  """
+  Kannada.
+  """
+  KN
+
+  """
+  Korean.
+  """
+  KO
+
+  """
+  Kashmiri.
+  """
+  KS
+
+  """
+  Kurdish.
+  """
+  KU
+
+  """
+  Cornish.
+  """
+  KW
+
+  """
+  Kyrgyz.
+  """
+  KY
+
+  """
+  Luxembourgish.
+  """
+  LB
+
+  """
+  Ganda.
+  """
+  LG
+
+  """
+  Lingala.
+  """
+  LN
+
+  """
+  Lao.
+  """
+  LO
+
+  """
+  Lithuanian.
+  """
+  LT
+
+  """
+  Luba-Katanga.
+  """
+  LU
+
+  """
+  Latvian.
+  """
+  LV
+
+  """
+  Malagasy.
+  """
+  MG
+
+  """
+  Māori.
+  """
+  MI
+
+  """
+  Macedonian.
+  """
+  MK
+
+  """
+  Malayalam.
+  """
+  ML
+
+  """
+  Mongolian.
+  """
+  MN
+
+  """
+  Marathi.
+  """
+  MR
+
+  """
+  Malay.
+  """
+  MS
+
+  """
+  Maltese.
+  """
+  MT
+
+  """
+  Burmese.
+  """
+  MY
+
+  """
+  Norwegian (Bokmål).
+  """
+  NB
+
+  """
+  North Ndebele.
+  """
+  ND
+
+  """
+  Nepali.
+  """
+  NE
+
+  """
+  Dutch.
+  """
+  NL
+
+  """
+  Norwegian Nynorsk.
+  """
+  NN
+
+  """
+  Norwegian.
+  """
+  NO
+
+  """
+  Oromo.
+  """
+  OM
+
+  """
+  Odia.
+  """
+  OR
+
+  """
+  Ossetic.
+  """
+  OS
+
+  """
+  Punjabi.
+  """
+  PA
+
+  """
+  Polish.
+  """
+  PL
+
+  """
+  Pashto.
+  """
+  PS
+
+  """
+  Portuguese.
+  """
+  PT
+
+  """
+  Portuguese (Brazil).
+  """
+  PT_BR
+
+  """
+  Portuguese (Portugal).
+  """
+  PT_PT
+
+  """
+  Quechua.
+  """
+  QU
+
+  """
+  Romansh.
+  """
+  RM
+
+  """
+  Rundi.
+  """
+  RN
+
+  """
+  Romanian.
+  """
+  RO
+
+  """
+  Russian.
+  """
+  RU
+
+  """
+  Kinyarwanda.
+  """
+  RW
+
+  """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
+  Sindhi.
+  """
+  SD
+
+  """
+  Northern Sami.
+  """
+  SE
+
+  """
+  Sango.
+  """
+  SG
+
+  """
+  Sinhala.
+  """
+  SI
+
+  """
+  Slovak.
+  """
+  SK
+
+  """
+  Slovenian.
+  """
+  SL
+
+  """
+  Shona.
+  """
+  SN
+
+  """
+  Somali.
+  """
+  SO
+
+  """
+  Albanian.
+  """
+  SQ
+
+  """
+  Serbian.
+  """
+  SR
+
+  """
+  Sundanese.
+  """
+  SU
+
+  """
+  Swedish.
+  """
+  SV
+
+  """
+  Swahili.
+  """
+  SW
+
+  """
+  Tamil.
+  """
+  TA
+
+  """
+  Telugu.
+  """
+  TE
+
+  """
+  Tajik.
+  """
+  TG
+
+  """
+  Thai.
+  """
+  TH
+
+  """
+  Tigrinya.
+  """
+  TI
+
+  """
+  Turkmen.
+  """
+  TK
+
+  """
+  Tongan.
+  """
+  TO
+
+  """
+  Turkish.
+  """
+  TR
+
+  """
+  Tatar.
+  """
+  TT
+
+  """
+  Uyghur.
+  """
+  UG
+
+  """
+  Ukrainian.
+  """
+  UK
+
+  """
+  Urdu.
+  """
+  UR
+
+  """
+  Uzbek.
+  """
+  UZ
+
+  """
+  Vietnamese.
+  """
+  VI
+
+  """
+  Volapük.
+  """
+  VO
+
+  """
+  Wolof.
+  """
+  WO
+
+  """
+  Xhosa.
+  """
+  XH
+
+  """
+  Yiddish.
+  """
+  YI
+
+  """
+  Yoruba.
+  """
+  YO
+
+  """
+  Chinese.
+  """
+  ZH
+
+  """
+  Chinese (Simplified).
+  """
+  ZH_CN
+
+  """
+  Chinese (Traditional).
+  """
+  ZH_TW
+
+  """
+  Zulu.
+  """
+  ZU
+}
+
+"""
+Information about the localized experiences configured for the shop.
+"""
+type Localization {
+  """
+  The country of the active localized experience.
+  """
+  country: Country!
+
+  """
+  The language of the active localized experience.
+  """
+  language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -2795,9 +3569,9 @@ type Location implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 
   """
@@ -2921,6 +3695,11 @@ type MailingAddress {
   longitude: Float
 
   """
+  The market of the address.
+  """
+  market: Market
+
+  """
   The full name of the customer, based on firstName and lastName.
   """
   name: String
@@ -2939,6 +3718,71 @@ type MailingAddress {
   The zip or postal code of the address.
   """
   zip: String
+}
+
+"""
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
 }
 
 """
@@ -2989,12 +3833,12 @@ completing checkout will be blocked.
 """
 input MustFulfillFrom {
   """
-  Ids of the deliverable lines for which the constraint is applied.
+  The IDs of the deliverable lines for which the constraint is applied.
   """
   deliverableLineIds: [ID!]!
 
   """
-  Ids of the locations for which the cart lines must fulfill from.
+  The IDs of the locations for which the cart lines must fulfill from.
   """
   locationIds: [ID!]!
 }
@@ -3006,7 +3850,7 @@ then checkout won't return any shipping rates and completing checkout will be bl
 """
 input MustFulfillFromSameLocation {
   """
-  Ids of the deliverable lines for which the constraint is applied.
+  The IDs of the deliverable lines for which the constraint is applied.
   """
   deliverableLineIds: [ID!]!
 }
@@ -3016,11 +3860,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3124,15 +3968,20 @@ type Product implements HasGates & HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 
   """
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3159,9 +4008,9 @@ type ProductVariant implements HasMetafields {
     key: String!
 
     """
-    The namespace for the metafield.
+    The namespace for the metafield. If omitted, the app-reserved namespace will be used.
     """
-    namespace: String!
+    namespace: String
   ): Metafield
 
   """
@@ -3178,6 +4027,11 @@ type ProductVariant implements HasMetafields {
   An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
   """
   sku: String
+
+  """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
 
   """
   The weight of the product variant in the unit system specified with `weight_unit`.
@@ -3208,6 +4062,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "fulfillment_constraints"
-api_version = "unstable"
+api_version = "2023-07"
 
 [build]
 command = "cargo wasi build --release"

--- a/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 name = "{{name}}"
 type = "fulfillment_constraints"
-api_version = "2023-07"
+api_version = "unstable"
 
 [build]
 command = "cargo wasi build --release"

--- a/order-routing/rust/location-rules/default/schema.graphql
+++ b/order-routing/rust/location-rules/default/schema.graphql
@@ -1,10 +1,3 @@
-# This file is auto-generated from the current state of the GraphQL API. Instead of editing this file,
-# please edit the ruby definition files and run `bin/rails graphql:schema:dump` to regenerate the schema.
-#
-# If you're just looking to browse, you may find it friendlier to use the graphiql browser which is
-# available in services-internal at https://app.shopify.com/services/internal/shops/14168/graphql.
-# Check out the "Docs" tab in the top right.
-
 schema {
   query: Input
   mutation: MutationRoot
@@ -35,7 +28,7 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
@@ -45,7 +38,7 @@ type BuyerIdentity {
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -3098,11 +3091,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!

--- a/sample-apps/bundles-cart-transform/extensions/cart-expand-js/schema.graphql
+++ b/sample-apps/bundles-cart-transform/extensions/cart-expand-js/schema.graphql
@@ -33,7 +33,7 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
@@ -43,7 +43,7 @@ type BuyerIdentity {
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -153,7 +153,7 @@ input CartLineInput {
   cartLineId: ID!
 
   """
-  The quantity of the cart line to be merged.The max quantity is 50.
+  The quantity of the cart line to be merged.The max quantity is 2000.
   """
   quantity: Int!
 }
@@ -1276,7 +1276,7 @@ input ExpandedItem {
   merchandiseId: ID!
 
   """
-  The quantity of the expanded item.The max quantity is 50.
+  The quantity of the expanded item.The max quantity is 2000.
   """
   quantity: Int!
 }
@@ -1429,11 +1429,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!

--- a/sample-apps/bundles-cart-transform/extensions/cart-expand-js/shopify.extension.toml
+++ b/sample-apps/bundles-cart-transform/extensions/cart-expand-js/shopify.extension.toml
@@ -1,7 +1,7 @@
 name = "test-demo"
 type = "cart_transform"
 title = "cart transform"
-api_version = "unstable"
+api_version = "2023-07"
 
 [build]
 command = ""

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/schema.graphql
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/schema.graphql
@@ -24,7 +24,7 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart. Only set when the buyer is logged in.
+Represents information about the buyer that is interacting with the cart.
 """
 type BuyerIdentity {
   """
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -68,114 +73,9 @@ type Cart {
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
-  """
-  cost: CartCost!
-
-  """
-  A list of lines containing information about the items that can be delivered.
-  """
-  deliverableLines: [DeliverableCartLine!]!
-
-  """
-  The delivery groups available for the cart based on the buyer's shipping address.
-  """
-  deliveryGroups: [CartDeliveryGroup!]!
-
-  """
   A list of lines containing information about the items the customer intends to purchase.
   """
   lines: [CartLine!]!
-}
-
-"""
-The cost that the buyer will pay at checkout.
-"""
-type CartCost {
-  """
-  The amount, before taxes and discounts, for the customer to pay.
-  """
-  subtotalAmount: MoneyV2!
-
-  """
-  The total amount for the customer to pay.
-  """
-  totalAmount: MoneyV2!
-
-  """
-  The duty amount for the customer to pay at checkout.
-  """
-  totalDutyAmount: MoneyV2
-
-  """
-  The tax amount for the customer to pay at checkout.
-  """
-  totalTaxAmount: MoneyV2
-}
-
-"""
-Information about the options available for one or more line items to be delivered to a specific address.
-"""
-type CartDeliveryGroup {
-  """
-  A list of cart lines for the delivery group.
-  """
-  cartLines: [CartLine!]!
-
-  """
-  The destination address for the delivery group.
-  """
-  deliveryAddress: MailingAddress
-
-  """
-  The delivery options available for the delivery group.
-  """
-  deliveryOptions: [CartDeliveryOption!]!
-
-  """
-  Unique identifier for the delivery group.
-  """
-  id: ID!
-
-  """
-  Information about the delivery option the buyer has selected.
-  """
-  selectedDeliveryOption: CartDeliveryOption
-}
-
-"""
-Information about a delivery option.
-"""
-type CartDeliveryOption {
-  """
-  The code of the delivery option.
-  """
-  code: String
-
-  """
-  The cost for the delivery option.
-  """
-  cost: MoneyV2!
-
-  """
-  The method for the delivery option.
-  """
-  deliveryMethodType: DeliveryMethod!
-
-  """
-  The description of the delivery option.
-  """
-  description: String
-
-  """
-  The unique identifier of the delivery option.
-  """
-  handle: String!
-
-  """
-  The title of the delivery option.
-  """
-  title: String
 }
 
 """
@@ -213,6 +113,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -247,7 +153,7 @@ input CartLineInput {
   cartLineId: ID!
 
   """
-  The quantity of the cart line.
+  The quantity of the cart line to be merged.The max quantity is 2000.
   """
   quantity: Int!
 }
@@ -281,6 +187,21 @@ type CartTransform implements HasMetafields {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -290,7 +211,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -368,7 +289,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -407,1239 +328,6 @@ type CompanyLocation implements HasMetafields {
   at which the company location was last modified.
   """
   updatedAt: DateTime!
-}
-
-"""
-The code designating a country/region, which generally follows ISO 3166-1 alpha-2 guidelines.
-If a territory doesn't have a country code value in the `CountryCode` enum, then it might be considered a subdivision
-of another country. For example, the territories associated with Spain are represented by the country code `ES`,
-and the territories associated with the United States of America are represented by the country code `US`.
-"""
-enum CountryCode {
-  """
-  Ascension Island.
-  """
-  AC
-
-  """
-  Andorra.
-  """
-  AD
-
-  """
-  United Arab Emirates.
-  """
-  AE
-
-  """
-  Afghanistan.
-  """
-  AF
-
-  """
-  Antigua & Barbuda.
-  """
-  AG
-
-  """
-  Anguilla.
-  """
-  AI
-
-  """
-  Albania.
-  """
-  AL
-
-  """
-  Armenia.
-  """
-  AM
-
-  """
-  Netherlands Antilles.
-  """
-  AN
-
-  """
-  Angola.
-  """
-  AO
-
-  """
-  Argentina.
-  """
-  AR
-
-  """
-  Austria.
-  """
-  AT
-
-  """
-  Australia.
-  """
-  AU
-
-  """
-  Aruba.
-  """
-  AW
-
-  """
-  Åland Islands.
-  """
-  AX
-
-  """
-  Azerbaijan.
-  """
-  AZ
-
-  """
-  Bosnia & Herzegovina.
-  """
-  BA
-
-  """
-  Barbados.
-  """
-  BB
-
-  """
-  Bangladesh.
-  """
-  BD
-
-  """
-  Belgium.
-  """
-  BE
-
-  """
-  Burkina Faso.
-  """
-  BF
-
-  """
-  Bulgaria.
-  """
-  BG
-
-  """
-  Bahrain.
-  """
-  BH
-
-  """
-  Burundi.
-  """
-  BI
-
-  """
-  Benin.
-  """
-  BJ
-
-  """
-  St. Barthélemy.
-  """
-  BL
-
-  """
-  Bermuda.
-  """
-  BM
-
-  """
-  Brunei.
-  """
-  BN
-
-  """
-  Bolivia.
-  """
-  BO
-
-  """
-  Caribbean Netherlands.
-  """
-  BQ
-
-  """
-  Brazil.
-  """
-  BR
-
-  """
-  Bahamas.
-  """
-  BS
-
-  """
-  Bhutan.
-  """
-  BT
-
-  """
-  Bouvet Island.
-  """
-  BV
-
-  """
-  Botswana.
-  """
-  BW
-
-  """
-  Belarus.
-  """
-  BY
-
-  """
-  Belize.
-  """
-  BZ
-
-  """
-  Canada.
-  """
-  CA
-
-  """
-  Cocos (Keeling) Islands.
-  """
-  CC
-
-  """
-  Congo - Kinshasa.
-  """
-  CD
-
-  """
-  Central African Republic.
-  """
-  CF
-
-  """
-  Congo - Brazzaville.
-  """
-  CG
-
-  """
-  Switzerland.
-  """
-  CH
-
-  """
-  Côte d’Ivoire.
-  """
-  CI
-
-  """
-  Cook Islands.
-  """
-  CK
-
-  """
-  Chile.
-  """
-  CL
-
-  """
-  Cameroon.
-  """
-  CM
-
-  """
-  China.
-  """
-  CN
-
-  """
-  Colombia.
-  """
-  CO
-
-  """
-  Costa Rica.
-  """
-  CR
-
-  """
-  Cuba.
-  """
-  CU
-
-  """
-  Cape Verde.
-  """
-  CV
-
-  """
-  Curaçao.
-  """
-  CW
-
-  """
-  Christmas Island.
-  """
-  CX
-
-  """
-  Cyprus.
-  """
-  CY
-
-  """
-  Czechia.
-  """
-  CZ
-
-  """
-  Germany.
-  """
-  DE
-
-  """
-  Djibouti.
-  """
-  DJ
-
-  """
-  Denmark.
-  """
-  DK
-
-  """
-  Dominica.
-  """
-  DM
-
-  """
-  Dominican Republic.
-  """
-  DO
-
-  """
-  Algeria.
-  """
-  DZ
-
-  """
-  Ecuador.
-  """
-  EC
-
-  """
-  Estonia.
-  """
-  EE
-
-  """
-  Egypt.
-  """
-  EG
-
-  """
-  Western Sahara.
-  """
-  EH
-
-  """
-  Eritrea.
-  """
-  ER
-
-  """
-  Spain.
-  """
-  ES
-
-  """
-  Ethiopia.
-  """
-  ET
-
-  """
-  Finland.
-  """
-  FI
-
-  """
-  Fiji.
-  """
-  FJ
-
-  """
-  Falkland Islands.
-  """
-  FK
-
-  """
-  Faroe Islands.
-  """
-  FO
-
-  """
-  France.
-  """
-  FR
-
-  """
-  Gabon.
-  """
-  GA
-
-  """
-  United Kingdom.
-  """
-  GB
-
-  """
-  Grenada.
-  """
-  GD
-
-  """
-  Georgia.
-  """
-  GE
-
-  """
-  French Guiana.
-  """
-  GF
-
-  """
-  Guernsey.
-  """
-  GG
-
-  """
-  Ghana.
-  """
-  GH
-
-  """
-  Gibraltar.
-  """
-  GI
-
-  """
-  Greenland.
-  """
-  GL
-
-  """
-  Gambia.
-  """
-  GM
-
-  """
-  Guinea.
-  """
-  GN
-
-  """
-  Guadeloupe.
-  """
-  GP
-
-  """
-  Equatorial Guinea.
-  """
-  GQ
-
-  """
-  Greece.
-  """
-  GR
-
-  """
-  South Georgia & South Sandwich Islands.
-  """
-  GS
-
-  """
-  Guatemala.
-  """
-  GT
-
-  """
-  Guinea-Bissau.
-  """
-  GW
-
-  """
-  Guyana.
-  """
-  GY
-
-  """
-  Hong Kong SAR.
-  """
-  HK
-
-  """
-  Heard & McDonald Islands.
-  """
-  HM
-
-  """
-  Honduras.
-  """
-  HN
-
-  """
-  Croatia.
-  """
-  HR
-
-  """
-  Haiti.
-  """
-  HT
-
-  """
-  Hungary.
-  """
-  HU
-
-  """
-  Indonesia.
-  """
-  ID
-
-  """
-  Ireland.
-  """
-  IE
-
-  """
-  Israel.
-  """
-  IL
-
-  """
-  Isle of Man.
-  """
-  IM
-
-  """
-  India.
-  """
-  IN
-
-  """
-  British Indian Ocean Territory.
-  """
-  IO
-
-  """
-  Iraq.
-  """
-  IQ
-
-  """
-  Iran.
-  """
-  IR
-
-  """
-  Iceland.
-  """
-  IS
-
-  """
-  Italy.
-  """
-  IT
-
-  """
-  Jersey.
-  """
-  JE
-
-  """
-  Jamaica.
-  """
-  JM
-
-  """
-  Jordan.
-  """
-  JO
-
-  """
-  Japan.
-  """
-  JP
-
-  """
-  Kenya.
-  """
-  KE
-
-  """
-  Kyrgyzstan.
-  """
-  KG
-
-  """
-  Cambodia.
-  """
-  KH
-
-  """
-  Kiribati.
-  """
-  KI
-
-  """
-  Comoros.
-  """
-  KM
-
-  """
-  St. Kitts & Nevis.
-  """
-  KN
-
-  """
-  North Korea.
-  """
-  KP
-
-  """
-  South Korea.
-  """
-  KR
-
-  """
-  Kuwait.
-  """
-  KW
-
-  """
-  Cayman Islands.
-  """
-  KY
-
-  """
-  Kazakhstan.
-  """
-  KZ
-
-  """
-  Laos.
-  """
-  LA
-
-  """
-  Lebanon.
-  """
-  LB
-
-  """
-  St. Lucia.
-  """
-  LC
-
-  """
-  Liechtenstein.
-  """
-  LI
-
-  """
-  Sri Lanka.
-  """
-  LK
-
-  """
-  Liberia.
-  """
-  LR
-
-  """
-  Lesotho.
-  """
-  LS
-
-  """
-  Lithuania.
-  """
-  LT
-
-  """
-  Luxembourg.
-  """
-  LU
-
-  """
-  Latvia.
-  """
-  LV
-
-  """
-  Libya.
-  """
-  LY
-
-  """
-  Morocco.
-  """
-  MA
-
-  """
-  Monaco.
-  """
-  MC
-
-  """
-  Moldova.
-  """
-  MD
-
-  """
-  Montenegro.
-  """
-  ME
-
-  """
-  St. Martin.
-  """
-  MF
-
-  """
-  Madagascar.
-  """
-  MG
-
-  """
-  North Macedonia.
-  """
-  MK
-
-  """
-  Mali.
-  """
-  ML
-
-  """
-  Myanmar (Burma).
-  """
-  MM
-
-  """
-  Mongolia.
-  """
-  MN
-
-  """
-  Macao SAR.
-  """
-  MO
-
-  """
-  Martinique.
-  """
-  MQ
-
-  """
-  Mauritania.
-  """
-  MR
-
-  """
-  Montserrat.
-  """
-  MS
-
-  """
-  Malta.
-  """
-  MT
-
-  """
-  Mauritius.
-  """
-  MU
-
-  """
-  Maldives.
-  """
-  MV
-
-  """
-  Malawi.
-  """
-  MW
-
-  """
-  Mexico.
-  """
-  MX
-
-  """
-  Malaysia.
-  """
-  MY
-
-  """
-  Mozambique.
-  """
-  MZ
-
-  """
-  Namibia.
-  """
-  NA
-
-  """
-  New Caledonia.
-  """
-  NC
-
-  """
-  Niger.
-  """
-  NE
-
-  """
-  Norfolk Island.
-  """
-  NF
-
-  """
-  Nigeria.
-  """
-  NG
-
-  """
-  Nicaragua.
-  """
-  NI
-
-  """
-  Netherlands.
-  """
-  NL
-
-  """
-  Norway.
-  """
-  NO
-
-  """
-  Nepal.
-  """
-  NP
-
-  """
-  Nauru.
-  """
-  NR
-
-  """
-  Niue.
-  """
-  NU
-
-  """
-  New Zealand.
-  """
-  NZ
-
-  """
-  Oman.
-  """
-  OM
-
-  """
-  Panama.
-  """
-  PA
-
-  """
-  Peru.
-  """
-  PE
-
-  """
-  French Polynesia.
-  """
-  PF
-
-  """
-  Papua New Guinea.
-  """
-  PG
-
-  """
-  Philippines.
-  """
-  PH
-
-  """
-  Pakistan.
-  """
-  PK
-
-  """
-  Poland.
-  """
-  PL
-
-  """
-  St. Pierre & Miquelon.
-  """
-  PM
-
-  """
-  Pitcairn Islands.
-  """
-  PN
-
-  """
-  Palestinian Territories.
-  """
-  PS
-
-  """
-  Portugal.
-  """
-  PT
-
-  """
-  Paraguay.
-  """
-  PY
-
-  """
-  Qatar.
-  """
-  QA
-
-  """
-  Réunion.
-  """
-  RE
-
-  """
-  Romania.
-  """
-  RO
-
-  """
-  Serbia.
-  """
-  RS
-
-  """
-  Russia.
-  """
-  RU
-
-  """
-  Rwanda.
-  """
-  RW
-
-  """
-  Saudi Arabia.
-  """
-  SA
-
-  """
-  Solomon Islands.
-  """
-  SB
-
-  """
-  Seychelles.
-  """
-  SC
-
-  """
-  Sudan.
-  """
-  SD
-
-  """
-  Sweden.
-  """
-  SE
-
-  """
-  Singapore.
-  """
-  SG
-
-  """
-  St. Helena.
-  """
-  SH
-
-  """
-  Slovenia.
-  """
-  SI
-
-  """
-  Svalbard & Jan Mayen.
-  """
-  SJ
-
-  """
-  Slovakia.
-  """
-  SK
-
-  """
-  Sierra Leone.
-  """
-  SL
-
-  """
-  San Marino.
-  """
-  SM
-
-  """
-  Senegal.
-  """
-  SN
-
-  """
-  Somalia.
-  """
-  SO
-
-  """
-  Suriname.
-  """
-  SR
-
-  """
-  South Sudan.
-  """
-  SS
-
-  """
-  São Tomé & Príncipe.
-  """
-  ST
-
-  """
-  El Salvador.
-  """
-  SV
-
-  """
-  Sint Maarten.
-  """
-  SX
-
-  """
-  Syria.
-  """
-  SY
-
-  """
-  Eswatini.
-  """
-  SZ
-
-  """
-  Tristan da Cunha.
-  """
-  TA
-
-  """
-  Turks & Caicos Islands.
-  """
-  TC
-
-  """
-  Chad.
-  """
-  TD
-
-  """
-  French Southern Territories.
-  """
-  TF
-
-  """
-  Togo.
-  """
-  TG
-
-  """
-  Thailand.
-  """
-  TH
-
-  """
-  Tajikistan.
-  """
-  TJ
-
-  """
-  Tokelau.
-  """
-  TK
-
-  """
-  Timor-Leste.
-  """
-  TL
-
-  """
-  Turkmenistan.
-  """
-  TM
-
-  """
-  Tunisia.
-  """
-  TN
-
-  """
-  Tonga.
-  """
-  TO
-
-  """
-  Turkey.
-  """
-  TR
-
-  """
-  Trinidad & Tobago.
-  """
-  TT
-
-  """
-  Tuvalu.
-  """
-  TV
-
-  """
-  Taiwan.
-  """
-  TW
-
-  """
-  Tanzania.
-  """
-  TZ
-
-  """
-  Ukraine.
-  """
-  UA
-
-  """
-  Uganda.
-  """
-  UG
-
-  """
-  U.S. Outlying Islands.
-  """
-  UM
-
-  """
-  United States.
-  """
-  US
-
-  """
-  Uruguay.
-  """
-  UY
-
-  """
-  Uzbekistan.
-  """
-  UZ
-
-  """
-  Vatican City.
-  """
-  VA
-
-  """
-  St. Vincent & Grenadines.
-  """
-  VC
-
-  """
-  Venezuela.
-  """
-  VE
-
-  """
-  British Virgin Islands.
-  """
-  VG
-
-  """
-  Vietnam.
-  """
-  VN
-
-  """
-  Vanuatu.
-  """
-  VU
-
-  """
-  Wallis & Futuna.
-  """
-  WF
-
-  """
-  Samoa.
-  """
-  WS
-
-  """
-  Kosovo.
-  """
-  XK
-
-  """
-  Yemen.
-  """
-  YE
-
-  """
-  Mayotte.
-  """
-  YT
-
-  """
-  South Africa.
-  """
-  ZA
-
-  """
-  Zambia.
-  """
-  ZM
-
-  """
-  Zimbabwe.
-  """
-  ZW
-
-  """
-  Unknown Region.
-  """
-  ZZ
 }
 
 """
@@ -1771,10 +459,7 @@ enum CurrencyCode {
   """
   Belarusian Ruble (BYR).
   """
-  BYR
-    @deprecated(
-      reason: "`BYR` is deprecated. Use `BYN` available from version `2021-01` onwards instead."
-    )
+  BYR @deprecated(reason: "`BYR` is deprecated. Use `BYN` available from version `2021-01` onwards instead.")
 
   """
   Belize Dollar (BZD).
@@ -2299,10 +984,7 @@ enum CurrencyCode {
   """
   Sao Tome And Principe Dobra (STD).
   """
-  STD
-    @deprecated(
-      reason: "`STD` is deprecated. Use `STN` available from version `2022-07` onwards instead."
-    )
+  STD @deprecated(reason: "`STD` is deprecated. Use `STN` available from version `2022-07` onwards instead.")
 
   """
   Sao Tome And Principe Dobra (STN).
@@ -2397,10 +1079,7 @@ enum CurrencyCode {
   """
   Venezuelan Bolivares (VEF).
   """
-  VEF
-    @deprecated(
-      reason: "`VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead."
-    )
+  VEF @deprecated(reason: "`VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead.")
 
   """
   Venezuelan Bolivares (VES).
@@ -2478,6 +1157,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2519,6 +1203,16 @@ type Customer implements HasMetafields {
   ): Boolean!
 
   """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
+
+  """
   A unique identifier for the customer.
   """
   id: ID!
@@ -2558,73 +1252,6 @@ Example values: `"29.99"`, `"29.999"`.
 """
 scalar Decimal
 
-"""
-Represents information about the merchandise in the cart.
-"""
-type DeliverableCartLine {
-  """
-  Retrieve a cart line attribute by key.
-
-  Cart line attributes are also known as line item properties in Liquid.
-  """
-  attribute(
-    """
-    The key of the attribute to retrieve.
-    """
-    key: String
-  ): Attribute
-
-  """
-  The ID of the cart line.
-  """
-  id: ID!
-
-  """
-  The merchandise that the buyer intends to purchase.
-  """
-  merchandise: Merchandise!
-
-  """
-  The quantity of the merchandise that the customer intends to purchase.
-  """
-  quantity: Int!
-}
-
-"""
-List of different delivery method types.
-"""
-enum DeliveryMethod {
-  """
-  Local Delivery.
-  """
-  LOCAL
-
-  """
-  None.
-  """
-  NONE
-
-  """
-  Shipping to a Pickup Point.
-  """
-  PICKUP_POINT
-
-  """
-  Local Pickup.
-  """
-  PICK_UP
-
-  """
-  Retail.
-  """
-  RETAIL
-
-  """
-  Shipping.
-  """
-  SHIPPING
-}
-
 input ExpandOperation {
   """
   The cart line id to expand.
@@ -2649,7 +1276,7 @@ input ExpandedItem {
   merchandiseId: ID!
 
   """
-  The quantity of the expanded item.
+  The quantity of the expanded item.The max quantity is 2000.
   """
   quantity: Int!
 }
@@ -2661,67 +1288,7 @@ input FunctionResult {
   """
   Cart operations to run on Cart.
   """
-  operations: [CartOperation!]
-}
-
-"""
-Represents a gate configuration.
-"""
-type GateConfiguration implements HasMetafields {
-  """
-  An optional string identifier.
-  """
-  appId: String
-
-  """
-  The ID of the gate configuration.
-  """
-  id: ID!
-
-  """
-  Returns a metafield by namespace and key that belongs to the resource.
-  """
-  metafield(
-    """
-    The key for the metafield.
-    """
-    key: String!
-
-    """
-    The namespace for the metafield.
-    """
-    namespace: String!
-  ): Metafield
-}
-
-"""
-Represents a connection from a subject to a gate configuration.
-"""
-type GateSubject {
-  """
-  The bound gate configuration.
-  """
-  configuration(
-    """
-    The appId of the gate configurations to search for.
-    """
-    appId: String
-  ): GateConfiguration!
-
-  """
-  The ID of the gate subject.
-  """
-  id: ID!
-}
-
-"""
-Gate subjects associated to the specified resource.
-"""
-interface HasGates {
-  """
-  Returns active gate subjects bound to the resource.
-  """
-  gates: [GateSubject!]!
+  operations: [CartOperation!]!
 }
 
 """
@@ -2742,6 +1309,21 @@ interface HasMetafields {
     """
     namespace: String!
   ): Metafield
+}
+
+"""
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
 }
 
 """
@@ -2772,66 +1354,6 @@ type Input {
   The CartTransform containing the function.
   """
   cartTransform: CartTransform!
-}
-
-"""
-Represents a mailing address.
-"""
-type MailingAddress {
-  """
-  The first line of the address. Typically the street address or PO Box number.
-  """
-  address1: String
-
-  """
-  The second line of the address. Typically the number of the apartment, suite, or unit.
-  """
-  address2: String
-
-  """
-  The name of the city, district, village, or town.
-  """
-  city: String
-
-  """
-  The name of the customer's company or organization.
-  """
-  company: String
-
-  """
-  The two-letter code for the country of the address. For example, US.
-  """
-  countryCode: CountryCode
-
-  """
-  The first name of the customer.
-  """
-  firstName: String
-
-  """
-  The last name of the customer.
-  """
-  lastName: String
-
-  """
-  The full name of the customer, based on firstName and lastName.
-  """
-  name: String
-
-  """
-  A unique phone number for the customer. Formatted using E.164 standard. For example, +16135551111.
-  """
-  phone: String
-
-  """
-  The two-letter code for the region. For example, ON.
-  """
-  provinceCode: String
-
-  """
-  The zip or postal code of the address.
-  """
-  zip: String
 }
 
 """
@@ -2907,11 +1429,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -2934,12 +1456,7 @@ input PriceAdjustmentValue {
 """
 Represents a product.
 """
-type Product implements HasGates & HasMetafields {
-  """
-  Returns active gate subjects bound to the resource.
-  """
-  gates: [GateSubject!]!
-
+type Product implements HasMetafields {
   """
   A unique human-friendly string of the product's title.
   """
@@ -2950,10 +1467,20 @@ type Product implements HasGates & HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -2961,14 +1488,24 @@ type Product implements HasGates & HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -2994,6 +1531,11 @@ type Product implements HasGates & HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3041,6 +1583,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3069,6 +1616,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/shopify.extension.toml
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/shopify.extension.toml
@@ -1,7 +1,7 @@
 name = "cart merge expand"
 type = "cart_transform"
 title = "cart merge expand"
-api_version = "unstable"
+api_version = "2023-07"
 
 [build]
 command = "cargo wasi build --release"

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/src/main.rs
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/src/main.rs
@@ -58,7 +58,7 @@ fn function(input: input::ResponseData) -> Result<output::FunctionResult> {
         .collect();
 
     Ok(output::FunctionResult {
-        operations: Some(cart_operations),
+        operations: cart_operations,
     })
 }
 

--- a/sample-apps/delivery-customizations/extensions/delivery-customization-js/schema.graphql
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization-js/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -208,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -236,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -245,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -323,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2434,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2473,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2600,6 +2641,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Request to hide a delivery option.
 """
 input HideOperation {
@@ -2629,7 +2685,7 @@ type Input {
   deliveryCustomization: DeliveryCustomization!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3352,6 +3408,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3415,6 +3476,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3475,11 +3601,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3519,10 +3645,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3530,14 +3666,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3563,6 +3709,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3610,6 +3761,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3653,6 +3809,74 @@ input RenameOperation {
   The new name for the delivery option.
   """
   title: String!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/sample-apps/delivery-customizations/extensions/delivery-customization-rust/schema.graphql
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization-rust/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -208,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -236,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -245,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -323,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2434,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2473,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2600,6 +2641,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Request to hide a delivery option.
 """
 input HideOperation {
@@ -2629,7 +2685,7 @@ type Input {
   deliveryCustomization: DeliveryCustomization!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3352,6 +3408,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3415,6 +3476,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3475,11 +3601,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3519,10 +3645,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3530,14 +3666,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3563,6 +3709,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3610,6 +3761,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3653,6 +3809,74 @@ input RenameOperation {
   The new name for the delivery option.
   """
   title: String!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/sample-apps/discounts/extensions/product-discount-js/schema.graphql
+++ b/sample-apps/discounts/extensions/product-discount-js/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2429,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2468,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2655,6 +2701,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2667,7 +2728,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2677,7 +2738,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3400,6 +3461,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3463,6 +3529,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3508,11 +3639,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3544,10 +3675,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3555,14 +3696,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3588,6 +3739,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3633,6 +3789,11 @@ type ProductVariant implements HasMetafields {
   An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
   """
   sku: String
+
+  """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
 
   """
   The weight of the product variant in the unit system specified with `weight_unit`.
@@ -3681,6 +3842,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/sample-apps/discounts/extensions/product-discount-rust/schema.graphql
+++ b/sample-apps/discounts/extensions/product-discount-rust/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -163,6 +168,11 @@ type CartDeliveryOption {
   description: String
 
   """
+  The unique identifier of the delivery option.
+  """
+  handle: String!
+
+  """
   The title of the delivery option.
   """
   title: String
@@ -203,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -231,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -240,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -318,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2429,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2468,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2655,6 +2701,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -2667,7 +2728,7 @@ The input object for the function.
 """
 type Input {
   """
-  The cart to discount.
+  The cart.
   """
   cart: Cart!
 
@@ -2677,7 +2738,7 @@ type Input {
   discountNode: DiscountNode!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3400,6 +3461,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3463,6 +3529,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3508,11 +3639,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3544,10 +3675,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3555,14 +3696,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3588,6 +3739,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3633,6 +3789,11 @@ type ProductVariant implements HasMetafields {
   An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
   """
   sku: String
+
+  """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
 
   """
   The weight of the product variant in the unit system specified with `weight_unit`.
@@ -3681,6 +3842,74 @@ type PurchasingCompany {
   The company location associated to the order or draft order.
   """
   location: CompanyLocation!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/sample-apps/discounts/extensions/product-discount-rust/shopify.extension.toml
+++ b/sample-apps/discounts/extensions/product-discount-rust/shopify.extension.toml
@@ -1,6 +1,6 @@
 name = "product-discount-rust"
 type = "product_discounts"
-api_version = "2023-01"
+api_version = "2023-07"
 
 [build]
 command = "cargo wasi build --release"

--- a/sample-apps/payment-customizations/extensions/payment-customization-js/schema.graphql
+++ b/sample-apps/payment-customizations/extensions/payment-customization-js/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -208,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -236,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -245,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -323,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2434,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2473,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2580,6 +2621,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Request to hide a payment method.
 """
 input HideOperation {
@@ -2604,7 +2660,7 @@ type Input {
   cart: Cart!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3337,6 +3393,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3400,6 +3461,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3460,11 +3586,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3532,10 +3658,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3543,14 +3679,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3576,6 +3722,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3623,6 +3774,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3666,6 +3822,74 @@ input RenameOperation {
   The identifier of the payment method to rename.
   """
   paymentMethodId: ID!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/sample-apps/payment-customizations/extensions/payment-customization-rust/schema.graphql
+++ b/sample-apps/payment-customizations/extensions/payment-customization-rust/schema.graphql
@@ -33,12 +33,17 @@ type BuyerIdentity {
   customer: Customer
 
   """
-  The email address of the buyer that is interacting with the cart.
+  The email address of the buyer that's interacting with the cart.
   """
   email: String
 
   """
-  The phone number of the buyer that is interacting with the cart.
+  Whether the buyer authenticated with a customer account.
+  """
+  isAuthenticated: Boolean!
+
+  """
+  The phone number of the buyer that's interacting with the cart.
   """
   phone: String
 
@@ -208,6 +213,12 @@ type CartLine {
   The quantity of the merchandise that the customer intends to purchase.
   """
   quantity: Int!
+
+  """
+  The selling plan associated with the cart line and the effect that each
+  selling plan has on variants when they're purchased.
+  """
+  sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
@@ -236,6 +247,21 @@ type CartLineCost {
 }
 
 """
+Represents whether the product is a member of the given collection.
+"""
+type CollectionMembership {
+  """
+  The ID of the collection.
+  """
+  collectionId: ID!
+
+  """
+  Whether the product is a member of the collection.
+  """
+  isMember: Boolean!
+}
+
+"""
 Represents information about a company which is also a customer of the shop.
 """
 type Company implements HasMetafields {
@@ -245,7 +271,7 @@ type Company implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -323,7 +349,7 @@ type CompanyLocation implements HasMetafields {
   createdAt: DateTime!
 
   """
-  A unique externally-supplied identifier for the company.
+  A unique externally-supplied ID for the company.
   """
   externalId: String
 
@@ -2434,6 +2460,11 @@ type CustomProduct {
   requiresShipping: Boolean!
 
   """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -2473,6 +2504,16 @@ type Customer implements HasMetafields {
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the customer has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A unique identifier for the customer.
@@ -2580,6 +2621,21 @@ interface HasMetafields {
 }
 
 """
+Represents whether the current object has the given tag.
+"""
+type HasTagResponse {
+  """
+  Whether the current object has the tag.
+  """
+  hasTag: Boolean!
+
+  """
+  The tag.
+  """
+  tag: String!
+}
+
+"""
 Request to hide a payment method.
 """
 input HideOperation {
@@ -2604,7 +2660,7 @@ type Input {
   cart: Cart!
 
   """
-  The localization of the function execution context.
+  The localization of the Function execution context.
   """
   localization: Localization!
 
@@ -3337,6 +3393,11 @@ type Localization {
   The language of the active localized experience.
   """
   language: Language!
+
+  """
+  The market of the active localized experience.
+  """
+  market: Market!
 }
 
 """
@@ -3400,6 +3461,71 @@ type MailingAddress {
 }
 
 """
+A market is a group of one or more regions that you want to target for international sales.
+By creating a market, you can configure a distinct, localized shopping experience for
+customers from a specific area of the world. For example, you can
+[change currency](https://shopify.dev/api/admin-graphql/current/mutations/marketCurrencySettingsUpdate),
+[configure international pricing](https://shopify.dev/api/examples/product-price-lists),
+or [add market-specific domains or subfolders](https://shopify.dev/api/admin-graphql/current/objects/MarketWebPresence).
+"""
+type Market implements HasMetafields {
+  """
+  A human-readable unique string for the market automatically generated from its title.
+  """
+  handle: String!
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+
+  """
+  A geographic region which comprises a market.
+  """
+  regions: [MarketRegion!]!
+}
+
+"""
+Represents a region.
+"""
+interface MarketRegion {
+  """
+  The name of the region in the language of the current localization.
+  """
+  name: String
+}
+
+"""
+A country which comprises a market.
+"""
+type MarketRegionCountry implements MarketRegion {
+  """
+  The two-letter code for the country.
+  """
+  code: CountryCode!
+
+  """
+  The country name in the language of the current localization.
+  """
+  name: String!
+}
+
+"""
 The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
@@ -3460,11 +3586,11 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
-  Handles the function result.
+  Handles the Function result.
   """
   handleResult(
     """
-    The result of the function.
+    The result of the Function.
     """
     result: FunctionResult!
   ): Void!
@@ -3532,10 +3658,20 @@ type Product implements HasMetafields {
   """
   hasAnyTag(
     """
-    The tags to search for.
+    The tags to check.
     """
     tags: [String!]! = []
   ): Boolean!
+
+  """
+  Whether the product has the given tags.
+  """
+  hasTags(
+    """
+    The tags to check.
+    """
+    tags: [String!]! = []
+  ): [HasTagResponse!]!
 
   """
   A globally-unique identifier.
@@ -3543,14 +3679,24 @@ type Product implements HasMetafields {
   id: ID!
 
   """
-  Whether the product has any of the given collection.
+  Whether the product is in any of the given collections.
   """
   inAnyCollection(
     """
-    The collections to search for.
+    The IDs of the collections to check.
     """
     ids: [ID!]! = []
   ): Boolean!
+
+  """
+  Whether the product is in the given collections.
+  """
+  inCollections(
+    """
+    The IDs of the collections to check.
+    """
+    ids: [ID!]! = []
+  ): [CollectionMembership!]!
 
   """
   Whether the product is a gift card.
@@ -3576,6 +3722,11 @@ type Product implements HasMetafields {
   The product type specified by the merchant.
   """
   productType: String
+
+  """
+  The localized title of the product in the customer’s locale.
+  """
+  title: String!
 
   """
   The name of the product's vendor.
@@ -3623,6 +3774,11 @@ type ProductVariant implements HasMetafields {
   sku: String
 
   """
+  The localized title of the product variant in the customer’s locale.
+  """
+  title: String
+
+  """
   The weight of the product variant in the unit system specified with `weight_unit`.
   """
   weight: Float
@@ -3666,6 +3822,74 @@ input RenameOperation {
   The identifier of the payment method to rename.
   """
   paymentMethodId: ID!
+}
+
+"""
+Represents how products and variants can be sold and purchased.
+"""
+type SellingPlan {
+  """
+  The description of the selling plan.
+  """
+  description: String
+
+  """
+  A globally-unique identifier.
+  """
+  id: ID!
+
+  """
+  The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
+  """
+  name: String!
+
+  """
+  Whether purchasing the selling plan will result in multiple deliveries.
+  """
+  recurringDeliveries: Boolean!
+}
+
+"""
+Represents an association between a variant and a selling plan. Selling plan
+allocations describe the options offered for each variant, and the price of the
+variant when purchased with a selling plan.
+"""
+type SellingPlanAllocation {
+  """
+  A list of price adjustments, with a maximum of two. When there are two, the
+  first price adjustment goes into effect at the time of purchase, while the
+  second one starts after a certain number of orders. A price adjustment
+  represents how a selling plan affects pricing when a variant is purchased with
+  a selling plan. Prices display in the customer's currency if the shop is
+  configured for it.
+  """
+  priceAdjustments: [SellingPlanAllocationPriceAdjustment!]!
+
+  """
+  A representation of how products and variants can be sold and purchased. For
+  example, an individual selling plan could be '6 weeks of prepaid granola,
+  delivered weekly'.
+  """
+  sellingPlan: SellingPlan!
+}
+
+"""
+The resulting prices for variants when they're purchased with a specific selling plan.
+"""
+type SellingPlanAllocationPriceAdjustment {
+  """
+  The effective price for a single delivery. For example, for a prepaid
+  subscription plan that includes 6 deliveries at the price of $48.00, the per
+  delivery price is $8.00.
+  """
+  perDeliveryPrice: MoneyV2!
+
+  """
+  The price of the variant when it's purchased with a selling plan For example,
+  for a prepaid subscription plan that includes 6 deliveries of $10.00 granola,
+  where the customer gets 20% off, the price is 6 x $10.00 x 0.80 = $48.00.
+  """
+  price: MoneyV2!
 }
 
 """

--- a/sample-apps/payment-customizations/extensions/payment-customization-rust/shopify.extension.toml
+++ b/sample-apps/payment-customizations/extensions/payment-customization-rust/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2023-04"
+api_version = "2023-07"
 name = "payment-customization-rust"
 type = "payment_customization"
 


### PR DESCRIPTION
* Bump API version in all templates and samples to `2023-07`, except those in developer preview who were using `unstable`.
* Updated schemas for all templates and samples.
* There's a quick fix in here for the cart transform wasm template as well.

We've had no breaking changes in Function APIs yet, so this should be a safe update. I did spot check 🎩 the discounts sample app and JavaScript order discount.