### PR TITLE
Remove unused ui.paths from configuration

### DIFF
--- a/checkout/javascript/cart-checkout-validation/default/shopify.extension.toml.liquid
+++ b/checkout/javascript/cart-checkout-validation/default/shopify.extension.toml.liquid
@@ -16,6 +16,3 @@ description = "t:description"
   command = ""
   path = "dist/function.wasm"
 
-  [extensions.ui.paths]
-  create = "/"
-  details = "/"

--- a/checkout/rust/cart-checkout-validation/default/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-checkout-validation/default/shopify.extension.toml.liquid
@@ -17,6 +17,3 @@ description = "t:description"
   path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
-  [extensions.ui.paths]
-  create = "/"
-  details = "/"

--- a/checkout/wasm/cart-checkout-validation/default/shopify.extension.toml.liquid
+++ b/checkout/wasm/cart-checkout-validation/default/shopify.extension.toml.liquid
@@ -17,6 +17,3 @@ description = "t:description"
   path = ""
   watch = []
 
-  [extensions.ui.paths]
-  create = "/"
-  details = "/"


### PR DESCRIPTION
We're using Admin UI extensions so these do not need to be added to the configuration.