### PR TITLE
Low risk cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ node_modules
 **/shopify.extension.toml
 */javascript/**/package.json
 */javascript/**/src/*
+*/typescript/**/package.json
+*/typescript/**/src/*
 */rust/**/src/*.graphql
 */wasm/**/*.graphql
 !*/wasm/**/schema.graphql

--- a/checkout/rust/cart-checkout-validation/default/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-checkout-validation/default/shopify.extension.toml.liquid
@@ -15,5 +15,5 @@ description = "t:description"
   [extensions.build]
   command = "cargo build --target=wasm32-wasip1 --release"
   path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
-  watch = [ "src/**/*.rs" ]
+  watch = ["src/**/*.rs"]
 

--- a/discounts/javascript/discounts-allocator/default/package.json.liquid
+++ b/discounts/javascript/discounts-allocator/default/package.json.liquid
@@ -28,8 +28,6 @@
     "vitest": "^0.29.8"
   },
   "dependencies": {
-    "@shopify/shopify_function": "0.1.0",
-    "decimal.js": "^10.4.3",
-    "javy": "0.1.1"
+    "decimal.js": "^10.4.3"
   }
 }

--- a/discounts/rust/discounts/default/schema.graphql
+++ b/discounts/rust/discounts/default/schema.graphql
@@ -1,10 +1,3 @@
-# This file is auto-generated from the current state of the GraphQL API. Instead of editing this file,
-# please edit the ruby definition files and run `bin/rails graphql:schema:dump` to regenerate the schema.
-#
-# If you're just looking to browse, you may find it friendlier to use the graphiql browser which is
-# available in services-internal at https://app.shopify.com/services/internal/shops/14168/graphql.
-# Check out the "Docs" tab in the top right.
-
 schema {
   query: Input
   mutation: MutationRoot

--- a/discounts/wasm/discounts-allocator/default/shopify.extension.toml.liquid
+++ b/discounts/wasm/discounts-allocator/default/shopify.extension.toml.liquid
@@ -13,8 +13,9 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = ""
-  path = "dist/function.wasm"
+  command = "echo 'build the wasm'"
+  path = ""
+  watch = []
 
   [extensions.ui.paths]
   create = "/"

--- a/discounts/wasm/discounts-allocator/default/src/run.graphql.liquid
+++ b/discounts/wasm/discounts-allocator/default/src/run.graphql.liquid
@@ -1,0 +1,7 @@
+query Input {
+  shop {
+    metafield(namespace: "$app:{{handle | replace: " ", "-" | downcase}}", key: "function-configuration") {
+      value
+    }
+  }
+}

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/.gitignore
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/.gitignore
@@ -1,6 +1,2 @@
 dist
 generated
-node_modules
-
-!/src/*.js
-!/src/*.graphql

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/package.json.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/package.json.liquid
@@ -26,9 +26,5 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
-  },
-  "dependencies": {
-    "@shopify/shopify_function": "0.1.0",
-    "javy": "0.1.1"
   }
 }

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/.gitignore
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/.gitignore
@@ -1,5 +1,2 @@
 /target
 Cargo.lock
-.idea
-
-!/src/*.graphql

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/.gitignore
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/.gitignore
@@ -1,4 +1,2 @@
 dist
 generated
-node_modules
-package.json

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/package.json.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/package.json.liquid
@@ -26,9 +26,5 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
-  },
-  "dependencies": {
-    "@shopify/shopify_function": "0.1.0",
-    "javy": "0.1.1"
   }
 }


### PR DESCRIPTION
- Clean up all the .gitignores to be the same per function
- Remove some comments in generated schemas that shouldn't be there
- Add ignore for the typescript variant folder (until it's removed)
- Remove packages from package.json that shouldn't be dependencies
- Fix some wasm related templates