### PR TITLE
Update payment customizations js template

### DIFF
--- a/sample-apps/payment-customizations/extensions/payment-customization-js/src/run.js
+++ b/sample-apps/payment-customizations/extensions/payment-customization-js/src/run.js
@@ -28,11 +28,14 @@ export function run(input) {
   const configuration = JSON.parse(
     input?.paymentCustomization?.metafield?.value ?? "{}"
   );
-  if (!configuration.paymentMethodName || !configuration.cartTotal) {
+  if (configuration.paymentMethodName == undefined || configuration.cartTotal == undefined) {
+    console.error(
+      "Configuration is missing."
+    );
     return NO_CHANGES;
   }
 
-  const cartTotal = parseFloat(input.cart.cost.totalAmount.amount ?? "0.0");
+  const cartTotal = parseFloat(input.cart.cost.totalAmount.amount);
   // Use the configured cart total instead of a hardcoded value
   if (cartTotal < configuration.cartTotal) {
     console.error(

--- a/sample-apps/payment-customizations/extensions/payment-customization-js/src/run.js
+++ b/sample-apps/payment-customizations/extensions/payment-customization-js/src/run.js
@@ -28,7 +28,7 @@ export function run(input) {
   const configuration = JSON.parse(
     input?.paymentCustomization?.metafield?.value ?? "{}"
   );
-  if (configuration.paymentMethodName == undefined || configuration.cartTotal == undefined) {
+  if (configuration.paymentMethodName === undefined || configuration.cartTotal === undefined) {
     console.error(
       "Configuration is missing."
     );


### PR DESCRIPTION
Moving from `!configuration.cartTotal` to `configuration.cartTotal == undefined` to better reflect the desired behaviour.

<img width="422" alt="Screenshot 2024-05-03 at 9 15 26 AM" src="https://github.com/Shopify/function-examples/assets/207902/94321c1e-78a5-41c9-8d5f-8b02131cbc47">
