### PR TITLE
Make business hours optional for pickup points templates.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
       "discounts/rust/product-discounts/fixed-amount/Cargo.toml",
       "discounts/rust/shipping-discounts/default/Cargo.toml",
       "discounts/rust/shipping-discounts/fixed-amount/Cargo.toml",
-      "sample-apps/discounts/extensions/product-discount-rust/Cargo.toml"
+      "sample-apps/discounts/extensions/product-discount-rust/Cargo.toml",
+      "order-routing/rust/pickup-point-delivery-option-generators/default/Cargo.toml"
     ]
   }

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/README.md
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a function that demonstrates how to generate pickup point delivery options based on an external
 API accessible via an HTTP request. To simulate an external API, we have hosted a
-[JSON file](https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api.json?v=1706549257),
+[JSON file](https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748),
 which contains pickup point information in the following format:
 
 ```json

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/schema.graphql
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/schema.graphql
@@ -2692,29 +2692,17 @@ enum DeliveryMethod {
 }
 
 """
-The result of a pickup point delivery option generator function fetch command.
+The fetch target result. Refer to network access for Shopify Functions.
 """
 input FunctionFetchResult {
   """
-  Request.
+  HTTP Request.
   """
   request: HttpRequest
 }
 
 """
-The result of a pickup point delivery option generator function run command. In
-API versions 2023-10 and beyond, this type is deprecated in favor of
-`FunctionRunResult`.
-"""
-input FunctionResult {
-  """
-  An ordered list of operations to apply for pickup point delivery option generation.
-  """
-  operations: [Operation!]!
-}
-
-"""
-The result of a pickup point delivery option generator function run command.
+The run target result.
 """
 input FunctionRunResult {
   """
@@ -2960,7 +2948,7 @@ type Input {
   cart: Cart!
 
   """
-  The HTTP response of the HTTP request from the fetch command.
+  The result of the fetch target. Refer to network access for Shopify Functions.
   """
   fetchResult: HttpResponse @restrictTarget(only: ["purchase.pickup-point-delivery-option-generator.run"])
 
@@ -3996,16 +3984,6 @@ type MutationRoot {
   ): Void!
 
   """
-  Handles the Function result.
-  """
-  handleResult(
-    """
-    The result of the Function.
-    """
-    result: FunctionResult!
-  ): Void! @deprecated(reason: "Use the target-specific field instead.")
-
-  """
   Handles the Function result for the purchase.pickup-point-delivery-option-generator.run target.
   """
   run(
@@ -4099,7 +4077,7 @@ input PickupPoint {
   The business hours of the pickup point location. Any day that is either not
   mentioned or does not have any defined periods will be considered as closed.
   """
-  businessHours: [BusinessHours!]!
+  businessHours: [BusinessHours!]
 
   """
   The external id assigned by the provider for the pickup point delivery option.
@@ -4292,7 +4270,7 @@ The provider for a pickup point.
 """
 input Provider {
   """
-  The provider logo url. The base URL must be `https::/cdn.shopify.com`.
+  The provider logo url. The base URL must be `https://cdn.shopify.com`.
   """
   logoUrl: URL!
 

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/src/fetch.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/src/fetch.liquid
@@ -13,7 +13,7 @@ export function fetch(input) {
 
 function buildExternalApiRequest(latitude, longitude) {
     // The latitude and longitude parameters are included in the URL for demonstration purposes only. They do not influence the result.
-    let url = `https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api.json?v=1706549257&lat=${latitude}&lon=${longitude}`;
+    let url = `https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748&lat=${latitude}&lon=${longitude}`
 
     return {
         method: 'GET',

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/src/fetch.test.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/src/fetch.test.liquid
@@ -28,7 +28,7 @@ describe('fetch function', () => {
         policy: {
           readTimeoutMs: 500,
         },
-        url: 'https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api.json?v=1706549257&lat=45.6&lon=12.3',
+        url: 'https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748&lat=45.6&lon=12.3',
       }
     });
 
@@ -105,7 +105,7 @@ describe('fetch function', () => {
         policy: {
           readTimeoutMs: 500,
         },
-        url: 'https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api.json?v=1706549257&lat=45.6&lon=12.3',
+        url: 'https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748&lat=45.6&lon=12.3',
       }
     });
 

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/src/run.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/src/run.liquid
@@ -64,7 +64,11 @@ function buildAddress(externalApiDeliveryPoint) {
 // "Monday: 9:00 AM – 5:00 PM" is transformed to {day: "MONDAY", periods: [{opening_time: "09:00:00", closing_time: "17:00:00"}]}
 // "Tuesday: Closed" is transformed to {day: "TUESDAY", periods: []}
 function buildBusinessHours(externalApiDeliveryPoint) {
-    return externalApiDeliveryPoint.openingHours.weekdayText
+    if(!externalApiDeliveryPoint.openingHours) {
+        return null;
+    }
+
+   return externalApiDeliveryPoint.openingHours.weekdayText
         .map(day => {
             let dayParts = day.split(": ");
             let dayName = dayParts[0].toUpperCase();

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/src/run.test.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/src/run.test.liquid
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { run } from './run';
 
+
 describe('run function', () => {
   it('returns operations when fetch result is successful', () => {
     const result = run({
@@ -98,6 +99,74 @@ describe('run function', () => {
     const expected = {
       operations: []
     }
+
+    expect(result).toEqual(expected);
+  });
+
+  it("returns an add operation with null pickup point business hours when the external API's delivery point has null opening hours", () => {
+    const result = run({
+      fetchResult: {
+        status: 200,
+        body: JSON.stringify({
+          deliveryPoints: [
+            {
+              location: {
+                addressComponents: {
+                  country: 'Canada',
+                  countryCode: 'CA',
+                  streetNumber: '123',
+                  route: 'Main St',
+                  locality: 'Toronto',
+                  administrativeAreaLevel1: 'ON',
+                  postalCode: 'M5V 2T6',
+                },
+                geometry: {
+                  location: {
+                    lat: 43.70,
+                    lng: -79.42,
+                  },
+                },
+              },
+              openingHours: null,
+              pointId: '1',
+              pointName: 'Point 1',
+            },
+          ],
+        }),
+      },
+    });
+
+    const expected = {
+      operations: [
+        {
+          add: {
+            cost: null,
+            pickupPoint: {
+              address: {
+                address1: '123 Main St',
+                address2: null,
+                city: 'Toronto',
+                country: 'Canada',
+                countryCode: 'CA',
+                latitude: 43.70,
+                longitude: -79.42,
+                phone: null,
+                province: 'ON',
+                provinceCode: null,
+                zip: 'M5V 2T6',
+              },
+              businessHours: null,
+              provider: {
+                name: 'Shopify Javascript Demo',
+                logoUrl: 'https://cdn.shopify.com/s/files/1/0628/3830/9033/files/shopify_icon_146101.png?v=1706120545',
+              },
+              externalId: '1',
+              name: 'Point 1',
+            },
+          },
+        },
+      ],
+    };
 
     expect(result).toEqual(expected);
   });

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/README.md
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a function that demonstrates how to generate pickup point delivery options based on an external
 API accessible via an HTTP request. To simulate an external API, we have hosted a
-[JSON file](https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api.json?v=1706549257),
+[JSON file](https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748),
 which contains pickup point information in the following format:
 
 ```json

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/schema.graphql
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/schema.graphql
@@ -2692,29 +2692,17 @@ enum DeliveryMethod {
 }
 
 """
-The result of a pickup point delivery option generator function fetch command.
+The fetch target result. Refer to network access for Shopify Functions.
 """
 input FunctionFetchResult {
   """
-  Request.
+  HTTP Request.
   """
   request: HttpRequest
 }
 
 """
-The result of a pickup point delivery option generator function run command. In
-API versions 2023-10 and beyond, this type is deprecated in favor of
-`FunctionRunResult`.
-"""
-input FunctionResult {
-  """
-  An ordered list of operations to apply for pickup point delivery option generation.
-  """
-  operations: [Operation!]!
-}
-
-"""
-The result of a pickup point delivery option generator function run command.
+The run target result.
 """
 input FunctionRunResult {
   """
@@ -2960,7 +2948,7 @@ type Input {
   cart: Cart!
 
   """
-  The HTTP response of the HTTP request from the fetch command.
+  The result of the fetch target. Refer to network access for Shopify Functions.
   """
   fetchResult: HttpResponse @restrictTarget(only: ["purchase.pickup-point-delivery-option-generator.run"])
 
@@ -3996,16 +3984,6 @@ type MutationRoot {
   ): Void!
 
   """
-  Handles the Function result.
-  """
-  handleResult(
-    """
-    The result of the Function.
-    """
-    result: FunctionResult!
-  ): Void! @deprecated(reason: "Use the target-specific field instead.")
-
-  """
   Handles the Function result for the purchase.pickup-point-delivery-option-generator.run target.
   """
   run(
@@ -4099,7 +4077,7 @@ input PickupPoint {
   The business hours of the pickup point location. Any day that is either not
   mentioned or does not have any defined periods will be considered as closed.
   """
-  businessHours: [BusinessHours!]!
+  businessHours: [BusinessHours!]
 
   """
   The external id assigned by the provider for the pickup point delivery option.
@@ -4292,7 +4270,7 @@ The provider for a pickup point.
 """
 input Provider {
   """
-  The provider logo url. The base URL must be `https::/cdn.shopify.com`.
+  The provider logo url. The base URL must be `https://cdn.shopify.com`.
   """
   logoUrl: URL!
 

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/src/fetch.rs
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/src/fetch.rs
@@ -23,7 +23,7 @@ fn fetch(input: fetch::input::ResponseData) -> Result<fetch::output::FunctionFet
 fn build_external_api_request(latitude: &f64, longitude: &f64) -> fetch::output::HttpRequest {
     // The latitude and longitude parameters are included in the URL for demonstration purposes only. They do not influence the result.
     let url = format!(
-        "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api.json?v=1706549257&lat={}&lon={}",
+        "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748&lat={}&lon={}",
         latitude, longitude
     );
 
@@ -89,7 +89,7 @@ mod tests {
         let expected = FunctionFetchResult {
             request: Some(HttpRequest {
                 method: HttpRequestMethod::GET,
-                url: "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api.json?v=1706549257&lat=-79.42&lon=43.7".to_string(),
+                url: "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748&lat=-79.42&lon=43.7".to_string(),
 
                 headers: vec![
                     HttpRequestHeader {
@@ -192,7 +192,7 @@ mod tests {
         let expected = FunctionFetchResult {
             request: Some(HttpRequest {
                 method: HttpRequestMethod::GET,
-                url: "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api.json?v=1706549257&lat=-79.42&lon=43.7".to_string(),
+                url: "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748&lat=-79.42&lon=43.7".to_string(),
 
                 headers: vec![
                     HttpRequestHeader {

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/README.md
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a function that demonstrates how to generate pickup point delivery options based on an external
 API accessible via an HTTP request. To simulate an external API, we have hosted a
-[JSON file](https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api.json?v=1706549257),
+[JSON file](https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748),
 which contains pickup point information in the following format:
 
 ```json

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/schema.graphql
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/schema.graphql
@@ -2692,29 +2692,17 @@ enum DeliveryMethod {
 }
 
 """
-The result of a pickup point delivery option generator function fetch command.
+The fetch target result. Refer to network access for Shopify Functions.
 """
 input FunctionFetchResult {
   """
-  Request.
+  HTTP Request.
   """
   request: HttpRequest
 }
 
 """
-The result of a pickup point delivery option generator function run command. In
-API versions 2023-10 and beyond, this type is deprecated in favor of
-`FunctionRunResult`.
-"""
-input FunctionResult {
-  """
-  An ordered list of operations to apply for pickup point delivery option generation.
-  """
-  operations: [Operation!]!
-}
-
-"""
-The result of a pickup point delivery option generator function run command.
+The run target result.
 """
 input FunctionRunResult {
   """
@@ -2960,7 +2948,7 @@ type Input {
   cart: Cart!
 
   """
-  The HTTP response of the HTTP request from the fetch command.
+  The result of the fetch target. Refer to network access for Shopify Functions.
   """
   fetchResult: HttpResponse @restrictTarget(only: ["purchase.pickup-point-delivery-option-generator.run"])
 
@@ -3996,16 +3984,6 @@ type MutationRoot {
   ): Void!
 
   """
-  Handles the Function result.
-  """
-  handleResult(
-    """
-    The result of the Function.
-    """
-    result: FunctionResult!
-  ): Void! @deprecated(reason: "Use the target-specific field instead.")
-
-  """
   Handles the Function result for the purchase.pickup-point-delivery-option-generator.run target.
   """
   run(
@@ -4099,7 +4077,7 @@ input PickupPoint {
   The business hours of the pickup point location. Any day that is either not
   mentioned or does not have any defined periods will be considered as closed.
   """
-  businessHours: [BusinessHours!]!
+  businessHours: [BusinessHours!]
 
   """
   The external id assigned by the provider for the pickup point delivery option.
@@ -4292,7 +4270,7 @@ The provider for a pickup point.
 """
 input Provider {
   """
-  The provider logo url. The base URL must be `https::/cdn.shopify.com`.
+  The provider logo url. The base URL must be `https://cdn.shopify.com`.
   """
   logoUrl: URL!
 

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/src/fetch.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/src/fetch.liquid
@@ -24,7 +24,7 @@ export function fetch(input: FetchInput): FunctionFetchResult {
 
 function buildExternalApiRequest(latitude: number, longitude: number): HttpRequest {
     // The latitude and longitude parameters are included in the URL for demonstration purposes only. They do not influence the result.
-    let url = `https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api.json?v=1706549257&lat=${latitude}&lon=${longitude}`;
+    let url = `https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748&lat=${latitude}&lon=${longitude}`;
 
     return {
         method: HttpRequestMethod.Get,

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/src/fetch.test.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/src/fetch.test.liquid
@@ -26,7 +26,7 @@ describe('fetch function', () => {
         policy: {
           readTimeoutMs: 500,
         },
-        url: 'https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api.json?v=1706549257&lat=45.6&lon=12.3',
+        url: 'https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748&lat=45.6&lon=12.3',
       }
     });
 
@@ -103,7 +103,7 @@ describe('fetch function', () => {
         policy: {
           readTimeoutMs: 500,
         },
-        url: 'https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api.json?v=1706549257&lat=45.6&lon=12.3',
+        url: 'https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748&lat=45.6&lon=12.3',
       }
     });
 

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/src/run.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/src/run.liquid
@@ -73,7 +73,11 @@ function buildAddress(externalApiDeliveryPoint: any): PickupAddress {
 // Each day's opening hours are represented using a `BusinessHours` object as follows:
 // "Monday: 9:00 AM – 5:00 PM" is transformed to {day: "MONDAY", periods: [{opening_time: "09:00:00", closing_time: "17:00:00"}]}
 // "Tuesday: Closed" is transformed to {day: "TUESDAY", periods: []}
-function buildBusinessHours(externalApiDeliveryPoint: any): BusinessHours[] {
+function buildBusinessHours(externalApiDeliveryPoint: any): BusinessHours[] | null {
+    if(!externalApiDeliveryPoint.openingHours){
+        return null;
+    }
+
     return externalApiDeliveryPoint.openingHours.weekdayText
         .map((dayOpeningHours: string) => {
             let dayOpeningHoursParts = dayOpeningHours.split(": ");

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/src/run.test.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/src/run.test.liquid
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { run } from './run';
 import { CountryCode, FunctionRunResult, Weekday } from '../generated/api';
 
+
 describe('run function', () => {
   it('returns operations when fetch result is successful', () => {
     const result = run({
@@ -99,6 +100,74 @@ describe('run function', () => {
     const expected: FunctionRunResult = {
       operations: []
     }
+
+    expect(result).toEqual(expected);
+  });
+
+  it("returns an add operation with null pickup point business hours when the external API's delivery point has null opening hours", () => {
+    const result = run({
+      fetchResult: {
+        status: 200,
+        body: JSON.stringify({
+          deliveryPoints: [
+            {
+              location: {
+                addressComponents: {
+                  country: 'Canada',
+                  countryCode: 'CA',
+                  streetNumber: '123',
+                  route: 'Main St',
+                  locality: 'Toronto',
+                  administrativeAreaLevel1: 'ON',
+                  postalCode: 'M5V 2T6',
+                },
+                geometry: {
+                  location: {
+                    lat: 43.70,
+                    lng: -79.42,
+                  },
+                },
+              },
+              openingHours: null,
+              pointId: '1',
+              pointName: 'Point 1',
+            },
+          ],
+        }),
+      },
+    });
+
+    const expected: FunctionRunResult = {
+      operations: [
+        {
+          add: {
+            cost: null,
+            pickupPoint: {
+              address: {
+                address1: '123 Main St',
+                address2: null,
+                city: 'Toronto',
+                country: 'Canada',
+                countryCode: CountryCode.Ca,
+                latitude: 43.70,
+                longitude: -79.42,
+                phone: null,
+                province: 'ON',
+                provinceCode: null,
+                zip: 'M5V 2T6',
+              },
+              businessHours: null,
+              provider: {
+                name: 'Shopify TypeScript Demo',
+                logoUrl: 'https://cdn.shopify.com/s/files/1/0628/3830/9033/files/shopify_icon_146101.png?v=1706120545',
+              },
+              externalId: '1',
+              name: 'Point 1',
+            },
+          },
+        },
+      ],
+    };
 
     expect(result).toEqual(expected);
   });

--- a/order-routing/wasm/pickup-point-delivery-option-generators/default/schema.graphql
+++ b/order-routing/wasm/pickup-point-delivery-option-generators/default/schema.graphql
@@ -2692,29 +2692,17 @@ enum DeliveryMethod {
 }
 
 """
-The result of a pickup point delivery option generator function fetch command.
+The fetch target result. Refer to network access for Shopify Functions.
 """
 input FunctionFetchResult {
   """
-  Request.
+  HTTP Request.
   """
   request: HttpRequest
 }
 
 """
-The result of a pickup point delivery option generator function run command. In
-API versions 2023-10 and beyond, this type is deprecated in favor of
-`FunctionRunResult`.
-"""
-input FunctionResult {
-  """
-  An ordered list of operations to apply for pickup point delivery option generation.
-  """
-  operations: [Operation!]!
-}
-
-"""
-The result of a pickup point delivery option generator function run command.
+The run target result.
 """
 input FunctionRunResult {
   """
@@ -2960,7 +2948,7 @@ type Input {
   cart: Cart!
 
   """
-  The HTTP response of the HTTP request from the fetch command.
+  The result of the fetch target. Refer to network access for Shopify Functions.
   """
   fetchResult: HttpResponse @restrictTarget(only: ["purchase.pickup-point-delivery-option-generator.run"])
 
@@ -3996,16 +3984,6 @@ type MutationRoot {
   ): Void!
 
   """
-  Handles the Function result.
-  """
-  handleResult(
-    """
-    The result of the Function.
-    """
-    result: FunctionResult!
-  ): Void! @deprecated(reason: "Use the target-specific field instead.")
-
-  """
   Handles the Function result for the purchase.pickup-point-delivery-option-generator.run target.
   """
   run(
@@ -4099,7 +4077,7 @@ input PickupPoint {
   The business hours of the pickup point location. Any day that is either not
   mentioned or does not have any defined periods will be considered as closed.
   """
-  businessHours: [BusinessHours!]!
+  businessHours: [BusinessHours!]
 
   """
   The external id assigned by the provider for the pickup point delivery option.
@@ -4292,7 +4270,7 @@ The provider for a pickup point.
 """
 input Provider {
   """
-  The provider logo url. The base URL must be `https::/cdn.shopify.com`.
+  The provider logo url. The base URL must be `https://cdn.shopify.com`.
   """
   logoUrl: URL!
 


### PR DESCRIPTION
Resolves: https://github.com/Shopify/shopify/issues/496756
Tophatted on CLI using: https://github.com/Shopify/function-examples-tophat/pull/12
Reference tophat result: https://github.com/Shopify/function-examples-tophat/pull/12#issuecomment-2050288746

Make `business_hours` an optional field on all pickup point extension templates.