### PR TITLE
fix: downgrade eslint for discounts app

### DIFF
--- a/sample-apps/discounts/package.json
+++ b/sample-apps/discounts/package.json
@@ -42,7 +42,7 @@
     "@remix-run/dev": "^2.8.1",
     "@remix-run/eslint-config": "^2.8.1",
     "@types/eslint": "^8.56.9",
-    "eslint": "^9.0.0",
+    "eslint": "^8.0.0",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.2.5"
   },


### PR DESCRIPTION
### Description

My [previous fix](https://github.com/Shopify/function-examples/pull/547) worked for yarn packages, but was failing still with npm on:

```
Error coming from `npm install`

Command failed with exit code 1: npm install
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: specialized-shareholder-app@undefined
npm error Found: eslint@9.7.0
npm error node_modules/eslint
npm error   dev eslint@"^9.0.0" from the root project
...
```
Seems that the `@remix-run/remix` package is using `eslint@^8.23.1` which is causing the dependency conflict:

https://github.com/remix-run/remix/blob/main/package.json#L99

### 🎩 Instructions
shopify app init --template https://github.com/Shopify/function-examples/sample-apps/discounts\#mathiusj/downgrade-eslint-discounts 
should not fail 🙏
try shopify app init --template https://github.com/Shopify/function-examples/sample-apps/discounts --package-manager yarn and you will see that it does