### PR TITLE
chore: upgrade discounts repo discount-app-components to 3.0.1

### DIFF
--- a/sample-apps/discounts/package.json
+++ b/sample-apps/discounts/package.json
@@ -27,7 +27,7 @@
     "@shopify/app-bridge": "^3.7.10",
     "@shopify/app-bridge-types": "^0.0.11",
     "@shopify/cli": "3.59.0",
-    "@shopify/discount-app-components": "3.0.0",
+    "@shopify/discount-app-components": "3.0.1",
     "@shopify/polaris": "^13.0.0",
     "@shopify/react-form": "^2.5.6",
     "@shopify/shopify-app-remix": "^2.8.0",


### PR DESCRIPTION
### 🎩 Instructions

- `shopify app init --template https://github.com/Shopify/function-examples/sample-apps/discounts\#mathiusj/update-discount-app-components-version --package-manager yarn`
- should not fail 🙏 
- try `shopify app init --template https://github.com/Shopify/function-examples/sample-apps/discounts --package-manager yarn` and you will see that it does