### PR TITLE
version bumping validation functions api_version

### DIFF
--- a/checkout/javascript/cart-checkout-validation/default/shopify.extension.toml.liquid
+++ b/checkout/javascript/cart-checkout-validation/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2023-10"
+api_version = "2024-01"
 
 [[extensions]]
 handle = "{{handle}}"


### PR DESCRIPTION
bumping the api_version of validation functions to the latest published api version: 2024-01