### PR TITLE
Fix max cart line amount comparison

### DIFF
--- a/discounts/javascript/discount/default/src/generate_cart_run.liquid
+++ b/discounts/javascript/discount/default/src/generate_cart_run.liquid
@@ -21,7 +21,7 @@ export function generateCartRun(input) {
         throw new Error('No cart lines found');
     }
     const maxCartLine = input.cart.lines.reduce((maxLine, line) => {
-        if (line.cost.subtotalAmount > maxLine.cost.subtotalAmount) {
+        if (line.cost.subtotalAmount.amount > maxLine.cost.subtotalAmount.amount) {
             return line;
         }
         return maxLine;
@@ -89,7 +89,7 @@ export function generateCartRun(input: CartInput): CartLinesDiscountsGenerateRun
   }
 
   const maxCartLine = input.cart.lines.reduce((maxLine, line) => {
-    if (line.cost.subtotalAmount > maxLine.cost.subtotalAmount) {
+    if (line.cost.subtotalAmount.amount > maxLine.cost.subtotalAmount.amount) {
       return line;
     }
     return maxLine;


### PR DESCRIPTION
The max cart line was not looking at `subtotalAmount.amount` so the comparison was not working properly when comparing the subtotal amounts of two lines.