### PR TITLE
Bump api version for product, order, shipping discount functions

### DIFF
--- a/discounts/javascript/order-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/javascript/order-discounts/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-07"
+api_version = "2024-10"
 
 [[extensions]]
 name = "t:name"

--- a/discounts/javascript/product-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/javascript/product-discounts/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-07"
+api_version = "2024-10"
 
 [[extensions]]
 name = "t:name"

--- a/discounts/javascript/shipping-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/javascript/shipping-discounts/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-07"
+api_version = "2024-10"
 
 [[extensions]]
 name = "t:name"

--- a/discounts/rust/order-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/order-discounts/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-07"
+api_version = "2024-10"
 
 [[extensions]]
 name = "t:name"

--- a/discounts/rust/product-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/product-discounts/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-07"
+api_version = "2024-10"
 
 [[extensions]]
 name = "t:name"

--- a/discounts/rust/shipping-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/shipping-discounts/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-07"
+api_version = "2024-10"
 
 [[extensions]]
 name = "t:name"

--- a/discounts/wasm/order-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/wasm/order-discounts/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-07"
+api_version = "2024-10"
 
 [[extensions]]
 name = "t:name"

--- a/discounts/wasm/product-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/wasm/product-discounts/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-07"
+api_version = "2024-10"
 
 [[extensions]]
 name = "t:name"

--- a/discounts/wasm/shipping-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/wasm/shipping-discounts/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-07"
+api_version = "2024-10"
 
 [[extensions]]
 name = "t:name"


### PR DESCRIPTION
Bumped the version to 2024-10 for product, order, shipping discount function examples.