### PR TITLE
Address handle issue when extension name contains dashes

### DIFF
--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/package.json.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/package.json.liquid
@@ -1,5 +1,5 @@
 {
-  "name": "{{name | replace: " ", "-" | downcase}}",
+  "name": "{{handle}}",
   "version": "0.0.1",
   "license": "UNLICENSED",
   "scripts": {

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,24 +1,24 @@
 api_version = "unstable"
 
 [[extensions]]
-handle = "{{name | replace: " ", "-" | downcase}}"
+handle = "{{handle}}"
 name = "{{name}}"
 type = "function"
 
-[[extensions.targeting]]
-target = "purchase.pickup-point-delivery-option-generator.fetch"
-input_query = "src/fetch.graphql"
-export = "fetch"
+  [[extensions.targeting]]
+  target = "purchase.pickup-point-delivery-option-generator.fetch"
+  input_query = "src/fetch.graphql"
+  export = "fetch"
 
-[[extensions.targeting]]
-target = "purchase.pickup-point-delivery-option-generator.run"
-input_query = "src/run.graphql"
-export = "run"
+  [[extensions.targeting]]
+  target = "purchase.pickup-point-delivery-option-generator.run"
+  input_query = "src/run.graphql"
+  export = "run"
 
-[extensions.build]
-command = ""
-path = "dist/function.wasm"
+  [extensions.build]
+  command = ""
+  path = "dist/function.wasm"
 
-[extensions.ui.paths]
-create = "/"
-details = "/"
+  [extensions.ui.paths]
+  create = "/"
+  details = "/"

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/Cargo.toml.liquid
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/Cargo.toml.liquid
@@ -1,5 +1,5 @@
 [package]
-name = "{{name | replace: " ", "-" | downcase}}"
+name = "{{handle}}"
 version = "1.0.0"
 edition = "2021"
 rust-version = "1.62"

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,7 +1,7 @@
 api_version = "unstable"
 
 [[extensions]]
-handle = "{{name | replace: " ", "-" | downcase}}"
+handle = "{{handle}}"
 name = "{{name}}"
 type = "function"
 
@@ -17,7 +17,7 @@ export = "run"
 
 [extensions.build]
 command = "cargo wasi build --release"
-path = "target/wasm32-wasi/release/{{name | replace: " ", "_" | downcase}}.wasm"
+path = "target/wasm32-wasi/release/{{handle | replace: "-", "_" | downcase}}.wasm"
 watch = ["src/**/*.rs"]
 
 [extensions.ui.paths]

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/package.json.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/package.json.liquid
@@ -1,5 +1,5 @@
 {
-  "name": "{{name | replace: " ", "-" | downcase}}",
+  "name": "{{handle}}",
   "version": "0.0.1",
   "license": "UNLICENSED",
   "scripts": {

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,24 +1,24 @@
 api_version = "unstable"
 
 [[extensions]]
-handle = "{{name | replace: " ", "-" | downcase}}"
+handle = "{{handle}}"
 name = "{{name}}"
 type = "function"
 
-[[extensions.targeting]]
-target = "purchase.pickup-point-delivery-option-generator.fetch"
-input_query = "src/fetch.graphql"
-export = "fetch"
+  [[extensions.targeting]]
+  target = "purchase.pickup-point-delivery-option-generator.fetch"
+  input_query = "src/fetch.graphql"
+  export = "fetch"
 
-[[extensions.targeting]]
-target = "purchase.pickup-point-delivery-option-generator.run"
-input_query = "src/run.graphql"
-export = "run"
+  [[extensions.targeting]]
+  target = "purchase.pickup-point-delivery-option-generator.run"
+  input_query = "src/run.graphql"
+  export = "run"
 
-[extensions.build]
-command = ""
-path = "dist/function.wasm"
+  [extensions.build]
+  command = ""
+  path = "dist/function.wasm"
 
-[extensions.ui.paths]
-create = "/"
-details = "/"
+  [extensions.ui.paths]
+  create = "/"
+  details = "/"

--- a/order-routing/wasm/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/wasm/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,10 +1,23 @@
-name = "{{name}}"
-type = "function"
 api_version = "unstable"
 
-[build]
-command = "echo 'build the wasm'"
+[[extensions]]
+handle = "{{handle}}"
+name = "{{name}}"
+type = "function"
 
-[ui.paths]
-create = "/"
-details = "/"
+  [[extensions.targeting]]
+  target = "purchase.pickup-point-delivery-option-generator.fetch"
+  input_query = "src/fetch.graphql"
+  export = "fetch"
+
+  [[extensions.targeting]]
+  target = "purchase.pickup-point-delivery-option-generator.run"
+  input_query = "src/run.graphql"
+  export = "run"
+
+  [extensions.build]
+  command = "echo 'build the wasm'"
+
+  [extensions.ui.paths]
+  create = "/"
+  details = "/"


### PR DESCRIPTION
# Description

Fixes issue when extension name contains dashes (`-`) on Pickup Point Options Generator template.

Example extension name: `function-name`.

It uses the proper `handle` variable instead of manually parsing the extension name.