### PR TITLE
Split Discount JS template test files

### DIFF
--- a/discounts/javascript/discount/default/src/generate_cart_run.test.liquid
+++ b/discounts/javascript/discount/default/src/generate_cart_run.test.liquid
@@ -7,6 +7,10 @@ import {
   ProductDiscountSelectionStrategy,
 } from "../generated/api";
 
+/**
+ * @typedef {import("../generated/api").CartLinesDiscountsGenerateRunResult} CartLinesDiscountsGenerateRunResult
+ */
+
 describe("generateCartRun", () => {
   it("returns a product and order discount", () => {
     const input = {
@@ -79,11 +83,13 @@ import { generateCartRun } from "./generate_cart_run";
 import {
   OrderDiscountSelectionStrategy,
   ProductDiscountSelectionStrategy,
+  CartInput,
+  CartLinesDiscountsGenerateRunResult
 } from "../generated/api";
 
 describe("generateCartRun", () => {
   it("returns a product and order discount", () => {
-    const input = {
+    const input: CartInput = {
       cart: {
         lines: [
           {
@@ -96,7 +102,7 @@ describe("generateCartRun", () => {
       },
     };
 
-    const result = generateCartRun(input);
+    const result: CartLinesDiscountsGenerateRunResult = generateCartRun(input);
 
     expect(result.operations.length).toBe(2);
     expect(result.operations[0]).toMatchObject({

--- a/discounts/javascript/discount/default/src/generate_cart_run.test.liquid
+++ b/discounts/javascript/discount/default/src/generate_cart_run.test.liquid
@@ -1,15 +1,14 @@
+{%- if flavor contains "vanilla-js" -%}
 import { describe, it, expect } from "vitest";
 
 import { generateCartRun } from "./generate_cart_run";
-import { generateDeliveryRun } from "./generate_delivery_run";
 import {
   OrderDiscountSelectionStrategy,
   ProductDiscountSelectionStrategy,
-  DeliveryDiscountSelectionStrategy,
 } from "../generated/api";
 
-describe("discount", () => {
-  it("cart.lines.discounts.generate.run returns a product and order discount", () => {
+describe("generateCartRun", () => {
+  it("returns a product and order discount", () => {
     const input = {
       cart: {
         lines: [
@@ -72,42 +71,79 @@ describe("discount", () => {
       },
     });
   });
+});
+{%- elsif flavor contains "typescript" -%}
+import { describe, it, expect } from "vitest";
 
-  it("cart.delivery-options.generate.run returns a delivery discount", () => {
+import { generateCartRun } from "./generate_cart_run";
+import {
+  OrderDiscountSelectionStrategy,
+  ProductDiscountSelectionStrategy,
+} from "../generated/api";
+
+describe("generateCartRun", () => {
+  it("returns a product and order discount", () => {
     const input = {
       cart: {
-        deliveryGroups: [
+        lines: [
           {
-            id: "gid://shopify/DeliveryGroup/0",
+            id: "gid://shopify/CartLine/0",
+            cost: {
+              subtotalAmount: 100,
+            },
           },
         ],
       },
     };
 
-    const result = generateDeliveryRun(input);
+    const result = generateCartRun(input);
 
-    expect(result.operations.length).toBe(1);
+    expect(result.operations.length).toBe(2);
     expect(result.operations[0]).toMatchObject({
-      deliveryDiscountsAdd: {
+      orderDiscountsAdd: {
         candidates: [
           {
-            message: "FREE DELIVERY",
+            message: "10% OFF ORDER",
             targets: [
               {
-                deliveryGroup: {
-                  id: "gid://shopify/DeliveryGroup/0",
+                orderSubtotal: {
+                  excludedCartLineIds: [],
                 },
               },
             ],
             value: {
               percentage: {
-                value: 100,
+                value: 10,
               },
             },
           },
         ],
-        selectionStrategy: DeliveryDiscountSelectionStrategy.All,
+        selectionStrategy: OrderDiscountSelectionStrategy.First,
+      },
+    });
+
+    expect(result.operations[1]).toMatchObject({
+      productDiscountsAdd: {
+        candidates: [
+          {
+            message: "20% OFF PRODUCT",
+            targets: [
+              {
+                cartLine: {
+                  id: "gid://shopify/CartLine/0",
+                },
+              },
+            ],
+            value: {
+              percentage: {
+                value: 20,
+              },
+            },
+          },
+        ],
+        selectionStrategy: ProductDiscountSelectionStrategy.First,
       },
     });
   });
 });
+{%- endif -%} 

--- a/discounts/javascript/discount/default/src/generate_delivery_run.test.liquid
+++ b/discounts/javascript/discount/default/src/generate_delivery_run.test.liquid
@@ -1,0 +1,95 @@
+{%- if flavor contains "vanilla-js" -%}
+import { describe, it, expect } from "vitest";
+
+import { generateDeliveryRun } from "./generate_delivery_run";
+import {
+  DeliveryDiscountSelectionStrategy,
+} from "../generated/api";
+
+describe("generateDeliveryRun", () => {
+  it("returns a delivery discount", () => {
+    const input = {
+      cart: {
+        deliveryGroups: [
+          {
+            id: "gid://shopify/DeliveryGroup/0",
+          },
+        ],
+      },
+    };
+
+    const result = generateDeliveryRun(input);
+
+    expect(result.operations.length).toBe(1);
+    expect(result.operations[0]).toMatchObject({
+      deliveryDiscountsAdd: {
+        candidates: [
+          {
+            message: "FREE DELIVERY",
+            targets: [
+              {
+                deliveryGroup: {
+                  id: "gid://shopify/DeliveryGroup/0",
+                },
+              },
+            ],
+            value: {
+              percentage: {
+                value: 100,
+              },
+            },
+          },
+        ],
+        selectionStrategy: DeliveryDiscountSelectionStrategy.All,
+      },
+    });
+  });
+});
+{%- elsif flavor contains "typescript" -%}
+import { describe, it, expect } from "vitest";
+
+import { generateDeliveryRun } from "./generate_delivery_run";
+import {
+  DeliveryDiscountSelectionStrategy,
+} from "../generated/api";
+
+describe("generateDeliveryRun", () => {
+  it("returns a delivery discount", () => {
+    const input = {
+      cart: {
+        deliveryGroups: [
+          {
+            id: "gid://shopify/DeliveryGroup/0",
+          },
+        ],
+      },
+    };
+
+    const result = generateDeliveryRun(input);
+
+    expect(result.operations.length).toBe(1);
+    expect(result.operations[0]).toMatchObject({
+      deliveryDiscountsAdd: {
+        candidates: [
+          {
+            message: "FREE DELIVERY",
+            targets: [
+              {
+                deliveryGroup: {
+                  id: "gid://shopify/DeliveryGroup/0",
+                },
+              },
+            ],
+            value: {
+              percentage: {
+                value: 100,
+              },
+            },
+          },
+        ],
+        selectionStrategy: DeliveryDiscountSelectionStrategy.All,
+      },
+    });
+  });
+});
+{%- endif -%} 

--- a/discounts/javascript/discount/default/src/generate_delivery_run.test.liquid
+++ b/discounts/javascript/discount/default/src/generate_delivery_run.test.liquid
@@ -6,9 +6,14 @@ import {
   DeliveryDiscountSelectionStrategy,
 } from "../generated/api";
 
+/**
+ * @typedef {import("../generated/api").CartDeliveryOptionsDiscountsGenerateRunResult} CartDeliveryOptionsDiscountsGenerateRunResult
+ * @typedef {import("../generated/api").DeliveryInput} DeliveryInput
+ */
+
 describe("generateDeliveryRun", () => {
   it("returns a delivery discount", () => {
-    const input = {
+    const input = /** @type {DeliveryInput} */ ({
       cart: {
         deliveryGroups: [
           {
@@ -16,7 +21,7 @@ describe("generateDeliveryRun", () => {
           },
         ],
       },
-    };
+    });
 
     const result = generateDeliveryRun(input);
 
@@ -51,11 +56,13 @@ import { describe, it, expect } from "vitest";
 import { generateDeliveryRun } from "./generate_delivery_run";
 import {
   DeliveryDiscountSelectionStrategy,
+  DeliveryInput,
+  CartDeliveryOptionsDiscountsGenerateRunResult
 } from "../generated/api";
 
 describe("generateDeliveryRun", () => {
   it("returns a delivery discount", () => {
-    const input = {
+    const input: DeliveryInput = {
       cart: {
         deliveryGroups: [
           {
@@ -65,7 +72,7 @@ describe("generateDeliveryRun", () => {
       },
     };
 
-    const result = generateDeliveryRun(input);
+    const result: CartDeliveryOptionsDiscountsGenerateRunResult = generateDeliveryRun(input);
 
     expect(result.operations.length).toBe(1);
     expect(result.operations[0]).toMatchObject({


### PR DESCRIPTION
# Split discount tests into separate files

This PR splits the combined discount test file into separate test files for each function:

1. Created `generate_cart_run.test.liquid` for testing cart-based discounts
2. Created `generate_delivery_run.test.liquid` for testing delivery-based discounts
3. Removed the original combined `discount.test.liquid` file

This change follows the one-test-file-per-implementation-file pattern, making it easier to maintain tests and implement new functionality. Tests continue to pass for both JavaScript and TypeScript flavors.
