### PR TITLE
Stop using cargo-wasi

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Run tests
         run: cargo test
-      - name: Add wasm32-wasi target
-        run: rustup target add wasm32-wasi
-      - name: Build with wasm32-wasi target
-        run: cargo build --release --target wasm32-wasi
+      - name: Add wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
+      - name: Build with wasm32-wasip1 target
+        run: cargo build --release --target wasm32-wasip1

--- a/checkout/rust/cart-checkout-validation/default/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-checkout-validation/default/shopify.extension.toml.liquid
@@ -13,7 +13,7 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/checkout/rust/cart-checkout-validation/default/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-checkout-validation/default/shopify.extension.toml.liquid
@@ -14,6 +14,6 @@ description = "t:description"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/checkout/rust/cart-transform/bundles/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-transform/bundles/shopify.extension.toml.liquid
@@ -14,7 +14,7 @@ description = "t:description"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/bundles_cart_transform.wasm"
+  path = "target/wasm32-wasip1/release/bundles_cart_transform.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/checkout/rust/cart-transform/bundles/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-transform/bundles/shopify.extension.toml.liquid
@@ -13,7 +13,7 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/bundles_cart_transform.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/checkout/rust/cart-transform/default/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-transform/default/shopify.extension.toml.liquid
@@ -13,7 +13,7 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/checkout/rust/cart-transform/default/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-transform/default/shopify.extension.toml.liquid
@@ -14,7 +14,7 @@ description = "t:description"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/checkout/rust/delivery-customization/default/shopify.extension.toml.liquid
+++ b/checkout/rust/delivery-customization/default/shopify.extension.toml.liquid
@@ -13,7 +13,7 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/checkout/rust/delivery-customization/default/shopify.extension.toml.liquid
+++ b/checkout/rust/delivery-customization/default/shopify.extension.toml.liquid
@@ -14,7 +14,7 @@ description = "t:description"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/checkout/rust/payment-customization/default/shopify.extension.toml.liquid
+++ b/checkout/rust/payment-customization/default/shopify.extension.toml.liquid
@@ -13,7 +13,7 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/checkout/rust/payment-customization/default/shopify.extension.toml.liquid
+++ b/checkout/rust/payment-customization/default/shopify.extension.toml.liquid
@@ -14,7 +14,7 @@ description = "t:description"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/discounts/rust/discounts-allocator/default/README.md
+++ b/discounts/rust/discounts-allocator/default/README.md
@@ -4,15 +4,13 @@
 
 - [Install Rust](https://www.rust-lang.org/tools/install)
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
-- Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
-  - `cargo install cargo-wasi`
 
 ## Building the function
 
-You can build this individual function using `cargo wasi`.
+You can build this individual function using `cargo build`.
 
 ```shell
-cargo wasi build --release
+cargo build --target=wasm32-wasip1 --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/discounts/rust/discounts-allocator/default/shopify.extension.toml.liquid
+++ b/discounts/rust/discounts-allocator/default/shopify.extension.toml.liquid
@@ -13,7 +13,7 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/discounts/rust/discounts-allocator/default/shopify.extension.toml.liquid
+++ b/discounts/rust/discounts-allocator/default/shopify.extension.toml.liquid
@@ -14,7 +14,7 @@ description = "t:description"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/discounts/rust/order-discounts/default/README.md
+++ b/discounts/rust/order-discounts/default/README.md
@@ -4,15 +4,13 @@
 
 - [Install Rust](https://www.rust-lang.org/tools/install)
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
-- Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
-  - `cargo install cargo-wasi`
 
 ## Building the function
 
-You can build this individual function using `cargo wasi`.
+You can build this individual function using `cargo build`.
 
 ```shell
-cargo wasi build --release
+cargo build --target=wasm32-wasip1 --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/discounts/rust/order-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/order-discounts/default/shopify.extension.toml.liquid
@@ -13,7 +13,7 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/discounts/rust/order-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/order-discounts/default/shopify.extension.toml.liquid
@@ -14,7 +14,7 @@ description = "t:description"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/discounts/rust/product-discounts/default/README.md
+++ b/discounts/rust/product-discounts/default/README.md
@@ -4,15 +4,13 @@
 
 - [Install Rust](https://www.rust-lang.org/tools/install)
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
-- Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
-  - `cargo install cargo-wasi`
 
 ## Building the function
 
-You can build this individual function using `cargo wasi`.
+You can build this individual function using `cargo build`.
 
 ```shell
-cargo wasi build --release
+cargo build --target=wasm32-wasip1 --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/discounts/rust/product-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/product-discounts/default/shopify.extension.toml.liquid
@@ -13,7 +13,7 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/discounts/rust/product-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/product-discounts/default/shopify.extension.toml.liquid
@@ -14,7 +14,7 @@ description = "t:description"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/discounts/rust/shipping-discounts/default/README.md
+++ b/discounts/rust/shipping-discounts/default/README.md
@@ -4,15 +4,13 @@
 
 - [Install Rust](https://www.rust-lang.org/tools/install)
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
-- Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
-  - `cargo install cargo-wasi`
 
 ## Building the function
 
-You can build this individual function using `cargo wasi`.
+You can build this individual function using `cargo build`.
 
 ```shell
-cargo wasi build --release
+cargo build --target=wasm32-wasip1 --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/discounts/rust/shipping-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/shipping-discounts/default/shopify.extension.toml.liquid
@@ -13,7 +13,7 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/discounts/rust/shipping-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/shipping-discounts/default/shopify.extension.toml.liquid
@@ -14,7 +14,7 @@ description = "t:description"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -13,7 +13,7 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -14,7 +14,7 @@ description = "t:description"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/order-routing/rust/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -5,7 +5,7 @@ api_version = "unstable"
 
 [build]
 command = "cargo build --target=wasm32-wasip1 --release"
-path = "target/wasm32-wasi/release/{{name | replace: " ", "-" | downcase}}.wasm"
+path = "target/wasm32-wasip1/release/{{name | replace: " ", "-" | downcase}}.wasm"
 watch = [ "src/**/*.rs" ]
 
 [ui.paths]

--- a/order-routing/rust/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -4,7 +4,7 @@ type = "local_pickup_delivery_option_generator"
 api_version = "unstable"
 
 [build]
-command = "cargo wasi build --release"
+command = "cargo build --target=wasm32-wasip1 --release"
 path = "target/wasm32-wasi/release/{{name | replace: " ", "-" | downcase}}.wasm"
 watch = [ "src/**/*.rs" ]
 

--- a/order-routing/rust/location-rules/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/location-rules/default/shopify.extension.toml.liquid
@@ -13,7 +13,7 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/order-routing/rust/location-rules/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/location-rules/default/shopify.extension.toml.liquid
@@ -14,7 +14,7 @@ description = "t:description"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -18,7 +18,7 @@ export = "run"
 
 [extensions.build]
 command = "cargo build --target=wasm32-wasip1 --release"
-path = "target/wasm32-wasi/release/{{handle | replace: "-", "_" | downcase}}.wasm"
+path = "target/wasm32-wasip1/release/{{handle | replace: "-", "_" | downcase}}.wasm"
 watch = ["src/**/*.rs"]
 
 [extensions.ui.paths]

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -17,7 +17,7 @@ input_query = "src/run.graphql"
 export = "run"
 
 [extensions.build]
-command = "cargo wasi build --release"
+command = "cargo build --target=wasm32-wasip1 --release"
 path = "target/wasm32-wasi/release/{{handle | replace: "-", "_" | downcase}}.wasm"
 watch = ["src/**/*.rs"]
 

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/shopify.extension.toml
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/shopify.extension.toml
@@ -4,5 +4,5 @@ title = "cart merge expand"
 api_version = "2024-04"
 
 [build]
-command = "cargo wasi build --release"
+command = "cargo build --target=wasm32-wasip1 --release"
 path = "target/wasm32-wasi/release/bundle_cart_transform.wasm"

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/shopify.extension.toml
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/shopify.extension.toml
@@ -5,4 +5,4 @@ api_version = "2024-04"
 
 [build]
 command = "cargo build --target=wasm32-wasip1 --release"
-path = "target/wasm32-wasi/release/bundle_cart_transform.wasm"
+path = "target/wasm32-wasip1/release/bundle_cart_transform.wasm"

--- a/sample-apps/delivery-customizations/extensions/delivery-customization-rust/shopify.extension.toml
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization-rust/shopify.extension.toml
@@ -12,7 +12,7 @@ type = "function"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/delivery-customization-rust.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/sample-apps/delivery-customizations/extensions/delivery-customization-rust/shopify.extension.toml
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization-rust/shopify.extension.toml
@@ -13,7 +13,7 @@ type = "function"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/delivery-customization-rust.wasm"
+  path = "target/wasm32-wasip1/release/delivery-customization-rust.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/sample-apps/discounts/extensions/product-discount-rust/README.md
+++ b/sample-apps/discounts/extensions/product-discount-rust/README.md
@@ -4,15 +4,13 @@
 
 - [Install Rust](https://www.rust-lang.org/tools/install)
   - On Windows, Rust requires the [Microsoft C++ Build Tools](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup). Be sure to select the _Desktop development with C++_ workload when installing them.
-- Install [`cargo-wasi`](https://bytecodealliance.github.io/cargo-wasi/)
-  - `cargo install cargo-wasi`
 
 ## Building the function
 
-You can build this individual function using `cargo wasi`.
+You can build this individual function using `cargo build`.
 
 ```shell
-cargo wasi build --release
+cargo build --target=wasm32-wasip1 --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/sample-apps/discounts/extensions/product-discount-rust/shopify.extension.toml
+++ b/sample-apps/discounts/extensions/product-discount-rust/shopify.extension.toml
@@ -12,7 +12,7 @@ type = "function"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/product-discount-rust.wasm"
   watch = ["src/**/*.rs"]
 

--- a/sample-apps/discounts/extensions/product-discount-rust/shopify.extension.toml
+++ b/sample-apps/discounts/extensions/product-discount-rust/shopify.extension.toml
@@ -13,7 +13,7 @@ type = "function"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/product-discount-rust.wasm"
+  path = "target/wasm32-wasip1/release/product-discount-rust.wasm"
   watch = ["src/**/*.rs"]
 
   [extensions.ui.paths]

--- a/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/shopify.extension.toml
+++ b/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/shopify.extension.toml
@@ -12,7 +12,7 @@ type = "function"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/optional-add-ons-rust.wasm"
   watch = [ "src/**/*.rs" ]
 

--- a/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/shopify.extension.toml
+++ b/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/shopify.extension.toml
@@ -13,7 +13,7 @@ type = "function"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/optional-add-ons-rust.wasm"
+  path = "target/wasm32-wasip1/release/optional-add-ons-rust.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/sample-apps/payment-customizations/extensions/payment-customization-rust/shopify.extension.toml
+++ b/sample-apps/payment-customizations/extensions/payment-customization-rust/shopify.extension.toml
@@ -13,7 +13,7 @@ type = "function"
 
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasi/release/payment-customization.wasm"
+  path = "target/wasm32-wasip1/release/payment-customization.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/sample-apps/payment-customizations/extensions/payment-customization-rust/shopify.extension.toml
+++ b/sample-apps/payment-customizations/extensions/payment-customization-rust/shopify.extension.toml
@@ -12,7 +12,7 @@ type = "function"
   export = "run"
 
   [extensions.build]
-  command = "cargo wasi build --release"
+  command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasi/release/payment-customization.wasm"
   watch = [ "src/**/*.rs" ]
 


### PR DESCRIPTION
Given [cargo-wasi is no longer maintained](https://github.com/bytecodealliance/cargo-wasi/issues/143), we should no longer use it in our function examples.

This PR will update the build command to use the newer target, `wasm32-wasip1`
See: https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html

Handles https://github.com/Shopify/shopify-functions/issues/449

Do not merge this until we have another way of running wasm-opt, probably through the CLI directly.