### PR TITLE
Use isbot ^4.1.0

### DIFF
--- a/sample-apps/delivery-customizations/app/entry.server.jsx
+++ b/sample-apps/delivery-customizations/app/entry.server.jsx
@@ -2,7 +2,7 @@ import { PassThrough } from "stream";
 import { renderToPipeableStream } from "react-dom/server";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
-import isbot from "isbot";
+import { isbot } from "isbot";
 
 import { addDocumentResponseHeaders } from "./shopify.server";
 

--- a/sample-apps/delivery-customizations/package.json
+++ b/sample-apps/delivery-customizations/package.json
@@ -29,7 +29,7 @@
     "@shopify/shopify-app-remix": "^1.0.0",
     "@shopify/shopify-app-session-storage-prisma": "^1.0.0",
     "cross-env": "^7.0.3",
-    "isbot": "latest",
+    "isbot": "^4.1.0",
     "prisma": "^4.13.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/sample-apps/discounts/app/entry.server.jsx
+++ b/sample-apps/discounts/app/entry.server.jsx
@@ -2,7 +2,7 @@ import { PassThrough } from "stream";
 import { renderToPipeableStream } from "react-dom/server";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
-import isbot from "isbot";
+import { isbot } from "isbot";
 
 import { addDocumentResponseHeaders } from "./shopify.server";
 

--- a/sample-apps/discounts/package.json
+++ b/sample-apps/discounts/package.json
@@ -32,7 +32,7 @@
     "@shopify/shopify-app-remix": "^1.1.0",
     "@shopify/shopify-app-session-storage-prisma": "^1.0.0",
     "cross-env": "^7.0.3",
-    "isbot": "latest",
+    "isbot": "^4.1.0",
     "prisma": "^4.13.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/sample-apps/order-submission-rules/app/entry.server.jsx
+++ b/sample-apps/order-submission-rules/app/entry.server.jsx
@@ -2,7 +2,7 @@ import { PassThrough } from "stream";
 import { renderToPipeableStream } from "react-dom/server";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
-import isbot from "isbot";
+import { isbot } from "isbot";
 
 import { addDocumentResponseHeaders } from "./shopify.server";
 

--- a/sample-apps/order-submission-rules/package.json
+++ b/sample-apps/order-submission-rules/package.json
@@ -30,7 +30,7 @@
     "@shopify/shopify-app-remix": "^1.3.0",
     "@shopify/shopify-app-session-storage-prisma": "^1.1.1",
     "cross-env": "^7.0.3",
-    "isbot": "latest",
+    "isbot": "^4.1.0",
     "prisma": "^4.13.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/sample-apps/payment-customizations/app/entry.server.jsx
+++ b/sample-apps/payment-customizations/app/entry.server.jsx
@@ -2,7 +2,7 @@ import { PassThrough } from "stream";
 import { renderToPipeableStream } from "react-dom/server";
 import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
-import isbot from "isbot";
+import { isbot } from "isbot";
 
 import { addDocumentResponseHeaders } from "./shopify.server";
 

--- a/sample-apps/payment-customizations/package.json
+++ b/sample-apps/payment-customizations/package.json
@@ -29,7 +29,7 @@
     "@shopify/shopify-app-remix": "^1.0.0",
     "@shopify/shopify-app-session-storage-prisma": "^1.0.0",
     "cross-env": "^7.0.3",
-    "isbot": "latest",
+    "isbot": "^4.1.0",
     "prisma": "^4.13.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
Some sample apps were using the `latest` version of `isbot`, which recently had a breaking change in the package exports.

This PR updates the `package.json` files to reference `^4.1.0`, and it updates the `isbot` imports to work correctly on this version.