### PR TITLE
Remove hardcoded rust versions

### DIFF
--- a/checkout/rust/cart-checkout-validation/default/Cargo.toml.liquid
+++ b/checkout/rust/cart-checkout-validation/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{handle | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.62"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/checkout/rust/cart-transform/bundles/Cargo.toml.liquid
+++ b/checkout/rust/cart-transform/bundles/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "bundles_cart_transform"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.62"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
@@ -13,5 +12,5 @@ graphql_client = "0.14.0"
 
 [profile.release]
 lto = true
-opt-level = 's'
+opt-level = 'z'
 strip = true

--- a/checkout/rust/cart-transform/default/Cargo.toml.liquid
+++ b/checkout/rust/cart-transform/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{handle | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.62"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
@@ -13,5 +12,5 @@ graphql_client = "0.14.0"
 
 [profile.release]
 lto = true
-opt-level = 's'
+opt-level = 'z'
 strip = true

--- a/checkout/rust/delivery-customization/default/Cargo.toml.liquid
+++ b/checkout/rust/delivery-customization/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{handle | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.62"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/checkout/rust/payment-customization/default/Cargo.toml.liquid
+++ b/checkout/rust/payment-customization/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{handle | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.62"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/discounts-allocator/default/Cargo.toml.liquid
+++ b/discounts/rust/discounts-allocator/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{handle | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.62"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/discounts/default/Cargo.toml.liquid
+++ b/discounts/rust/discounts/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{handle | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.84"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/order-discounts/default/Cargo.toml.liquid
+++ b/discounts/rust/order-discounts/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{handle | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.62"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/product-discounts/default/Cargo.toml.liquid
+++ b/discounts/rust/product-discounts/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{handle | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.62"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/discounts/rust/shipping-discounts/default/Cargo.toml.liquid
+++ b/discounts/rust/shipping-discounts/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{handle | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.62"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/order-routing/rust/fulfillment-constraints/default/Cargo.toml.liquid
+++ b/order-routing/rust/fulfillment-constraints/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{handle | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.62"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/order-routing/rust/local-pickup-delivery-option-generators/default/Cargo.toml.liquid
+++ b/order-routing/rust/local-pickup-delivery-option-generators/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{name | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.62"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/order-routing/rust/location-rules/default/Cargo.toml.liquid
+++ b/order-routing/rust/location-rules/default/Cargo.toml.liquid
@@ -2,7 +2,6 @@
 name = "{{handle | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.62"
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }


### PR DESCRIPTION
Removes a number of hardcoded rust versions so that they are compatible with our documentation of the latest Rust version and targets.