### PR TITLE
Update shopify_function crate to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
-
-[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,7 +16,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "shopify_function 0.3.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -33,7 +27,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -49,7 +43,7 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -60,7 +54,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -70,7 +64,7 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -80,7 +74,7 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -90,7 +84,7 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -157,7 +151,7 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -167,7 +161,7 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -177,7 +171,7 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -196,7 +190,7 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -215,7 +209,7 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -328,13 +322,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "optional-add-ons-rust"
+version = "1.0.0"
+dependencies = [
+ "graphql_client",
+ "serde",
+ "serde_json",
+ "shopify_function",
+]
+
+[[package]]
 name = "order-routing-fulfillment-constraints-default"
 version = "1.0.0"
 dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -344,7 +348,7 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -354,7 +358,17 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
+]
+
+[[package]]
+name = "order-routing-pickup-point-delivery-option-generators-default"
+version = "1.0.0"
+dependencies = [
+ "graphql_client",
+ "serde",
+ "serde_json",
+ "shopify_function",
 ]
 
 [[package]]
@@ -364,7 +378,7 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -374,7 +388,7 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -393,7 +407,7 @@ dependencies = [
  "graphql_client",
  "serde",
  "serde_json",
- "shopify_function 0.4.0",
+ "shopify_function",
 ]
 
 [[package]]
@@ -466,45 +480,21 @@ dependencies = [
 
 [[package]]
 name = "shopify_function"
-version = "0.3.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc7a71e257c107f3ded8e93626fd0aa8e16c0daecfcd20556930ec28503344d"
+checksum = "ac1bda8e334dc82f7b119e8f20696a500457f61157f6a925e0e6f1a4999bc5e3"
 dependencies = [
- "anyhow",
+ "ryu",
  "serde",
  "serde_json",
- "shopify_function_macro 0.3.0",
-]
-
-[[package]]
-name = "shopify_function"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249273a00f7ba7e5a855aa5feae26716179ee4f685c9c664636465d99acaa998"
-dependencies = [
- "anyhow",
- "serde",
- "serde_json",
- "shopify_function_macro 0.4.0",
+ "shopify_function_macro",
 ]
 
 [[package]]
 name = "shopify_function_macro"
-version = "0.3.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b3f3aa9afdba3a5f9b0066c3fd3d61d15c3230967d0c83a8c2483bc3a18453"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "shopify_function_macro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff74deb26d6ade7ea3050a37be63ecfbc275a9444a20414592e319b1cd45b7e"
+checksum = "72425c2a91f4f8e2b97905644b122f084f31106042c34e64d8bd320ed00b700c"
 dependencies = [
  "convert_case",
  "proc-macro2",

--- a/checkout/rust/cart-checkout-validation/default/Cargo.toml.liquid
+++ b/checkout/rust/cart-checkout-validation/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/checkout/rust/cart-transform/bundles/Cargo.toml.liquid
+++ b/checkout/rust/cart-transform/bundles/Cargo.toml.liquid
@@ -8,7 +8,7 @@ rust-version = "1.62"
 serde = { version = "1.0.13", features = ["derive"] }
 serde_with = "1.13.0"
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/checkout/rust/cart-transform/default/Cargo.toml.liquid
+++ b/checkout/rust/cart-transform/default/Cargo.toml.liquid
@@ -8,7 +8,7 @@ rust-version = "1.62"
 serde = { version = "1.0.13", features = ["derive"] }
 serde_with = "1.13.0"
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/checkout/rust/delivery-customization/default/Cargo.toml.liquid
+++ b/checkout/rust/delivery-customization/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/checkout/rust/order-submission-rule/default/Cargo.toml.liquid
+++ b/checkout/rust/order-submission-rule/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/checkout/rust/payment-customization/default/Cargo.toml.liquid
+++ b/checkout/rust/payment-customization/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/discounts/rust/discounts-allocator/default/Cargo.toml.liquid
+++ b/discounts/rust/discounts-allocator/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/discounts/rust/order-discounts/default/Cargo.toml.liquid
+++ b/discounts/rust/order-discounts/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/discounts/rust/product-discounts/default/Cargo.toml.liquid
+++ b/discounts/rust/product-discounts/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/discounts/rust/shipping-discounts/default/Cargo.toml.liquid
+++ b/discounts/rust/shipping-discounts/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/order-routing/rust/fulfillment-constraints/default/Cargo.toml.liquid
+++ b/order-routing/rust/fulfillment-constraints/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/order-routing/rust/local-pickup-delivery-option-generators/default/Cargo.toml.liquid
+++ b/order-routing/rust/local-pickup-delivery-option-generators/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/order-routing/rust/location-rules/default/Cargo.toml.liquid
+++ b/order-routing/rust/location-rules/default/Cargo.toml.liquid
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/Cargo.toml.liquid
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/Cargo.toml.liquid
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/src/fetch.rs
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/src/fetch.rs
@@ -9,7 +9,7 @@ fn fetch(input: fetch::input::ResponseData) -> Result<fetch::output::FunctionFet
             &delivery_address.longitude,
             &delivery_address.latitude,
         ) {
-            if *country_code == fetch::input::CountryCode::CA {
+            if country_code.as_str() == "CA" {
                 return Ok(fetch::output::FunctionFetchResult {
                     request: Some(build_external_api_request(latitude, longitude)),
                 });

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/src/run.rs
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/src/run.rs
@@ -84,16 +84,10 @@ fn build_address(external_api_delivery_point: &Value) -> Option<run::output::Pic
                 .unwrap()
                 .to_string(),
         ),
-        country_code: serde_json::from_str::<run::output::CountryCode>(
-            format!(
-                "\"{}\"",
-                external_api_delivery_point["location"]["addressComponents"]["countryCode"]
-                    .as_str()
-                    .unwrap()
-            )
-            .as_str(),
-        )
-        .unwrap(),
+        country_code: external_api_delivery_point["location"]["addressComponents"]["countryCode"]
+            .as_str()
+            .unwrap()
+            .to_string(),
         latitude: external_api_delivery_point["location"]["geometry"]["location"]["lat"]
             .as_f64()
             .unwrap_or_default(),
@@ -252,7 +246,7 @@ mod tests {
                             address2: None,
                             city: "Toronto".to_string(),
                             country: Some("Canada".to_string()),
-                            country_code: CountryCode::CA,
+                            country_code: "CA".to_string(),
                             latitude: 43.644664618786685,
                             longitude: -79.40066267417106,
                             phone: None,

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/Cargo.toml
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.62"
 serde = { version = "1.0.13", features = ["derive"] }
 serde_with = "1.13.0"
 serde_json = "1.0"
-shopify_function = "0.3.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/src/main.rs
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/src/main.rs
@@ -83,7 +83,7 @@ fn get_merge_cart_operations(cart: &Cart) -> impl Iterator<Item = CartOperation>
                     .price_adjustment
                     .map(|price_adjustment| PriceAdjustment {
                         percentage_decrease: Some(PriceAdjustmentValue {
-                            value: price_adjustment.to_string(),
+                            value: Decimal(price_adjustment),
                         }),
                     });
 
@@ -220,7 +220,7 @@ fn get_price_adjustment(
         .as_ref()
         .map(|price_adjustment| PriceAdjustment {
             percentage_decrease: Some(PriceAdjustmentValue {
-                value: price_adjustment.value.parse().unwrap(),
+                value: Decimal(price_adjustment.value.parse().unwrap()),
             }),
         })
 }

--- a/sample-apps/delivery-customizations/extensions/delivery-customization-rust/Cargo.toml
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization-rust/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/sample-apps/discounts/extensions/product-discount-rust/Cargo.toml
+++ b/sample-apps/discounts/extensions/product-discount-rust/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/Cargo.toml
+++ b/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.6.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 

--- a/sample-apps/order-submission-rules/extensions/order-submission-rule-rust/Cargo.toml
+++ b/sample-apps/order-submission-rules/extensions/order-submission-rule-rust/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]

--- a/sample-apps/payment-customizations/extensions/payment-customization-rust/Cargo.toml
+++ b/sample-apps/payment-customizations/extensions/payment-customization-rust/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.62"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "0.4.0"
+shopify_function = "0.7.0"
 graphql_client = "0.13.0"
 
 [profile.release]


### PR DESCRIPTION
- Bump all `Cargo.toml`s to use v0.7.0
- Update pickup-point-delivery-option-generators to no longer rely on generated `CountryCode` enum (we now use `String` for large enums to avoid binary bloat)
- Update cart-merge-expand_rust because the `Decimal` scalar is no longer aliased to String
- Run `cargo build` to update the top-level Cargo.lock