### PR TITLE
Add handle schema changes to pickup option inputs and outputs

### DIFF
--- a/order-routing/javascript/local-pickup-delivery-option-generators/default/input.graphql.liquid
+++ b/order-routing/javascript/local-pickup-delivery-option-generators/default/input.graphql.liquid
@@ -5,7 +5,7 @@ query Input {
     }
   }
   fulfillmentGroups {
-    id
+    handle
     locationHandles
     lines {
       id

--- a/order-routing/javascript/local-pickup-delivery-option-generators/default/schema.graphql
+++ b/order-routing/javascript/local-pickup-delivery-option-generators/default/schema.graphql
@@ -1,3 +1,10 @@
+# This file is auto-generated from the current state of the GraphQL API. Instead of editing this file,
+# please edit the ruby definition files and run `bin/rails graphql:schema:dump` to regenerate the schema.
+#
+# If you're just looking to browse, you may find it friendlier to use the graphiql browser which is
+# available in services-internal at https://app.shopify.com/services/internal/shops/14168/graphql.
+# Check out the "Docs" tab in the top right.
+
 schema {
   query: Input
   mutation: MutationRoot
@@ -387,6 +394,11 @@ type CompanyLocation implements HasMetafields {
   The name of the company location.
   """
   name: String!
+
+  """
+  The number of orders placed at this company location.
+  """
+  orderCount: Int!
 
   """
   The date and time ([ISO 8601 format](http://en.wikipedia.org/wiki/ISO_8601))
@@ -2663,9 +2675,9 @@ type FulfillmentGroup {
   deliveryGroup: CartDeliveryGroup!
 
   """
-  The ID of the fulfillment group.
+  The fulfillment group handle.
   """
-  id: ID!
+  handle: Handle!
 
   """
   The merchandise in the fulfillment group.
@@ -2673,7 +2685,7 @@ type FulfillmentGroup {
   lines: [CartLine!]!
 
   """
-  A list of location short IDs that can fulfill items in the fulfillment group.
+  A list of location handles that can fulfill items in the fulfillment group.
   """
   locationHandles: [Handle!]!
 }
@@ -3705,9 +3717,9 @@ input LocalPickupDeliveryOption {
   cost: Decimal!
 
   """
-  The fulfillment group IDs that this delivery option is limited to. Defaults to all groups.
+  The fulfillment group handles that this delivery option is limited to. Defaults to all groups.
   """
-  fulfillmentGroupIds: [ID!]
+  fulfillmentGroupHandles: [Handle!]
 
   """
   The additional metadata associate with a delivery option.
@@ -3976,8 +3988,7 @@ The entity that manages a particular market.
 type MarketManager {
   """
   The identity of the manager. This can either be `merchant` if the market is
-  manually managed by the merchant, `shopify` if the market is automatically
-  managed by Shopify, or an ID of the app responsible for managing the market.
+  manually managed by the merchant or an ID of the app responsible for managing the market.
   """
   identifier: String!
 }
@@ -4095,7 +4106,7 @@ input Operation {
 
 input PickupLocation {
   """
-  The location short id of the pickup in-store location.
+  The location handle of the pickup in-store location.
   """
   locationHandle: Handle!
 

--- a/order-routing/javascript/local-pickup-delivery-option-generators/default/src/index.liquid
+++ b/order-routing/javascript/local-pickup-delivery-option-generators/default/src/index.liquid
@@ -48,7 +48,7 @@ const DELIVERY_OPTION: FunctionResult = {
   operations: [
     {
       add: {
-        fulfillmentGroupIds: [""gid://shopify/FulfillmentGroup/1""],
+        fulfillmentGroupHandles: ["1"],
         code: "pickup-1",
         title: "Main St."
         cost: 1.99,

--- a/order-routing/javascript/local-pickup-delivery-option-generators/default/src/index.test.liquid
+++ b/order-routing/javascript/local-pickup-delivery-option-generators/default/src/index.test.liquid
@@ -18,7 +18,7 @@ describe('local pickup delivery option generator function', () => {
       },
       fulfillmentGroups: [
         {
-          id:  "gid://shopify/FulfillmentGroup/1",
+          handle:  "1",
           lines: [
             {
               id: "gid://shopify/CartLine/1"
@@ -47,7 +47,7 @@ describe('local pickup delivery option generator function', () => {
       operations: [
         {
           add: {
-            fulfillmentGroupIds: [""gid://shopify/FulfillmentGroup/1""],
+            fulfillmentGroupHandles: ["1"],
             code: "pickup-1",
             title: "Main St."
             cost: 1.99,
@@ -81,7 +81,7 @@ describe('local pickup delivery option generator function', () => {
       },
       fulfillmentGroups: [
         {
-          id:  "gid://shopify/FulfillmentGroup/1",
+          handle:  "1",
           lines: [
             {
               id: "gid://shopify/CartLine/1"
@@ -110,7 +110,7 @@ describe('local pickup delivery option generator function', () => {
       operations: [
         {
           add: {
-            fulfillmentGroupIds: [""gid://shopify/FulfillmentGroup/1""],
+            fulfillmentGroupHandles: ["1"],
             code: "pickup-1",
             title: "Main St."
             cost: 1.99,

--- a/order-routing/rust/local-pickup-delivery-option-generators/default/input.graphql.liquid
+++ b/order-routing/rust/local-pickup-delivery-option-generators/default/input.graphql.liquid
@@ -5,7 +5,7 @@ query Input {
     }
   }
   fulfillmentGroups {
-    id
+    handle
     locationHandles
     lines {
       id

--- a/order-routing/rust/local-pickup-delivery-option-generators/default/schema.graphql
+++ b/order-routing/rust/local-pickup-delivery-option-generators/default/schema.graphql
@@ -1,3 +1,10 @@
+# This file is auto-generated from the current state of the GraphQL API. Instead of editing this file,
+# please edit the ruby definition files and run `bin/rails graphql:schema:dump` to regenerate the schema.
+#
+# If you're just looking to browse, you may find it friendlier to use the graphiql browser which is
+# available in services-internal at https://app.shopify.com/services/internal/shops/14168/graphql.
+# Check out the "Docs" tab in the top right.
+
 schema {
   query: Input
   mutation: MutationRoot
@@ -387,6 +394,11 @@ type CompanyLocation implements HasMetafields {
   The name of the company location.
   """
   name: String!
+
+  """
+  The number of orders placed at this company location.
+  """
+  orderCount: Int!
 
   """
   The date and time ([ISO 8601 format](http://en.wikipedia.org/wiki/ISO_8601))
@@ -2663,9 +2675,9 @@ type FulfillmentGroup {
   deliveryGroup: CartDeliveryGroup!
 
   """
-  The ID of the fulfillment group.
+  The fulfillment group handle.
   """
-  id: ID!
+  handle: Handle!
 
   """
   The merchandise in the fulfillment group.
@@ -2673,7 +2685,7 @@ type FulfillmentGroup {
   lines: [CartLine!]!
 
   """
-  A list of location short IDs that can fulfill items in the fulfillment group.
+  A list of location handles that can fulfill items in the fulfillment group.
   """
   locationHandles: [Handle!]!
 }
@@ -3705,9 +3717,9 @@ input LocalPickupDeliveryOption {
   cost: Decimal!
 
   """
-  The fulfillment group IDs that this delivery option is limited to. Defaults to all groups.
+  The fulfillment group handles that this delivery option is limited to. Defaults to all groups.
   """
-  fulfillmentGroupIds: [ID!]
+  fulfillmentGroupHandles: [Handle!]
 
   """
   The additional metadata associate with a delivery option.
@@ -3976,8 +3988,7 @@ The entity that manages a particular market.
 type MarketManager {
   """
   The identity of the manager. This can either be `merchant` if the market is
-  manually managed by the merchant, `shopify` if the market is automatically
-  managed by Shopify, or an ID of the app responsible for managing the market.
+  manually managed by the merchant or an ID of the app responsible for managing the market.
   """
   identifier: String!
 }
@@ -4095,7 +4106,7 @@ input Operation {
 
 input PickupLocation {
   """
-  The location short id of the pickup in-store location.
+  The location handle of the pickup in-store location.
   """
   locationHandle: Handle!
 

--- a/order-routing/rust/local-pickup-delivery-option-generators/default/src/main.rs
+++ b/order-routing/rust/local-pickup-delivery-option-generators/default/src/main.rs
@@ -15,7 +15,7 @@ struct Config {}
 fn function(_input: input::ResponseData) -> Result<output::FunctionResult> {
     let operations = vec![output::Operation {
         add: output::LocalPickupDeliveryOption {
-            fulfillment_group_ids: None,
+            fulfillment_group_handles: None,
             code: "Main St.".to_string(),
             title: "Main St.".to_string(),
             cost: Decimal(1.99),

--- a/order-routing/rust/local-pickup-delivery-option-generators/default/src/tests.rs
+++ b/order-routing/rust/local-pickup-delivery-option-generators/default/src/tests.rs
@@ -16,7 +16,7 @@ fn test_result_contains_no_operations() -> Result<()> {
             },
             "fulfillmentGroups": [
               {
-                "id":  "gid://shopify/FulfillmentGroup/1",
+                "handle":  "1",
                 "lines": [
                   {
                     "id": "gid://shopify/CartLine/1"
@@ -46,7 +46,7 @@ fn test_result_contains_no_operations() -> Result<()> {
 
     let operations = vec![output::Operation {
         add: output::LocalPickupDeliveryOption {
-            fulfillment_group_ids: None,
+            fulfillment_group_handles: None,
             code: "Main St.".to_string(),
             title: "Main St.".to_string(),
             cost: Decimal(1.99),

--- a/order-routing/wasm/local-pickup-delivery-option-generators/default/input.graphql.liquid
+++ b/order-routing/wasm/local-pickup-delivery-option-generators/default/input.graphql.liquid
@@ -5,7 +5,7 @@ query Input {
     }
   }
   fulfillmentGroups {
-    id
+    handle
     locationHandles
     lines {
       id

--- a/order-routing/wasm/local-pickup-delivery-option-generators/default/schema.graphql
+++ b/order-routing/wasm/local-pickup-delivery-option-generators/default/schema.graphql
@@ -1,3 +1,10 @@
+# This file is auto-generated from the current state of the GraphQL API. Instead of editing this file,
+# please edit the ruby definition files and run `bin/rails graphql:schema:dump` to regenerate the schema.
+#
+# If you're just looking to browse, you may find it friendlier to use the graphiql browser which is
+# available in services-internal at https://app.shopify.com/services/internal/shops/14168/graphql.
+# Check out the "Docs" tab in the top right.
+
 schema {
   query: Input
   mutation: MutationRoot
@@ -387,6 +394,11 @@ type CompanyLocation implements HasMetafields {
   The name of the company location.
   """
   name: String!
+
+  """
+  The number of orders placed at this company location.
+  """
+  orderCount: Int!
 
   """
   The date and time ([ISO 8601 format](http://en.wikipedia.org/wiki/ISO_8601))
@@ -2663,9 +2675,9 @@ type FulfillmentGroup {
   deliveryGroup: CartDeliveryGroup!
 
   """
-  The ID of the fulfillment group.
+  The fulfillment group handle.
   """
-  id: ID!
+  handle: Handle!
 
   """
   The merchandise in the fulfillment group.
@@ -2673,7 +2685,7 @@ type FulfillmentGroup {
   lines: [CartLine!]!
 
   """
-  A list of location short IDs that can fulfill items in the fulfillment group.
+  A list of location handles that can fulfill items in the fulfillment group.
   """
   locationHandles: [Handle!]!
 }
@@ -3705,9 +3717,9 @@ input LocalPickupDeliveryOption {
   cost: Decimal!
 
   """
-  The fulfillment group IDs that this delivery option is limited to. Defaults to all groups.
+  The fulfillment group handles that this delivery option is limited to. Defaults to all groups.
   """
-  fulfillmentGroupIds: [ID!]
+  fulfillmentGroupHandles: [Handle!]
 
   """
   The additional metadata associate with a delivery option.
@@ -3976,8 +3988,7 @@ The entity that manages a particular market.
 type MarketManager {
   """
   The identity of the manager. This can either be `merchant` if the market is
-  manually managed by the merchant, `shopify` if the market is automatically
-  managed by Shopify, or an ID of the app responsible for managing the market.
+  manually managed by the merchant or an ID of the app responsible for managing the market.
   """
   identifier: String!
 }
@@ -4095,7 +4106,7 @@ input Operation {
 
 input PickupLocation {
   """
-  The location short id of the pickup in-store location.
+  The location handle of the pickup in-store location.
   """
   locationHandle: Handle!
 


### PR DESCRIPTION
In this PR, I updating the function example templates for local pickup delivery option generator functions. The update consists of changing the inputs and outputs to use `FulfillmentGroup.handle` and `DeliveryOption.fulfillmentGroupHandles`.