### PR TITLE
Fixing missed argument changes post schema update for local pickup

### DIFF
--- a/order-routing/javascript/local-pickup-delivery-option-generators/default/src/index.liquid
+++ b/order-routing/javascript/local-pickup-delivery-option-generators/default/src/index.liquid
@@ -13,15 +13,13 @@ const DELIVERY_OPTION = {
   operations: [
     {
       add: {
-        fulfillmentGroupIds: ["gid://shopify/FulfillmentGroup/1"],
-        code: "pickup-1",
+        fulfillmentGroupHandles: ["gid://shopify/FulfillmentGroup/1"],
         title: "Main St.",
         cost: 1.99,
         pickupLocation: {
           locationHandle: "2578303",
           pickupInstruction: "Usually ready in 24 hours."
-        },
-        metadata: null
+        }
       }
     }
   ],

--- a/order-routing/javascript/local-pickup-delivery-option-generators/default/src/index.test.liquid
+++ b/order-routing/javascript/local-pickup-delivery-option-generators/default/src/index.test.liquid
@@ -47,15 +47,13 @@ describe('local pickup delivery option generator function', () => {
       operations: [
         {
           add: {
-            fulfillmentGroupIds: ["gid://shopify/FulfillmentGroup/1"],
-            code: "pickup-1",
+            fulfillmentGroupHandles: ["gid://shopify/FulfillmentGroup/1"],
             title: "Main St.",
             cost: 1.99,
             pickupLocation: {
               locationHandle: "2578303",
               pickupInstruction: "Usually ready in 24 hours."
             },
-            metadata: null,
           },
         },
       ]


### PR DESCRIPTION
The PR fixes the JS function example for local pickup delivery option generators. Some argument changes were missed post schema change.