### PR TITLE
[CartTransform] Update api version to 2024-07

### DIFF
--- a/checkout/javascript/cart-transform/default/schema.graphql
+++ b/checkout/javascript/cart-transform/default/schema.graphql
@@ -24,6 +24,21 @@ type Attribute {
 }
 
 """
+Key-value pairs that contains additional information.
+"""
+input AttributeOutput {
+  """
+  Key or name of the attribute.
+  """
+  key: String!
+
+  """
+  Value of the attribute.
+  """
+  value: String!
+}
+
+"""
 Represents information about the buyer that is interacting with the cart.
 """
 type BuyerIdentity {
@@ -162,7 +177,14 @@ input CartLineInput {
 An operation to apply to the Cart.
 """
 input CartOperation @oneOf {
+  """
+  A cart line expand operation.
+  """
   expand: ExpandOperation
+
+  """
+  A cart line merge operation.
+  """
   merge: MergeOperation
 
   """
@@ -1448,7 +1470,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -2524,6 +2546,9 @@ Example values: `"29.99"`, `"29.999"`.
 """
 scalar Decimal
 
+"""
+A cart line expand operation.
+"""
 input ExpandOperation {
   """
   The cart line id to expand.
@@ -2552,6 +2577,11 @@ input ExpandOperation {
 }
 
 input ExpandedItem {
+  """
+  The CartLine attributes to be added to component line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The merchandise id of the expanded item.
   """
@@ -2599,8 +2629,7 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-Transformations to apply to the Cart. In API versions 2023-10 and beyond, this
-type is deprecated in favor of `FunctionRunResult`.
+The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
@@ -2610,7 +2639,7 @@ input FunctionResult {
 }
 
 """
-Transformations to apply to the Cart.
+The run target result.
 """
 input FunctionRunResult {
   """
@@ -3576,7 +3605,15 @@ The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
 
+"""
+A cart line merge operation.
+"""
 input MergeOperation {
+  """
+  The CartLine attributes to be added to the parent line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The list of cart lines to merge.
   """

--- a/checkout/javascript/cart-transform/default/shopify.extension.toml.liquid
+++ b/checkout/javascript/cart-transform/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "{{handle}}"

--- a/checkout/rust/cart-transform/bundles/schema.graphql
+++ b/checkout/rust/cart-transform/bundles/schema.graphql
@@ -24,6 +24,21 @@ type Attribute {
 }
 
 """
+Key-value pairs that contains additional information.
+"""
+input AttributeOutput {
+  """
+  Key or name of the attribute.
+  """
+  key: String!
+
+  """
+  Value of the attribute.
+  """
+  value: String!
+}
+
+"""
 Represents information about the buyer that is interacting with the cart.
 """
 type BuyerIdentity {
@@ -162,7 +177,14 @@ input CartLineInput {
 An operation to apply to the Cart.
 """
 input CartOperation @oneOf {
+  """
+  A cart line expand operation.
+  """
   expand: ExpandOperation
+
+  """
+  A cart line merge operation.
+  """
   merge: MergeOperation
 
   """
@@ -1448,7 +1470,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -2524,6 +2546,9 @@ Example values: `"29.99"`, `"29.999"`.
 """
 scalar Decimal
 
+"""
+A cart line expand operation.
+"""
 input ExpandOperation {
   """
   The cart line id to expand.
@@ -2552,6 +2577,11 @@ input ExpandOperation {
 }
 
 input ExpandedItem {
+  """
+  The CartLine attributes to be added to component line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The merchandise id of the expanded item.
   """
@@ -2599,8 +2629,7 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-Transformations to apply to the Cart. In API versions 2023-10 and beyond, this
-type is deprecated in favor of `FunctionRunResult`.
+The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
@@ -2610,7 +2639,7 @@ input FunctionResult {
 }
 
 """
-Transformations to apply to the Cart.
+The run target result.
 """
 input FunctionRunResult {
   """
@@ -3576,7 +3605,15 @@ The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
 
+"""
+A cart line merge operation.
+"""
 input MergeOperation {
+  """
+  The CartLine attributes to be added to the parent line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The list of cart lines to merge.
   """

--- a/checkout/rust/cart-transform/bundles/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-transform/bundles/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "bundles_cart_transform"

--- a/checkout/rust/cart-transform/bundles/src/run.rs
+++ b/checkout/rust/cart-transform/bundles/src/run.rs
@@ -88,6 +88,7 @@ fn get_merge_cart_operations(cart: &Cart) -> impl Iterator<Item = CartOperation>
                     cart_lines,
                     image: None,
                     price,
+                    attributes: None,
                 })
             })
         })
@@ -169,6 +170,7 @@ fn get_expand_cart_operations(cart: &Cart) -> impl Iterator<Item = CartOperation
                         merchandise_id: reference,
                         quantity,
                         price: None,
+                        attributes: None,
                     })
                     .collect();
 

--- a/checkout/wasm/cart-transform/default/schema.graphql
+++ b/checkout/wasm/cart-transform/default/schema.graphql
@@ -24,6 +24,21 @@ type Attribute {
 }
 
 """
+Key-value pairs that contains additional information.
+"""
+input AttributeOutput {
+  """
+  Key or name of the attribute.
+  """
+  key: String!
+
+  """
+  Value of the attribute.
+  """
+  value: String!
+}
+
+"""
 Represents information about the buyer that is interacting with the cart.
 """
 type BuyerIdentity {
@@ -162,7 +177,14 @@ input CartLineInput {
 An operation to apply to the Cart.
 """
 input CartOperation @oneOf {
+  """
+  A cart line expand operation.
+  """
   expand: ExpandOperation
+
+  """
+  A cart line merge operation.
+  """
   merge: MergeOperation
 
   """
@@ -1448,7 +1470,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -2524,6 +2546,9 @@ Example values: `"29.99"`, `"29.999"`.
 """
 scalar Decimal
 
+"""
+A cart line expand operation.
+"""
 input ExpandOperation {
   """
   The cart line id to expand.
@@ -2552,6 +2577,11 @@ input ExpandOperation {
 }
 
 input ExpandedItem {
+  """
+  The CartLine attributes to be added to component line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The merchandise id of the expanded item.
   """
@@ -2599,8 +2629,7 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-Transformations to apply to the Cart. In API versions 2023-10 and beyond, this
-type is deprecated in favor of `FunctionRunResult`.
+The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
@@ -2610,7 +2639,7 @@ input FunctionResult {
 }
 
 """
-Transformations to apply to the Cart.
+The run target result.
 """
 input FunctionRunResult {
   """
@@ -3576,7 +3605,15 @@ The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
 
+"""
+A cart line merge operation.
+"""
 input MergeOperation {
+  """
+  The CartLine attributes to be added to the parent line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The list of cart lines to merge.
   """

--- a/checkout/wasm/cart-transform/default/shopify.extension.toml.liquid
+++ b/checkout/wasm/cart-transform/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "{{handle}}"

--- a/sample-apps/bundles-cart-transform/extensions/cart-expand-js/schema.graphql
+++ b/sample-apps/bundles-cart-transform/extensions/cart-expand-js/schema.graphql
@@ -24,6 +24,21 @@ type Attribute {
 }
 
 """
+Key-value pairs that contains additional information.
+"""
+input AttributeOutput {
+  """
+  Key or name of the attribute.
+  """
+  key: String!
+
+  """
+  Value of the attribute.
+  """
+  value: String!
+}
+
+"""
 Represents information about the buyer that is interacting with the cart.
 """
 type BuyerIdentity {
@@ -162,7 +177,14 @@ input CartLineInput {
 An operation to apply to the Cart.
 """
 input CartOperation @oneOf {
+  """
+  A cart line expand operation.
+  """
   expand: ExpandOperation
+
+  """
+  A cart line merge operation.
+  """
   merge: MergeOperation
 
   """
@@ -1448,7 +1470,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -2524,6 +2546,9 @@ Example values: `"29.99"`, `"29.999"`.
 """
 scalar Decimal
 
+"""
+A cart line expand operation.
+"""
 input ExpandOperation {
   """
   The cart line id to expand.
@@ -2552,6 +2577,11 @@ input ExpandOperation {
 }
 
 input ExpandedItem {
+  """
+  The CartLine attributes to be added to component line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The merchandise id of the expanded item.
   """
@@ -2599,8 +2629,7 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-Transformations to apply to the Cart. In API versions 2023-10 and beyond, this
-type is deprecated in favor of `FunctionRunResult`.
+The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
@@ -2610,7 +2639,7 @@ input FunctionResult {
 }
 
 """
-Transformations to apply to the Cart.
+The run target result.
 """
 input FunctionRunResult {
   """
@@ -3576,7 +3605,15 @@ The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
 
+"""
+A cart line merge operation.
+"""
 input MergeOperation {
+  """
+  The CartLine attributes to be added to the parent line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The list of cart lines to merge.
   """

--- a/sample-apps/bundles-cart-transform/extensions/cart-expand-js/shopify.extension.toml
+++ b/sample-apps/bundles-cart-transform/extensions/cart-expand-js/shopify.extension.toml
@@ -1,7 +1,7 @@
 name = "test-demo"
 type = "cart_transform"
 title = "cart transform"
-api_version = "2024-01"
+api_version = "2024-04"
 
 [build]
 command = ""

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/schema.graphql
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/schema.graphql
@@ -24,6 +24,21 @@ type Attribute {
 }
 
 """
+Key-value pairs that contains additional information.
+"""
+input AttributeOutput {
+  """
+  Key or name of the attribute.
+  """
+  key: String!
+
+  """
+  Value of the attribute.
+  """
+  value: String!
+}
+
+"""
 Represents information about the buyer that is interacting with the cart.
 """
 type BuyerIdentity {
@@ -162,7 +177,14 @@ input CartLineInput {
 An operation to apply to the Cart.
 """
 input CartOperation @oneOf {
+  """
+  A cart line expand operation.
+  """
   expand: ExpandOperation
+
+  """
+  A cart line merge operation.
+  """
   merge: MergeOperation
 
   """
@@ -1448,7 +1470,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -2524,6 +2546,9 @@ Example values: `"29.99"`, `"29.999"`.
 """
 scalar Decimal
 
+"""
+A cart line expand operation.
+"""
 input ExpandOperation {
   """
   The cart line id to expand.
@@ -2552,6 +2577,11 @@ input ExpandOperation {
 }
 
 input ExpandedItem {
+  """
+  The CartLine attributes to be added to component line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The merchandise id of the expanded item.
   """
@@ -2599,8 +2629,7 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-Transformations to apply to the Cart. In API versions 2023-10 and beyond, this
-type is deprecated in favor of `FunctionRunResult`.
+The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
@@ -2610,7 +2639,7 @@ input FunctionResult {
 }
 
 """
-Transformations to apply to the Cart.
+The run target result.
 """
 input FunctionRunResult {
   """
@@ -3576,7 +3605,15 @@ The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
 
+"""
+A cart line merge operation.
+"""
 input MergeOperation {
+  """
+  The CartLine attributes to be added to the parent line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The list of cart lines to merge.
   """

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/shopify.extension.toml
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/shopify.extension.toml
@@ -1,7 +1,7 @@
 name = "cart merge expand"
 type = "cart_transform"
 title = "cart merge expand"
-api_version = "2024-01"
+api_version = "2024-04"
 
 [build]
 command = "cargo wasi build --release"

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/src/run.rs
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/src/run.rs
@@ -87,6 +87,7 @@ fn get_merge_cart_operations(cart: &Cart) -> impl Iterator<Item = CartOperation>
                     cart_lines,
                     image: None,
                     price,
+                    attributes: None,
                 };
 
                 CartOperation::Merge(merge_operation)
@@ -204,6 +205,7 @@ fn get_expand_cart_operations(cart: &Cart) -> impl Iterator<Item = CartOperation
                         merchandise_id: reference,
                         quantity,
                         price: None,
+                        attributes: None,
                     })
                     .collect();
 

--- a/sample-apps/bundles-price-per-component/extensions/price-per-component-js/schema.graphql
+++ b/sample-apps/bundles-price-per-component/extensions/price-per-component-js/schema.graphql
@@ -24,6 +24,21 @@ type Attribute {
 }
 
 """
+Key-value pairs that contains additional information.
+"""
+input AttributeOutput {
+  """
+  Key or name of the attribute.
+  """
+  key: String!
+
+  """
+  Value of the attribute.
+  """
+  value: String!
+}
+
+"""
 Represents information about the buyer that is interacting with the cart.
 """
 type BuyerIdentity {
@@ -162,7 +177,14 @@ input CartLineInput {
 An operation to apply to the Cart.
 """
 input CartOperation @oneOf {
+  """
+  A cart line expand operation.
+  """
   expand: ExpandOperation
+
+  """
+  A cart line merge operation.
+  """
   merge: MergeOperation
 
   """
@@ -1448,7 +1470,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -2524,6 +2546,9 @@ Example values: `"29.99"`, `"29.999"`.
 """
 scalar Decimal
 
+"""
+A cart line expand operation.
+"""
 input ExpandOperation {
   """
   The cart line id to expand.
@@ -2552,6 +2577,11 @@ input ExpandOperation {
 }
 
 input ExpandedItem {
+  """
+  The CartLine attributes to be added to component line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The merchandise id of the expanded item.
   """
@@ -2599,8 +2629,7 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-Transformations to apply to the Cart. In API versions 2023-10 and beyond, this
-type is deprecated in favor of `FunctionRunResult`.
+The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
@@ -2610,7 +2639,7 @@ input FunctionResult {
 }
 
 """
-Transformations to apply to the Cart.
+The run target result.
 """
 input FunctionRunResult {
   """
@@ -3576,7 +3605,15 @@ The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
 
+"""
+A cart line merge operation.
+"""
 input MergeOperation {
+  """
+  The CartLine attributes to be added to the parent line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The list of cart lines to merge.
   """

--- a/sample-apps/bundles-price-per-component/extensions/price-per-component-js/shopify.extension.toml
+++ b/sample-apps/bundles-price-per-component/extensions/price-per-component-js/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "price-per-component-demo"

--- a/sample-apps/update-line-item/extensions/update-line-item-js/schema.graphql
+++ b/sample-apps/update-line-item/extensions/update-line-item-js/schema.graphql
@@ -24,6 +24,21 @@ type Attribute {
 }
 
 """
+Key-value pairs that contains additional information.
+"""
+input AttributeOutput {
+  """
+  Key or name of the attribute.
+  """
+  key: String!
+
+  """
+  Value of the attribute.
+  """
+  value: String!
+}
+
+"""
 Represents information about the buyer that is interacting with the cart.
 """
 type BuyerIdentity {
@@ -162,7 +177,14 @@ input CartLineInput {
 An operation to apply to the Cart.
 """
 input CartOperation @oneOf {
+  """
+  A cart line expand operation.
+  """
   expand: ExpandOperation
+
+  """
+  A cart line merge operation.
+  """
   merge: MergeOperation
 
   """
@@ -1448,7 +1470,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -2524,6 +2546,9 @@ Example values: `"29.99"`, `"29.999"`.
 """
 scalar Decimal
 
+"""
+A cart line expand operation.
+"""
 input ExpandOperation {
   """
   The cart line id to expand.
@@ -2552,6 +2577,11 @@ input ExpandOperation {
 }
 
 input ExpandedItem {
+  """
+  The CartLine attributes to be added to component line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The merchandise id of the expanded item.
   """
@@ -2599,8 +2629,7 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-Transformations to apply to the Cart. In API versions 2023-10 and beyond, this
-type is deprecated in favor of `FunctionRunResult`.
+The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
@@ -2610,7 +2639,7 @@ input FunctionResult {
 }
 
 """
-Transformations to apply to the Cart.
+The run target result.
 """
 input FunctionRunResult {
   """
@@ -3576,7 +3605,15 @@ The merchandise to be purchased at checkout.
 """
 union Merchandise = CustomProduct | ProductVariant
 
+"""
+A cart line merge operation.
+"""
 input MergeOperation {
+  """
+  The CartLine attributes to be added to the parent line.
+  """
+  attributes: [AttributeOutput!] = []
+
   """
   The list of cart lines to merge.
   """

--- a/sample-apps/update-line-item/extensions/update-line-item-js/shopify.extension.toml
+++ b/sample-apps/update-line-item/extensions/update-line-item-js/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "update-line-item-demo"


### PR DESCRIPTION
Update api version to the latest stable release - `2024-07`

Changes:

- New field `attributes` for expand and merge operation