### PR TITLE
Update API version for delivery customization sample

### DIFF
--- a/checkout/javascript/delivery-customization/default/schema.graphql
+++ b/checkout/javascript/delivery-customization/default/schema.graphql
@@ -4,7 +4,7 @@ schema {
 }
 
 """
-Exactly one field of input must be provided, and all others omitted.
+Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
@@ -175,7 +175,7 @@ type CartDeliveryOption {
   """
   The unique identifier of the delivery option.
   """
-  handle: String!
+  handle: Handle!
 
   """
   The title of the delivery option.
@@ -1508,7 +1508,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -2501,6 +2501,11 @@ type Customer implements HasMetafields {
   email: String
 
   """
+  The customer's first name.
+  """
+  firstName: String
+
+  """
   Whether the customer has any of the given tags.
   """
   hasAnyTag(
@@ -2524,6 +2529,11 @@ type Customer implements HasMetafields {
   A unique identifier for the customer.
   """
   id: ID!
+
+  """
+  The customer's last name.
+  """
+  lastName: String
 
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -2683,6 +2693,13 @@ input FunctionRunResult {
 }
 
 """
+A function-scoped handle to a refer a resource.
+The Handle type appears in a JSON response as a String, but it is not intended to be human-readable.
+Example value: `"10079785100"`
+"""
+scalar Handle
+
+"""
 Represents information about the metafields associated to the specified resource.
 """
 interface HasMetafields {
@@ -2724,7 +2741,7 @@ input HideOperation {
   """
   The handle of the delivery option to hide.
   """
-  deliveryOptionHandle: String!
+  deliveryOptionHandle: Handle!
 }
 
 """
@@ -3649,7 +3666,7 @@ type Market implements HasMetafields {
   """
   A human-readable unique string for the market automatically generated from its title.
   """
-  handle: String!
+  handle: Handle!
 
   """
   A globally-unique identifier.
@@ -3750,7 +3767,7 @@ input MoveOperation {
   """
   The handle of the delivery option to move.
   """
-  deliveryOptionHandle: String!
+  deliveryOptionHandle: Handle!
 
   """
   The index to move the delivery option to.
@@ -3810,7 +3827,7 @@ type Product implements HasMetafields {
   """
   A unique human-friendly string of the product's title.
   """
-  handle: String!
+  handle: Handle!
 
   """
   Whether the product has any of the given tags.
@@ -3975,7 +3992,7 @@ input RenameOperation {
   """
   The handle of the delivery option to rename.
   """
-  deliveryOptionHandle: String!
+  deliveryOptionHandle: Handle!
 
   """
   The new name for the delivery option.

--- a/checkout/javascript/delivery-customization/default/shopify.extension.toml.liquid
+++ b/checkout/javascript/delivery-customization/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2023-10"
+api_version = "2024-01"
 
 [[extensions]]
 handle = "{{handle}}"

--- a/checkout/rust/delivery-customization/default/schema.graphql
+++ b/checkout/rust/delivery-customization/default/schema.graphql
@@ -4,7 +4,7 @@ schema {
 }
 
 """
-Exactly one field of input must be provided, and all others omitted.
+Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
@@ -175,7 +175,7 @@ type CartDeliveryOption {
   """
   The unique identifier of the delivery option.
   """
-  handle: String!
+  handle: Handle!
 
   """
   The title of the delivery option.
@@ -1508,7 +1508,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -2501,6 +2501,11 @@ type Customer implements HasMetafields {
   email: String
 
   """
+  The customer's first name.
+  """
+  firstName: String
+
+  """
   Whether the customer has any of the given tags.
   """
   hasAnyTag(
@@ -2524,6 +2529,11 @@ type Customer implements HasMetafields {
   A unique identifier for the customer.
   """
   id: ID!
+
+  """
+  The customer's last name.
+  """
+  lastName: String
 
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -2683,6 +2693,13 @@ input FunctionRunResult {
 }
 
 """
+A function-scoped handle to a refer a resource.
+The Handle type appears in a JSON response as a String, but it is not intended to be human-readable.
+Example value: `"10079785100"`
+"""
+scalar Handle
+
+"""
 Represents information about the metafields associated to the specified resource.
 """
 interface HasMetafields {
@@ -2724,7 +2741,7 @@ input HideOperation {
   """
   The handle of the delivery option to hide.
   """
-  deliveryOptionHandle: String!
+  deliveryOptionHandle: Handle!
 }
 
 """
@@ -3649,7 +3666,7 @@ type Market implements HasMetafields {
   """
   A human-readable unique string for the market automatically generated from its title.
   """
-  handle: String!
+  handle: Handle!
 
   """
   A globally-unique identifier.
@@ -3750,7 +3767,7 @@ input MoveOperation {
   """
   The handle of the delivery option to move.
   """
-  deliveryOptionHandle: String!
+  deliveryOptionHandle: Handle!
 
   """
   The index to move the delivery option to.
@@ -3810,7 +3827,7 @@ type Product implements HasMetafields {
   """
   A unique human-friendly string of the product's title.
   """
-  handle: String!
+  handle: Handle!
 
   """
   Whether the product has any of the given tags.
@@ -3975,7 +3992,7 @@ input RenameOperation {
   """
   The handle of the delivery option to rename.
   """
-  deliveryOptionHandle: String!
+  deliveryOptionHandle: Handle!
 
   """
   The new name for the delivery option.

--- a/checkout/rust/delivery-customization/default/shopify.extension.toml.liquid
+++ b/checkout/rust/delivery-customization/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2023-10"
+api_version = "2024-01"
 
 [[extensions]]
 handle = "{{handle}}"

--- a/checkout/wasm/delivery-customization/default/schema.graphql
+++ b/checkout/wasm/delivery-customization/default/schema.graphql
@@ -4,7 +4,7 @@ schema {
 }
 
 """
-Exactly one field of input must be provided, and all others omitted.
+Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
@@ -175,7 +175,7 @@ type CartDeliveryOption {
   """
   The unique identifier of the delivery option.
   """
-  handle: String!
+  handle: Handle!
 
   """
   The title of the delivery option.
@@ -1508,7 +1508,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -2501,6 +2501,11 @@ type Customer implements HasMetafields {
   email: String
 
   """
+  The customer's first name.
+  """
+  firstName: String
+
+  """
   Whether the customer has any of the given tags.
   """
   hasAnyTag(
@@ -2524,6 +2529,11 @@ type Customer implements HasMetafields {
   A unique identifier for the customer.
   """
   id: ID!
+
+  """
+  The customer's last name.
+  """
+  lastName: String
 
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -2683,6 +2693,13 @@ input FunctionRunResult {
 }
 
 """
+A function-scoped handle to a refer a resource.
+The Handle type appears in a JSON response as a String, but it is not intended to be human-readable.
+Example value: `"10079785100"`
+"""
+scalar Handle
+
+"""
 Represents information about the metafields associated to the specified resource.
 """
 interface HasMetafields {
@@ -2724,7 +2741,7 @@ input HideOperation {
   """
   The handle of the delivery option to hide.
   """
-  deliveryOptionHandle: String!
+  deliveryOptionHandle: Handle!
 }
 
 """
@@ -3649,7 +3666,7 @@ type Market implements HasMetafields {
   """
   A human-readable unique string for the market automatically generated from its title.
   """
-  handle: String!
+  handle: Handle!
 
   """
   A globally-unique identifier.
@@ -3750,7 +3767,7 @@ input MoveOperation {
   """
   The handle of the delivery option to move.
   """
-  deliveryOptionHandle: String!
+  deliveryOptionHandle: Handle!
 
   """
   The index to move the delivery option to.
@@ -3810,7 +3827,7 @@ type Product implements HasMetafields {
   """
   A unique human-friendly string of the product's title.
   """
-  handle: String!
+  handle: Handle!
 
   """
   Whether the product has any of the given tags.
@@ -3975,7 +3992,7 @@ input RenameOperation {
   """
   The handle of the delivery option to rename.
   """
-  deliveryOptionHandle: String!
+  deliveryOptionHandle: Handle!
 
   """
   The new name for the delivery option.

--- a/checkout/wasm/delivery-customization/default/shopify.extension.toml.liquid
+++ b/checkout/wasm/delivery-customization/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2023-10"
+api_version = "2024-01"
 
 [[extensions]]
 handle = "{{handle}}"


### PR DESCRIPTION
Bumping the API version to 2024-01 for the delivery customization examples. I also regenerated the GraphQL schema based on the new version. Same change for all three languages (JS/Rust/WASM).

Part of fix for https://github.com/Shopify/shopify/issues/467227