### PR TITLE
Update error target to recommended syntax

### DIFF
--- a/checkout/javascript/cart-checkout-validation/default/src/run.liquid
+++ b/checkout/javascript/cart-checkout-validation/default/src/run.liquid
@@ -15,7 +15,7 @@ export function run(input) {
     .filter(({ quantity }) => quantity > 1)
     .map(() => ({
       localizedMessage: "Not possible to order more than one of each",
-      target: "cart",
+      target: "$.cart",
     }));
 
   return {
@@ -34,7 +34,7 @@ export function run(input: RunInput): FunctionRunResult {
     .filter(({ quantity }) => quantity > 1)
     .map(() => ({
       localizedMessage: "Not possible to order more than one of each",
-      target: "cart",
+      target: "$.cart",
     }));
 
   return {

--- a/checkout/javascript/cart-checkout-validation/default/src/run.test.liquid
+++ b/checkout/javascript/cart-checkout-validation/default/src/run.test.liquid
@@ -20,7 +20,7 @@ describe('cart checkout validation function', () => {
     const expected = /** @type {FunctionRunResult} */ ({ errors: [
       {
         localizedMessage: "Not possible to order more than one of each",
-        target: "cart"
+        target: "$.cart"
       }
     ] });
 
@@ -61,7 +61,7 @@ describe('cart checkout validation function', () => {
     const expected: FunctionRunResult = { errors: [
       {
         localizedMessage: "Not possible to order more than one of each",
-        target: "cart"
+        target: "$.cart"
       }
     ] };
 

--- a/checkout/rust/cart-checkout-validation/default/src/run.rs
+++ b/checkout/rust/cart-checkout-validation/default/src/run.rs
@@ -19,7 +19,7 @@ fn run(input: input::ResponseData) -> Result<output::FunctionRunResult> {
     {
         errors.push(output::FunctionError {
             localized_message: "Not possible to order more than one of each".to_owned(),
-            target: "cart".to_owned(),
+            target: "$.cart".to_owned(),
         })
     }
     Ok(output::FunctionRunResult { errors })
@@ -51,7 +51,7 @@ mod tests {
         let expected = FunctionRunResult {
             errors: vec![FunctionError {
                 localized_message: "Not possible to order more than one of each".to_owned(),
-                target: "cart".to_owned(),
+                target: "$.cart".to_owned(),
             }],
         };
 


### PR DESCRIPTION
We had a target that was not in line with recommendations in these templates. Fixed.