### PR TITLE
Add uid to TOML templates

### DIFF
--- a/checkout/javascript/cart-checkout-validation/default/shopify.extension.toml.liquid
+++ b/checkout/javascript/cart-checkout-validation/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.validation.run"

--- a/checkout/javascript/cart-transform/default/shopify.extension.toml.liquid
+++ b/checkout/javascript/cart-transform/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.cart-transform.run"

--- a/checkout/javascript/delivery-customization/default/shopify.extension.toml.liquid
+++ b/checkout/javascript/delivery-customization/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.delivery-customization.run"

--- a/checkout/javascript/order-submission-rule/default/shopify.extension.toml.liquid
+++ b/checkout/javascript/order-submission-rule/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "unstable"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.order-submission-rule.run"

--- a/checkout/javascript/payment-customization/default/shopify.extension.toml.liquid
+++ b/checkout/javascript/payment-customization/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.payment-customization.run"

--- a/checkout/rust/cart-checkout-validation/default/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-checkout-validation/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.validation.run"

--- a/checkout/rust/cart-transform/bundles/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-transform/bundles/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "bundles_cart_transform"
 name = "t:name"
-description = "t:description"
+handle = "bundles_cart_transform"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.cart-transform.run"

--- a/checkout/rust/cart-transform/default/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-transform/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.cart-transform.run"

--- a/checkout/rust/delivery-customization/default/shopify.extension.toml.liquid
+++ b/checkout/rust/delivery-customization/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.delivery-customization.run"

--- a/checkout/rust/order-submission-rule/default/shopify.extension.toml.liquid
+++ b/checkout/rust/order-submission-rule/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "unstable"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.order-submission-rule.run"

--- a/checkout/rust/payment-customization/default/shopify.extension.toml.liquid
+++ b/checkout/rust/payment-customization/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.payment-customization.run"

--- a/checkout/wasm/cart-checkout-validation/default/shopify.extension.toml.liquid
+++ b/checkout/wasm/cart-checkout-validation/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.validation.run"

--- a/checkout/wasm/cart-transform/default/shopify.extension.toml.liquid
+++ b/checkout/wasm/cart-transform/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.cart-transform.run"

--- a/checkout/wasm/delivery-customization/default/shopify.extension.toml.liquid
+++ b/checkout/wasm/delivery-customization/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.delivery-customization.run"

--- a/checkout/wasm/order-submission-rule/default/shopify.extension.toml.liquid
+++ b/checkout/wasm/order-submission-rule/default/shopify.extension.toml.liquid
@@ -1,5 +1,6 @@
 name = "{{name}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 api_version = "unstable"
 
 [[targeting]]

--- a/checkout/wasm/payment-customization/default/shopify.extension.toml.liquid
+++ b/checkout/wasm/payment-customization/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.payment-customization.run"

--- a/discounts/javascript/discounts-allocator/default/shopify.extension.toml.liquid
+++ b/discounts/javascript/discounts-allocator/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "unstable"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.discounts-allocator.run"

--- a/discounts/javascript/order-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/javascript/order-discounts/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.order-discount.run"

--- a/discounts/javascript/product-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/javascript/product-discounts/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.product-discount.run"

--- a/discounts/javascript/shipping-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/javascript/shipping-discounts/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.shipping-discount.run"

--- a/discounts/rust/discounts-allocator/default/shopify.extension.toml.liquid
+++ b/discounts/rust/discounts-allocator/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "unstable"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.discounts-allocator.run"

--- a/discounts/rust/order-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/order-discounts/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.order-discount.run"

--- a/discounts/rust/order-discounts/fixed-amount/shopify.extension.toml.liquid
+++ b/discounts/rust/order-discounts/fixed-amount/shopify.extension.toml.liquid
@@ -1,5 +1,6 @@
 name = "Fixed Amount Off Order"
 type = "order_discounts"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 api_version = "2023-07"
 
 [build]

--- a/discounts/rust/product-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/product-discounts/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.product-discount.run"

--- a/discounts/rust/product-discounts/fixed-amount/shopify.extension.toml.liquid
+++ b/discounts/rust/product-discounts/fixed-amount/shopify.extension.toml.liquid
@@ -1,5 +1,6 @@
 name = "Fixed Amount"
 type = "product_discounts"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 api_version = "2023-07"
 
 [build]

--- a/discounts/rust/shipping-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/shipping-discounts/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.shipping-discount.run"

--- a/discounts/wasm/discounts-allocator/default/shopify.extension.toml.liquid
+++ b/discounts/wasm/discounts-allocator/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "unstable"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.discounts-allocator.run"

--- a/discounts/wasm/order-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/wasm/order-discounts/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.order-discount.run"

--- a/discounts/wasm/product-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/wasm/product-discounts/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.product-discount.run"

--- a/discounts/wasm/shipping-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/wasm/shipping-discounts/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.shipping-discount.run"

--- a/order-routing/javascript/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/javascript/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.fulfillment-constraint-rule.run"

--- a/order-routing/javascript/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/javascript/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,5 +1,6 @@
 name = "{{name}}"
 type = "local_pickup_delivery_option_generator"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 api_version = "unstable"
 
 [build]

--- a/order-routing/javascript/location-rules/default/shopify.extension.toml.liquid
+++ b/order-routing/javascript/location-rules/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.order-routing-location-rule.run"

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,9 +1,10 @@
 api_version = "unstable"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "{{name}}"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
   [[extensions.targeting]]
   target = "purchase.pickup-point-delivery-option-generator.fetch"

--- a/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.fulfillment-constraint-rule.run"

--- a/order-routing/rust/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,5 +1,6 @@
 name = "{{name}}"
 type = "local_pickup_delivery_option_generator"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 api_version = "unstable"
 
 [build]

--- a/order-routing/rust/location-rules/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/location-rules/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.order-routing-location-rule.run"

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,9 +1,10 @@
 api_version = "unstable"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "{{name}}"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
 [[extensions.targeting]]
 target = "purchase.pickup-point-delivery-option-generator.fetch"

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,9 +1,10 @@
 api_version = "unstable"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "{{name}}"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
   [[extensions.targeting]]
   target = "purchase.pickup-point-delivery-option-generator.fetch"

--- a/order-routing/wasm/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/wasm/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.fulfillment-constraint-rule.run"

--- a/order-routing/wasm/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/wasm/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,5 +1,6 @@
 name = "{{name}}"
 type = "local_pickup_delivery_option_generator"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 api_version = "unstable"
 
 [build]

--- a/order-routing/wasm/location-rules/default/shopify.extension.toml.liquid
+++ b/order-routing/wasm/location-rules/default/shopify.extension.toml.liquid
@@ -1,10 +1,11 @@
 api_version = "2024-01"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "t:name"
-description = "t:description"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 
   [[extensions.targeting]]
   target = "purchase.order-routing-location-rule.run"

--- a/order-routing/wasm/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/wasm/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,9 +1,10 @@
 api_version = "unstable"
 
 [[extensions]]
-handle = "{{handle}}"
 name = "{{name}}"
+handle = "{{handle}}"
 type = "function"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
   [[extensions.targeting]]
   target = "purchase.pickup-point-delivery-option-generator.fetch"


### PR DESCRIPTION
Continuation of https://github.com/Shopify/cli/pull/3725/files

Add the `uid` field if present to the TOML templates.