### PR TITLE
deprecate `allocations` on pickup point functions template.

### DIFF
--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/README.md
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/README.md
@@ -66,15 +66,11 @@ the [schema](./schema.graphql).
 
 ```json
 {
-  "allocations": [
-    {
-      "deliveryAddress": {
-        "countryCode": "CA",
-        "longitude": 43.70,
-        "latitude": -79.42
-      }
-    }
-  ]
+  "deliveryAddres": {
+    "countryCode": "CA",
+    "longitude": 43.70,
+    "latitude": -79.42
+  }
 }
 ```
 

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/schema.graphql
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/schema.graphql
@@ -2940,12 +2940,17 @@ type Input {
   """
   A list of allocations.
   """
-  allocations: [Allocation!]!
+  allocations: [Allocation!]! @deprecated(reason: "Use `deliveryAddress` instead.")
 
   """
   The cart.
   """
   cart: Cart!
+
+  """
+  The delivery address for pickup point delivery option.
+  """
+  deliveryAddress: MailingAddress!
 
   """
   The result of the fetch target. Refer to network access for Shopify Functions.
@@ -4303,7 +4308,7 @@ type PurchasingCompany {
 """
 Represents how products and variants can be sold and purchased.
 """
-type SellingPlan {
+type SellingPlan implements HasMetafields {
   """
   The description of the selling plan.
   """
@@ -4313,6 +4318,21 @@ type SellingPlan {
   A globally-unique identifier.
   """
   id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    """
+    namespace: String
+  ): Metafield
 
   """
   The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/src/fetch.graphql
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/src/fetch.graphql
@@ -1,9 +1,7 @@
 query FetchInput {
-  allocations {
-    deliveryAddress {
-      countryCode
-      longitude
-      latitude
-    }
+  deliveryAddress{
+    countryCode
+    longitude
+    latitude
   }
 }

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/src/fetch.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/src/fetch.liquid
@@ -1,12 +1,9 @@
 export function fetch(input) {
-    let deliveryAddress = getUniformDeliveryAddress(input.allocations);
-    if (deliveryAddress) {
-        let { countryCode, longitude, latitude } = deliveryAddress;
-        if (longitude && latitude && countryCode === 'CA') {
-            return {
-                request: buildExternalApiRequest(latitude, longitude),
-            };
-        }
+    let { countryCode, longitude, latitude } = input.deliveryAddress;
+    if (longitude && latitude && countryCode === 'CA') {
+        return {
+            request: buildExternalApiRequest(latitude, longitude),
+        };
     }
     return { request: null };
 }
@@ -27,27 +24,4 @@ function buildExternalApiRequest(latitude, longitude) {
             readTimeoutMs: 500,
         },
     };
-}
-
-function getUniformDeliveryAddress(allocations) {
-    if (allocations.length === 0) {
-        return null;
-    }
-
-    let deliveryAddress = allocations[0].deliveryAddress;
-
-    for (let i = 1; i < allocations.length; i++) {
-        if (!isDeliveryAddressEqual(allocations[i].deliveryAddress, deliveryAddress)) {
-            console.error("Allocations pointing to different delivery addresses are not supported.");
-            return null;
-        }
-    }
-
-    return deliveryAddress;
-}
-
-function isDeliveryAddressEqual(address1, address2) {
-    return address1.countryCode === address2.countryCode &&
-        address1.longitude === address2.longitude &&
-        address1.latitude === address2.latitude;
 }

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/src/fetch.test.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/src/fetch.test.liquid
@@ -8,15 +8,11 @@ import { fetch } from './fetch';
 describe('fetch function', () => {
   it('returns a request when country is Canada', () => {
     const result = fetch({
-      allocations: [
-        {
-          deliveryAddress: {
-            countryCode: 'CA',
-            longitude: 12.3,
-            latitude: 45.6,
-          }
-        }
-      ]
+      deliveryAddress: {
+        countryCode: 'CA',
+        longitude: 12.3,
+        latitude: 45.6,
+      }
     });
     const expected = ({
       request: {
@@ -37,77 +33,13 @@ describe('fetch function', () => {
 
   it('returns no request when country is not Canada', () => {
     const result = fetch({
-      allocations: [
-        {
-          deliveryAddress: {
-            countryCode: 'US',
-            longitude: 12.3,
-            latitude: 45.6,
-          }
-        }
-      ]
-    });
-    const expected = ({ request: null });
-
-    expect(result).toEqual(expected);
-  });
-
-  it('returns no request when allocations have different addresses', () => {
-    const result = fetch({
-      allocations: [
-        {
-          deliveryAddress: {
-            countryCode: 'CA',
-            longitude: 12.3,
-            latitude: 45.6,
-          }
-        },
-        {
-          deliveryAddress: {
-            countryCode: 'CA',
-            longitude: 78.9,
-            latitude: 10.1,
-          }
-        }
-      ]
-    });
-    const expected = ({ request: null });
-
-    expect(result).toEqual(expected);
-  });
-
-  it('returns a request when allocations have the same address', () => {
-    const result = fetch({
-      allocations: [
-        {
-          deliveryAddress: {
-            countryCode: 'CA',
-            longitude: 12.3,
-            latitude: 45.6,
-          }
-        },
-        {
-          deliveryAddress: {
-            countryCode: 'CA',
-            longitude: 12.3,
-            latitude: 45.6,
-          }
-        }
-      ]
-    });
-    const expected = ({
-      request: {
-        body: null,
-        headers: [
-          { name: "Accept", value: "application/json; charset=utf-8" },
-        ],
-        method: 'GET',
-        policy: {
-          readTimeoutMs: 500,
-        },
-        url: 'https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748&lat=45.6&lon=12.3',
+      deliveryAddress: {
+        countryCode: 'US',
+        longitude: 12.3,
+        latitude: 45.6,
       }
     });
+    const expected = ({ request: null });
 
     expect(result).toEqual(expected);
   });

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/README.md
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/README.md
@@ -66,15 +66,11 @@ the [schema](./schema.graphql).
 
 ```json
 {
-  "allocations": [
-    {
-      "deliveryAddress": {
-        "countryCode": "CA",
-        "longitude": 43.70,
-        "latitude": -79.42
-      }
-    }
-  ]
+  "deliveryAddress": {
+    "countryCode": "CA",
+    "longitude": 43.70,
+    "latitude": -79.42
+  }
 }
 ```
 

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/schema.graphql
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/schema.graphql
@@ -2940,12 +2940,17 @@ type Input {
   """
   A list of allocations.
   """
-  allocations: [Allocation!]!
+  allocations: [Allocation!]! @deprecated(reason: "Use `deliveryAddress` instead.")
 
   """
   The cart.
   """
   cart: Cart!
+
+  """
+  The delivery address for pickup point delivery option.
+  """
+  deliveryAddress: MailingAddress!
 
   """
   The result of the fetch target. Refer to network access for Shopify Functions.
@@ -4303,7 +4308,7 @@ type PurchasingCompany {
 """
 Represents how products and variants can be sold and purchased.
 """
-type SellingPlan {
+type SellingPlan implements HasMetafields {
   """
   The description of the selling plan.
   """
@@ -4313,6 +4318,21 @@ type SellingPlan {
   A globally-unique identifier.
   """
   id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    """
+    namespace: String
+  ): Metafield
 
   """
   The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/src/fetch.graphql
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/src/fetch.graphql
@@ -1,9 +1,7 @@
 query Input {
-  allocations {
-    deliveryAddress {
-      countryCode
-      longitude
-      latitude
-    }
+  deliveryAddress{
+    countryCode
+    longitude
+    latitude
   }
 }

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/src/fetch.rs
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/src/fetch.rs
@@ -3,17 +3,16 @@ use shopify_function::Result;
 
 #[shopify_function_target(query_path = "src/fetch.graphql", schema_path = "schema.graphql")]
 fn fetch(input: fetch::input::ResponseData) -> Result<fetch::output::FunctionFetchResult> {
-    if let Some(delivery_address) = get_uniform_delivery_address(&input.allocations) {
-        if let (Some(country_code), Some(longitude), Some(latitude)) = (
-            &delivery_address.country_code,
-            &delivery_address.longitude,
-            &delivery_address.latitude,
-        ) {
-            if country_code.as_str() == "CA" {
-                return Ok(fetch::output::FunctionFetchResult {
-                    request: Some(build_external_api_request(latitude, longitude)),
-                });
-            }
+    let delivery_address = &input.delivery_address;
+    if let (Some(country_code), Some(longitude), Some(latitude)) = (
+        &delivery_address.country_code,
+        &delivery_address.longitude,
+        &delivery_address.latitude,
+    ) {
+        if country_code.as_str() == "CA" {
+            return Ok(fetch::output::FunctionFetchResult {
+                request: Some(build_external_api_request(latitude, longitude)),
+            });
         }
     }
 
@@ -41,25 +40,6 @@ fn build_external_api_request(latitude: &f64, longitude: &f64) -> fetch::output:
     }
 }
 
-fn get_uniform_delivery_address(
-    allocations: &[fetch::input::InputAllocations],
-) -> Option<&fetch::input::InputAllocationsDeliveryAddress> {
-    if allocations.is_empty() {
-        return None;
-    }
-
-    let delivery_address = &allocations[0].delivery_address;
-
-    for allocation in allocations.iter().skip(1) {
-        if &allocation.delivery_address != delivery_address {
-            eprintln!("Allocations pointing to different delivery addresses are not supported.");
-            return None;
-        }
-    }
-
-    Some(delivery_address)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -73,15 +53,11 @@ mod tests {
             fetch,
             r#"
                 {
-                    "allocations": [
-                        {
-                            "deliveryAddress": {
-                                "countryCode": "CA",
-                                "longitude": 43.70,
-                                "latitude": -79.42
-                            }
-                        }
-                    ]
+                    "deliveryAddress": {
+                        "countryCode": "CA",
+                        "longitude": 43.70,
+                        "latitude": -79.42
+                    }
                 }
             "#,
         )?;
@@ -114,100 +90,16 @@ mod tests {
             fetch,
             r#"
                 {
-                    "allocations": [
-                        {
-                            "deliveryAddress": {
-                                "countryCode": "US",
-                                "longitude": 40.71,
-                                "latitude": -74.01
-                            }
-                        }
-                    ]
+                    "deliveryAddress": {
+                        "countryCode": "US",
+                        "longitude": 40.71,
+                        "latitude": -74.01
+                    }
                 }
             "#,
         )?;
 
         assert!(result.request.is_none());
-        Ok(())
-    }
-
-    #[test]
-    fn test_fetch_returns_no_request_when_allocations_have_different_addresses() -> Result<()> {
-        let result = run_function_with_input(
-            fetch,
-            r#"
-                {
-                    "allocations": [
-                        {
-                            "deliveryAddress": {
-                                "countryCode": "CA",
-                                "longitude": 43.70,
-                                "latitude": -79.42
-                            }
-                        },
-                        {
-                            "deliveryAddress": {
-                                "countryCode": "CA",
-                                "longitude": 44.70,
-                                "latitude": -80.42
-                            }
-                        }
-                    ]
-                }
-            "#,
-        )?;
-
-        assert!(result.request.is_none());
-        Ok(())
-    }
-
-    #[test]
-    fn test_fetch_returns_request_when_allocations_have_same_address() -> Result<()> {
-        use fetch::output::*;
-
-        let result = run_function_with_input(
-            fetch,
-            r#"
-                {
-                    "allocations": [
-                        {
-                            "deliveryAddress": {
-                                "countryCode": "CA",
-                                "longitude": 43.70,
-                                "latitude": -79.42
-                            }
-                        },
-                        {
-                            "deliveryAddress": {
-                                "countryCode": "CA",
-                                "longitude": 43.70,
-                                "latitude": -79.42
-                            }
-                        }
-                    ]
-                }
-            "#,
-        )?;
-
-        let expected = FunctionFetchResult {
-            request: Some(HttpRequest {
-                method: HttpRequestMethod::GET,
-                url: "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748&lat=-79.42&lon=43.7".to_string(),
-
-                headers: vec![
-                    HttpRequestHeader {
-                        name: "Accept".to_string(),
-                        value: "application/json; charset=utf-8".to_string(),
-                    },
-                ],
-                body: None,
-                policy: HttpRequestPolicy {
-                    read_timeout_ms: 500,
-                },
-            }),
-        };
-
-        assert_eq!(result, expected);
         Ok(())
     }
 }

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/README.md
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/README.md
@@ -66,15 +66,11 @@ the [schema](./schema.graphql).
 
 ```json
 {
-  "allocations": [
-    {
-      "deliveryAddress": {
-        "countryCode": "CA",
-        "longitude": 43.70,
-        "latitude": -79.42
-      }
-    }
-  ]
+  "deliveryAddress": {
+    "countryCode": "CA",
+    "longitude": 43.70,
+    "latitude": -79.42
+  }
 }
 ```
 

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/schema.graphql
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/schema.graphql
@@ -2940,12 +2940,17 @@ type Input {
   """
   A list of allocations.
   """
-  allocations: [Allocation!]!
+  allocations: [Allocation!]! @deprecated(reason: "Use `deliveryAddress` instead.")
 
   """
   The cart.
   """
   cart: Cart!
+
+  """
+  The delivery address for pickup point delivery option.
+  """
+  deliveryAddress: MailingAddress!
 
   """
   The result of the fetch target. Refer to network access for Shopify Functions.
@@ -4303,7 +4308,7 @@ type PurchasingCompany {
 """
 Represents how products and variants can be sold and purchased.
 """
-type SellingPlan {
+type SellingPlan implements HasMetafields {
   """
   The description of the selling plan.
   """
@@ -4313,6 +4318,21 @@ type SellingPlan {
   A globally-unique identifier.
   """
   id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    """
+    namespace: String
+  ): Metafield
 
   """
   The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/src/fetch.graphql
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/src/fetch.graphql
@@ -1,9 +1,7 @@
 query FetchInput {
-  allocations {
-    deliveryAddress {
-      countryCode
-      longitude
-      latitude
-    }
+  deliveryAddress {
+    countryCode
+    longitude
+    latitude
   }
 }

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/src/fetch.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/src/fetch.liquid
@@ -10,14 +10,11 @@ import {
 } from '../generated/api';
 
 export function fetch(input: FetchInput): FunctionFetchResult {
-    let deliveryAddress = getUniformDeliveryAddress(input.allocations);
-    if (deliveryAddress) {
-        let { countryCode, longitude, latitude } = deliveryAddress;
-        if (longitude && latitude && countryCode === CountryCode.Ca) {
-            return {
-                request: buildExternalApiRequest(latitude, longitude),
-            };
-        }
+    let { countryCode, longitude, latitude } = input.deliveryAddress;
+    if (longitude && latitude && countryCode === CountryCode.Ca) {
+        return {
+            request: buildExternalApiRequest(latitude, longitude),
+        };
     }
     return { request: null };
 }
@@ -38,27 +35,4 @@ function buildExternalApiRequest(latitude: number, longitude: number): HttpReque
             readTimeoutMs: 500,
         },
     };
-}
-
-function getUniformDeliveryAddress(allocations: Allocation[]): Maybe<MailingAddress> {
-    if (allocations.length === 0) {
-        return null;
-    }
-
-    let deliveryAddress = allocations[0].deliveryAddress;
-
-    for (let i = 1; i < allocations.length; i++) {
-        if (!isDeliveryAddressEqual(allocations[i].deliveryAddress, deliveryAddress)) {
-            console.error("Allocations pointing to different delivery addresses are not supported.");
-            return null;
-        }
-    }
-
-    return deliveryAddress;
-}
-
-function isDeliveryAddressEqual(address1: MailingAddress, address2: MailingAddress): boolean {
-    return address1.countryCode === address2.countryCode &&
-        address1.longitude === address2.longitude &&
-        address1.latitude === address2.latitude;
 }

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/src/fetch.test.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/src/fetch.test.liquid
@@ -6,15 +6,11 @@ import { CountryCode, FunctionFetchResult, HttpRequestMethod } from '../generate
 describe('fetch function', () => {
   it('returns a request when country is Canada', () => {
     const result = fetch({
-      allocations: [
-        {
-          deliveryAddress: {
-            countryCode: CountryCode.Ca,
-            longitude: 12.3,
-            latitude: 45.6,
-          }
-        }
-      ]
+      deliveryAddress: {
+        countryCode: CountryCode.Ca,
+        longitude: 12.3,
+        latitude: 45.6,
+      }
     });
     const expected: FunctionFetchResult = ({
       request: {
@@ -35,77 +31,13 @@ describe('fetch function', () => {
 
   it('returns no request when country is not Canada', () => {
     const result = fetch({
-      allocations: [
-        {
-          deliveryAddress: {
-            countryCode: CountryCode.Us,
-            longitude: 12.3,
-            latitude: 45.6,
-          }
-        }
-      ]
-    });
-    const expected: FunctionFetchResult = ({ request: null });
-
-    expect(result).toEqual(expected);
-  });
-
-  it('returns no request when allocations have different addresses', () => {
-    const result = fetch({
-      allocations: [
-        {
-          deliveryAddress: {
-            countryCode: CountryCode.Ca,
-            longitude: 12.3,
-            latitude: 45.6,
-          }
-        },
-        {
-          deliveryAddress: {
-            countryCode: CountryCode.Ca,
-            longitude: 78.9,
-            latitude: 10.1,
-          }
-        }
-      ]
-    });
-    const expected: FunctionFetchResult = ({ request: null });
-
-    expect(result).toEqual(expected);
-  });
-
-  it('returns a request when allocations have the same address', () => {
-    const result = fetch({
-      allocations: [
-        {
-          deliveryAddress: {
-            countryCode: CountryCode.Ca,
-            longitude: 12.3,
-            latitude: 45.6,
-          }
-        },
-        {
-          deliveryAddress: {
-            countryCode: CountryCode.Ca,
-            longitude: 12.3,
-            latitude: 45.6,
-          }
-        }
-      ]
-    });
-    const expected: FunctionFetchResult = ({
-      request: {
-        body: null,
-        headers: [
-          { name: "Accept", value: "application/json; charset=utf-8" },
-        ],
-        method: HttpRequestMethod.Get,
-        policy: {
-          readTimeoutMs: 500,
-        },
-        url: 'https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v1.json?v=1712853748&lat=45.6&lon=12.3',
+      deliveryAddress: {
+        countryCode: CountryCode.Us,
+        longitude: 12.3,
+        latitude: 45.6,
       }
     });
+    const expected: FunctionFetchResult = ({ request: null });
 
     expect(result).toEqual(expected);
   });

--- a/order-routing/wasm/pickup-point-delivery-option-generators/default/fetch.graphql.liquid
+++ b/order-routing/wasm/pickup-point-delivery-option-generators/default/fetch.graphql.liquid
@@ -1,9 +1,7 @@
 query Input {
-  allocations {
-    deliveryAddress {
-      countryCode
-      longitude
-      latitude
-    }
+  deliveryAddress {
+    countryCode
+    longitude
+    latitude
   }
 }

--- a/order-routing/wasm/pickup-point-delivery-option-generators/default/schema.graphql
+++ b/order-routing/wasm/pickup-point-delivery-option-generators/default/schema.graphql
@@ -2940,12 +2940,17 @@ type Input {
   """
   A list of allocations.
   """
-  allocations: [Allocation!]!
+  allocations: [Allocation!]! @deprecated(reason: "Use `deliveryAddress` instead.")
 
   """
   The cart.
   """
   cart: Cart!
+
+  """
+  The delivery address for pickup point delivery option.
+  """
+  deliveryAddress: MailingAddress!
 
   """
   The result of the fetch target. Refer to network access for Shopify Functions.
@@ -4303,7 +4308,7 @@ type PurchasingCompany {
 """
 Represents how products and variants can be sold and purchased.
 """
-type SellingPlan {
+type SellingPlan implements HasMetafields {
   """
   The description of the selling plan.
   """
@@ -4313,6 +4318,21 @@ type SellingPlan {
   A globally-unique identifier.
   """
   id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    """
+    namespace: String
+  ): Metafield
 
   """
   The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.


### PR DESCRIPTION
Resolves: https://github.com/Shopify/shopify/issues/499574
Tophat result: https://github.com/Shopify/function-examples-tophat/pull/13#issuecomment-2072355233

Deprecate [allocations](https://shopify.dev/docs/api/functions/reference/pickup-point-delivery-option-generator/graphql/common-objects/allocation) on [pickup point function API Input](https://shopify.dev/docs/api/functions/reference/pickup-point-delivery-option-generator/graphql/input) in favour of `delivery_address`.
Note: `allocations` will continue to be supported for the time being. 
