### PR TITLE
Update pickup points

### DIFF
--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/locales/en.default.json.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/locales/en.default.json.liquid
@@ -1,0 +1,4 @@
+{
+  "name": "{{name}}",
+  "description": "{{name}}"
+}

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,7 +1,7 @@
 api_version = "unstable"
 
 [[extensions]]
-name = "{{name}}"
+name = "t:name"
 handle = "{{handle}}"
 type = "function"
 {% if uid %}uid = "{{ uid }}"{% endif %}

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/Cargo.toml.liquid
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/Cargo.toml.liquid
@@ -1,11 +1,7 @@
 [package]
-name = "{{handle}}"
+name = "{{handle | replace: " ", "-" | downcase}}"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.62"
-
-[lib]
-crate-type = ["cdylib"]
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/locales/en.default.json.liquid
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/locales/en.default.json.liquid
@@ -1,0 +1,4 @@
+{
+  "name": "{{name}}",
+  "description": "{{name}}"
+}

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,7 +1,7 @@
 api_version = "unstable"
 
 [[extensions]]
-name = "{{name}}"
+name = "t:name"
 handle = "{{handle}}"
 type = "function"
 {% if uid %}uid = "{{ uid }}"{% endif %}

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -18,7 +18,7 @@ export = "run"
 
 [extensions.build]
 command = "cargo build --target=wasm32-wasip1 --release"
-path = "target/wasm32-wasip1/release/{{handle | replace: "-", "_" | downcase}}.wasm"
+path = "target/wasm32-wasip1/release/{{handle | replace: " ", "_" | downcase}}.wasm"
 watch = ["src/**/*.rs"]
 
 [extensions.ui.paths]

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/src/lib.rs
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/src/lib.rs
@@ -1,2 +1,0 @@
-pub mod fetch;
-pub mod run;

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/src/main.rs
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/src/main.rs
@@ -1,0 +1,8 @@
+use std::process;
+pub mod fetch;
+pub mod run;
+
+fn main() {
+    eprintln!("Please invoke a named export.");
+    process::exit(1);
+}

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/locales/en.default.json.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/locales/en.default.json.liquid
@@ -1,0 +1,4 @@
+{
+  "name": "{{name}}",
+  "description": "{{name}}"
+}

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -1,7 +1,7 @@
 api_version = "unstable"
 
 [[extensions]]
-name = "{{name}}"
+name = "t:name"
 handle = "{{handle}}"
 type = "function"
 {% if uid %}uid = "{{ uid }}"{% endif %}


### PR DESCRIPTION
Updates pickup-point-delivery-option-generators
- Use locales
- Migrate from a library to the same style of other rust functions

Compared against https://shopify.dev/docs/apps/build/checkout/delivery-shipping/delivery-methods/generate-pickup-points