### PR TITLE
Update `fulfillment_constraints` API schema to latest

### DIFF
--- a/order-routing/javascript/fulfillment-constraints/default/schema.graphql
+++ b/order-routing/javascript/fulfillment-constraints/default/schema.graphql
@@ -2547,11 +2547,25 @@ type Customer implements HasMetafields {
 }
 
 """
+Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date string.
+For example, September 7, 2019 is represented as `"2019-07-16"`.
+"""
+scalar Date
+
+"""
 Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date and time string.
 For example, 3:50 pm on September 7, 2019 in the time zone of UTC (Coordinated Universal Time) is
 represented as `"2019-09-07T15:50:00Z`".
 """
 scalar DateTime
+
+"""
+A subset of the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format that
+includes the date and time but not the timezone which is determined from context.
+
+For example, "2018-01-01T00:00:00".
+"""
+scalar DateTimeWithoutTimezone
 
 """
 A signed decimal number, which supports arbitrary precision and is serialized as a string.
@@ -2648,9 +2662,19 @@ type FulfillmentConstraintRule implements HasMetafields {
 }
 
 """
-The result of the function.
+The result of the function. This type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
+  """
+  The fulfillment constraints determined by the function.
+  """
+  operations: [Operation!]!
+}
+
+"""
+The result of the function.
+"""
+input FunctionRunResult {
   """
   The fulfillment constraints determined by the function.
   """
@@ -2803,6 +2827,16 @@ type Input {
     """
     names: [String!]
   ): [Location!]!
+
+  """
+  The conversion rate between the shop's currency and the currency of the cart.
+  """
+  presentmentCurrencyRate: Decimal!
+
+  """
+  Information about the shop.
+  """
+  shop: Shop!
 }
 
 """
@@ -3526,6 +3560,86 @@ enum LanguageCode {
 }
 
 """
+Represents limited information about the current time relative to the parent object.
+"""
+type LocalTime {
+  """
+  The current date relative to the parent object.
+  """
+  date: Date!
+
+  """
+  Returns true if the current date and time is at or past the given date and time, and false otherwise.
+  """
+  dateTimeAfter(
+    """
+    The date and time to compare against, assumed to be in the timezone of the parent object.
+    """
+    dateTime: DateTimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current date and time is before the given date and time, and false otherwise.
+  """
+  dateTimeBefore(
+    """
+    The date and time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    dateTime: DateTimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current date and time is between the two given date and times, and false otherwise.
+  """
+  dateTimeBetween(
+    """
+    The upper bound time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    endDateTime: DateTimeWithoutTimezone!
+
+    """
+    The lower bound time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    startDateTime: DateTimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current time is at or past the given time, and false otherwise.
+  """
+  timeAfter(
+    """
+    The time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    time: TimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current time is at or past the given time, and false otherwise.
+  """
+  timeBefore(
+    """
+    The time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    time: TimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current time is between the two given times, and false otherwise.
+  """
+  timeBetween(
+    """
+    The upper bound time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    endTime: TimeWithoutTimezone!
+
+    """
+    The lower bound time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    startTime: TimeWithoutTimezone!
+  ): Boolean!
+}
+
+"""
 Information about the localized experiences configured for the shop.
 """
 type Localization {
@@ -3615,12 +3729,12 @@ type LocationAddress {
   formatted: [String!]!
 
   """
-  The latitude coordinates of the location.
+  The approximate latitude coordinates of the location.
   """
   latitude: Float
 
   """
-  The longitude coordinates of the location.
+  The approximate longitude coordinates of the location.
   """
   longitude: Float
 
@@ -3835,7 +3949,7 @@ input MustFulfillFrom {
   """
   The IDs of the deliverable lines for which the constraint is applied.
   """
-  deliverableLineIds: [ID!]!
+  deliverableLineIds: [ID!]
 
   """
   The IDs of the locations for which the cart lines must fulfill from.
@@ -3852,7 +3966,7 @@ input MustFulfillFromSameLocation {
   """
   The IDs of the deliverable lines for which the constraint is applied.
   """
-  deliverableLineIds: [ID!]!
+  deliverableLineIds: [ID!]
 }
 
 """
@@ -3867,6 +3981,16 @@ type MutationRoot {
     The result of the Function.
     """
     result: FunctionResult!
+  ): Void! @deprecated(reason: "Use the target-specific field instead.")
+
+  """
+  Handles the Function result for the purchase.fulfillment-constraint-rule.run target.
+  """
+  run(
+    """
+    The result of the Function.
+    """
+    result: FunctionRunResult!
   ): Void!
 }
 
@@ -4131,6 +4255,38 @@ type SellingPlanAllocationPriceAdjustment {
   """
   price: MoneyV2!
 }
+
+"""
+Information about the shop.
+"""
+type Shop implements HasMetafields {
+  """
+  Information about the current time relative to the shop's timezone setting.
+  """
+  localTime: LocalTime!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    """
+    namespace: String
+  ): Metafield
+}
+
+"""
+A subset of the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format that
+includes the time but not the date or timezone which is determined from context.
+For example, "05:43:21".
+"""
+scalar TimeWithoutTimezone
 
 """
 A void type that can be used to return a null value from a mutation.

--- a/order-routing/rust/fulfillment-constraints/default/Cargo.toml.liquid
+++ b/order-routing/rust/fulfillment-constraints/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.3.0"
+shopify_function = "0.4.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/order-routing/rust/fulfillment-constraints/default/schema.graphql
+++ b/order-routing/rust/fulfillment-constraints/default/schema.graphql
@@ -2547,11 +2547,25 @@ type Customer implements HasMetafields {
 }
 
 """
+Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date string.
+For example, September 7, 2019 is represented as `"2019-07-16"`.
+"""
+scalar Date
+
+"""
 Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date and time string.
 For example, 3:50 pm on September 7, 2019 in the time zone of UTC (Coordinated Universal Time) is
 represented as `"2019-09-07T15:50:00Z`".
 """
 scalar DateTime
+
+"""
+A subset of the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format that
+includes the date and time but not the timezone which is determined from context.
+
+For example, "2018-01-01T00:00:00".
+"""
+scalar DateTimeWithoutTimezone
 
 """
 A signed decimal number, which supports arbitrary precision and is serialized as a string.
@@ -2648,9 +2662,19 @@ type FulfillmentConstraintRule implements HasMetafields {
 }
 
 """
-The result of the function.
+The result of the function. This type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
+  """
+  The fulfillment constraints determined by the function.
+  """
+  operations: [Operation!]!
+}
+
+"""
+The result of the function.
+"""
+input FunctionRunResult {
   """
   The fulfillment constraints determined by the function.
   """
@@ -2803,6 +2827,16 @@ type Input {
     """
     names: [String!]
   ): [Location!]!
+
+  """
+  The conversion rate between the shop's currency and the currency of the cart.
+  """
+  presentmentCurrencyRate: Decimal!
+
+  """
+  Information about the shop.
+  """
+  shop: Shop!
 }
 
 """
@@ -3526,6 +3560,86 @@ enum LanguageCode {
 }
 
 """
+Represents limited information about the current time relative to the parent object.
+"""
+type LocalTime {
+  """
+  The current date relative to the parent object.
+  """
+  date: Date!
+
+  """
+  Returns true if the current date and time is at or past the given date and time, and false otherwise.
+  """
+  dateTimeAfter(
+    """
+    The date and time to compare against, assumed to be in the timezone of the parent object.
+    """
+    dateTime: DateTimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current date and time is before the given date and time, and false otherwise.
+  """
+  dateTimeBefore(
+    """
+    The date and time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    dateTime: DateTimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current date and time is between the two given date and times, and false otherwise.
+  """
+  dateTimeBetween(
+    """
+    The upper bound time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    endDateTime: DateTimeWithoutTimezone!
+
+    """
+    The lower bound time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    startDateTime: DateTimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current time is at or past the given time, and false otherwise.
+  """
+  timeAfter(
+    """
+    The time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    time: TimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current time is at or past the given time, and false otherwise.
+  """
+  timeBefore(
+    """
+    The time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    time: TimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current time is between the two given times, and false otherwise.
+  """
+  timeBetween(
+    """
+    The upper bound time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    endTime: TimeWithoutTimezone!
+
+    """
+    The lower bound time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    startTime: TimeWithoutTimezone!
+  ): Boolean!
+}
+
+"""
 Information about the localized experiences configured for the shop.
 """
 type Localization {
@@ -3615,12 +3729,12 @@ type LocationAddress {
   formatted: [String!]!
 
   """
-  The latitude coordinates of the location.
+  The approximate latitude coordinates of the location.
   """
   latitude: Float
 
   """
-  The longitude coordinates of the location.
+  The approximate longitude coordinates of the location.
   """
   longitude: Float
 
@@ -3835,7 +3949,7 @@ input MustFulfillFrom {
   """
   The IDs of the deliverable lines for which the constraint is applied.
   """
-  deliverableLineIds: [ID!]!
+  deliverableLineIds: [ID!]
 
   """
   The IDs of the locations for which the cart lines must fulfill from.
@@ -3852,7 +3966,7 @@ input MustFulfillFromSameLocation {
   """
   The IDs of the deliverable lines for which the constraint is applied.
   """
-  deliverableLineIds: [ID!]!
+  deliverableLineIds: [ID!]
 }
 
 """
@@ -3867,6 +3981,16 @@ type MutationRoot {
     The result of the Function.
     """
     result: FunctionResult!
+  ): Void! @deprecated(reason: "Use the target-specific field instead.")
+
+  """
+  Handles the Function result for the purchase.fulfillment-constraint-rule.run target.
+  """
+  run(
+    """
+    The result of the Function.
+    """
+    result: FunctionRunResult!
   ): Void!
 }
 
@@ -4131,6 +4255,38 @@ type SellingPlanAllocationPriceAdjustment {
   """
   price: MoneyV2!
 }
+
+"""
+Information about the shop.
+"""
+type Shop implements HasMetafields {
+  """
+  Information about the current time relative to the shop's timezone setting.
+  """
+  localTime: LocalTime!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    """
+    namespace: String
+  ): Metafield
+}
+
+"""
+A subset of the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format that
+includes the time but not the date or timezone which is determined from context.
+For example, "05:43:21".
+"""
+scalar TimeWithoutTimezone
 
 """
 A void type that can be used to return a null value from a mutation.

--- a/order-routing/wasm/fulfillment-constraints/default/schema.graphql
+++ b/order-routing/wasm/fulfillment-constraints/default/schema.graphql
@@ -2547,11 +2547,25 @@ type Customer implements HasMetafields {
 }
 
 """
+Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date string.
+For example, September 7, 2019 is represented as `"2019-07-16"`.
+"""
+scalar Date
+
+"""
 Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date and time string.
 For example, 3:50 pm on September 7, 2019 in the time zone of UTC (Coordinated Universal Time) is
 represented as `"2019-09-07T15:50:00Z`".
 """
 scalar DateTime
+
+"""
+A subset of the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format that
+includes the date and time but not the timezone which is determined from context.
+
+For example, "2018-01-01T00:00:00".
+"""
+scalar DateTimeWithoutTimezone
 
 """
 A signed decimal number, which supports arbitrary precision and is serialized as a string.
@@ -2648,9 +2662,19 @@ type FulfillmentConstraintRule implements HasMetafields {
 }
 
 """
-The result of the function.
+The result of the function. This type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
+  """
+  The fulfillment constraints determined by the function.
+  """
+  operations: [Operation!]!
+}
+
+"""
+The result of the function.
+"""
+input FunctionRunResult {
   """
   The fulfillment constraints determined by the function.
   """
@@ -2803,6 +2827,16 @@ type Input {
     """
     names: [String!]
   ): [Location!]!
+
+  """
+  The conversion rate between the shop's currency and the currency of the cart.
+  """
+  presentmentCurrencyRate: Decimal!
+
+  """
+  Information about the shop.
+  """
+  shop: Shop!
 }
 
 """
@@ -3526,6 +3560,86 @@ enum LanguageCode {
 }
 
 """
+Represents limited information about the current time relative to the parent object.
+"""
+type LocalTime {
+  """
+  The current date relative to the parent object.
+  """
+  date: Date!
+
+  """
+  Returns true if the current date and time is at or past the given date and time, and false otherwise.
+  """
+  dateTimeAfter(
+    """
+    The date and time to compare against, assumed to be in the timezone of the parent object.
+    """
+    dateTime: DateTimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current date and time is before the given date and time, and false otherwise.
+  """
+  dateTimeBefore(
+    """
+    The date and time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    dateTime: DateTimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current date and time is between the two given date and times, and false otherwise.
+  """
+  dateTimeBetween(
+    """
+    The upper bound time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    endDateTime: DateTimeWithoutTimezone!
+
+    """
+    The lower bound time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    startDateTime: DateTimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current time is at or past the given time, and false otherwise.
+  """
+  timeAfter(
+    """
+    The time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    time: TimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current time is at or past the given time, and false otherwise.
+  """
+  timeBefore(
+    """
+    The time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    time: TimeWithoutTimezone!
+  ): Boolean!
+
+  """
+  Returns true if the current time is between the two given times, and false otherwise.
+  """
+  timeBetween(
+    """
+    The upper bound time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    endTime: TimeWithoutTimezone!
+
+    """
+    The lower bound time to compare against, assumed to be in the timezone of the parent timezone.
+    """
+    startTime: TimeWithoutTimezone!
+  ): Boolean!
+}
+
+"""
 Information about the localized experiences configured for the shop.
 """
 type Localization {
@@ -3615,12 +3729,12 @@ type LocationAddress {
   formatted: [String!]!
 
   """
-  The latitude coordinates of the location.
+  The approximate latitude coordinates of the location.
   """
   latitude: Float
 
   """
-  The longitude coordinates of the location.
+  The approximate longitude coordinates of the location.
   """
   longitude: Float
 
@@ -3835,7 +3949,7 @@ input MustFulfillFrom {
   """
   The IDs of the deliverable lines for which the constraint is applied.
   """
-  deliverableLineIds: [ID!]!
+  deliverableLineIds: [ID!]
 
   """
   The IDs of the locations for which the cart lines must fulfill from.
@@ -3852,7 +3966,7 @@ input MustFulfillFromSameLocation {
   """
   The IDs of the deliverable lines for which the constraint is applied.
   """
-  deliverableLineIds: [ID!]!
+  deliverableLineIds: [ID!]
 }
 
 """
@@ -3867,6 +3981,16 @@ type MutationRoot {
     The result of the Function.
     """
     result: FunctionResult!
+  ): Void! @deprecated(reason: "Use the target-specific field instead.")
+
+  """
+  Handles the Function result for the purchase.fulfillment-constraint-rule.run target.
+  """
+  run(
+    """
+    The result of the Function.
+    """
+    result: FunctionRunResult!
   ): Void!
 }
 
@@ -4131,6 +4255,38 @@ type SellingPlanAllocationPriceAdjustment {
   """
   price: MoneyV2!
 }
+
+"""
+Information about the shop.
+"""
+type Shop implements HasMetafields {
+  """
+  Information about the current time relative to the shop's timezone setting.
+  """
+  localTime: LocalTime!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    """
+    namespace: String
+  ): Metafield
+}
+
+"""
+A subset of the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format that
+includes the time but not the date or timezone which is determined from context.
+For example, "05:43:21".
+"""
+scalar TimeWithoutTimezone
 
 """
 A void type that can be used to return a null value from a mutation.


### PR DESCRIPTION
Updating the GraphQL schema for the `fulfillment_constraints` sample functions to use the latest.