### PR TITLE
fix: update dep version of sample-apps

### DIFF
--- a/sample-apps/discounts/package.json
+++ b/sample-apps/discounts/package.json
@@ -27,7 +27,7 @@
     "@shopify/app-bridge": "^3.7.10",
     "@shopify/app-bridge-types": "^0.0.11",
     "@shopify/cli": "3.59.0",
-    "@shopify/discount-app-components": "2.1.2",
+    "@shopify/discount-app-components": "3.0.0",
     "@shopify/polaris": "^13.0.0",
     "@shopify/react-form": "^2.5.6",
     "@shopify/shopify-app-remix": "^2.8.0",


### PR DESCRIPTION
Trying to build an app with https://shopify.dev/docs/apps/build/discounts/experience#sample-code, then I met this: https://github.com/Shopify/discount-app-components/issues/196