### PR TITLE
Update fulfillment constraints to use the new target

### DIFF
--- a/order-routing/javascript/fulfillment-constraints/default/schema.graphql
+++ b/order-routing/javascript/fulfillment-constraints/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,154 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
+"""
+input CartFulfillmentConstraintsGenerateRunResult {
+  """
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
+  """
+  operations: [Operation!]!
+}
+
+"""
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +293,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +382,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +473,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +508,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1753,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2564,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2576,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2630,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2665,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2726,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,14 +2747,43 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
+}
+
+"""
+Force a set of items to be fulfilled from a specified location.
+If the cart item isn't stocked at the specified location, then checkout won't return any shipping rates and
+completing checkout will be blocked.
+"""
+input DeliverableLinesMustFulfillFromAddOperation {
+  """
+  The IDs of the deliverable lines for which the constraint is applied.
+  """
+  deliverableLineIds: [ID!]
+
+  """
+  The IDs of the locations for which the cart lines must fulfill from.
+  """
+  locationIds: [ID!]!
+}
+
+"""
+Force a set of items to be fulfilled from the same location.
+If the cart items with constraints aren't stocked at the same location,
+then checkout won't return any shipping rates and completing checkout will be blocked.
+"""
+input DeliverableLinesMustFulfillFromSameLocationAddOperation {
+  """
+  The IDs of the deliverable lines for which the constraint is applied.
+  """
+  deliverableLineIds: [ID!]
 }
 
 """
@@ -2668,43 +2822,143 @@ enum DeliveryMethod {
 }
 
 """
+An operation to apply fulfillment constraints.
+"""
+input DeprecatedOperation @oneOf {
+  """
+  Force a set of items to be fulfilled from a specified location.
+  If the cart item isn't stocked at the specified location, then checkout won't return any shipping rates and
+  completing checkout will be blocked.
+  """
+  mustFulfillFrom: MustFulfillFrom @deprecated(reason: "Use `deliverableLinesMustFulfillFromAdd` instead.")
+
+  """
+  Force a set of items to be fulfilled from the same location.
+  If the cart items with constraints aren't stocked at the same location,
+  then checkout won't return any shipping rates and completing checkout will be blocked.
+  """
+  mustFulfillFromSameLocation: MustFulfillFromSameLocation @deprecated(reason: "Use `deliverableLinesMustFulfillFromSameLocationAdd` instead.")
+}
+
+"""
 A customization which applies constraint rules to order routing and fulfillments.
 """
 type FulfillmentConstraintRule implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
+In API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The fulfillment constraints determined by the function.
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
   """
-  operations: [Operation!]!
+  operations: [DeprecatedOperation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
 """
 input FunctionRunResult {
   """
-  The fulfillment constraints determined by the function.
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
   """
-  operations: [Operation!]!
+  operations: [DeprecatedOperation!]!
+}
+
+"""
+Represents a gate configuration.
+"""
+type GateConfiguration implements HasMetafields {
+  """
+  An optional string identifier.
+  """
+  appId: String
+
+  """
+  A non-unique string used to group gate configurations.
+  """
+  handle: Handle
+
+  """
+  The ID of the gate configuration.
+  """
+  id: ID!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+}
+
+"""
+Represents a connection from a subject to a gate configuration.
+"""
+type GateSubject {
+  """
+  The bound gate configuration.
+  """
+  configuration(
+    """
+    The appId of the gate configurations to search for.
+    """
+    appId: String @deprecated(reason: "Use GateSubject.handle to filter gates instead.")
+  ): GateConfiguration!
+
+  """
+  The ID of the gate subject.
+  """
+  id: ID!
 }
 
 """
@@ -2715,36 +2969,61 @@ Example value: `"10079785100"`
 scalar Handle
 
 """
+Gate subjects associated to the specified resource.
+"""
+interface HasGates {
+  """
+  Returns active gate subjects bound to the resource.
+  """
+  gates(
+    """
+    The handle of the gate configurations to search for.
+    """
+    handle: Handle
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
+}
+
+"""
 Represents information about the metafields associated to the specified resource.
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2762,42 +3041,55 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The fulfillment constraint rule containing the function.
+  The backend logic that the Function uses to determine how to
+  [fulfill orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders). It includes the
+  [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   fulfillmentConstraintRule: FulfillmentConstraintRule!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  A list of all locations for the current shop.
+  A list of all geographical locations where the inventory is stored,
+  including warehouses, retail locations, and distribution centers.
   """
   locations(
     """
-    The list of location GIDs to search for.
+    A list of [globally-unique identifiers](https://shopify.dev/docs/api/usage/gids)
+    for the locations where inventory resides.
     """
-    identifiers: [String!]
+    identifiers: [ID!]
 
     """
-    The list of location names to search for.
+    A list of location names where the inventory resides.
     """
     names: [String!]
   ): [Location!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2820,7 +3112,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3540,7 +3833,18 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+Local pickup settings associated with a location.
+"""
+type LocalPickup {
+  """
+  Whether local pickup is enabled for the location.
+  """
+  enabled: Boolean!
+}
+
+"""
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3620,23 +3924,29 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
   """
   The market of the active localized experience.
   """
-  market: Market!
+  market: Market! @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 }
 
 """
@@ -3667,187 +3977,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3872,16 +4182,29 @@ type Location implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  Local pickup settings associated with a location.
+  """
+  localPickup: LocalPickup!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4009,7 +4332,7 @@ type MailingAddress {
   """
   The market of the address.
   """
-  market: Market
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 
   """
   The full name of the customer, based on firstName and lastName.
@@ -4052,16 +4375,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4098,47 +4429,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4177,6 +4521,16 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
+  Handles the Function result for the cart.fulfillment-constraints.generate.run target.
+  """
+  cartFulfillmentConstraintsGenerateRun(
+    """
+    The result of the Function.
+    """
+    result: CartFulfillmentConstraintsGenerateRunResult!
+  ): Void!
+
+  """
   Handles the Function result.
   """
   handleResult(
@@ -4206,66 +4560,99 @@ input Operation @oneOf {
   If the cart item isn't stocked at the specified location, then checkout won't return any shipping rates and
   completing checkout will be blocked.
   """
-  mustFulfillFrom: MustFulfillFrom
+  deliverableLinesMustFulfillFromAdd: DeliverableLinesMustFulfillFromAddOperation
 
   """
   Force a set of items to be fulfilled from the same location.
   If the cart items with constraints aren't stocked at the same location,
   then checkout won't return any shipping rates and completing checkout will be blocked.
   """
-  mustFulfillFromSameLocation: MustFulfillFromSameLocation
+  deliverableLinesMustFulfillFromSameLocationAdd: DeliverableLinesMustFulfillFromSameLocationAddOperation
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
-type Product implements HasMetafields {
+type Product implements HasGates & HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  Returns active gate subjects bound to the resource.
+  """
+  gates(
+    """
+    The handle of the gate configurations to search for.
+    """
+    handle: Handle
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
+
+  """
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4276,27 +4663,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4307,62 +4706,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4396,16 +4814,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4465,25 +4891,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/order-routing/javascript/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/javascript/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2025-01"
+api_version = "2025-07"
 
 [[extensions]]
 name = "t:name"
@@ -8,7 +8,7 @@ type = "function"
 description = "t:description"
 
   [[extensions.targeting]]
-  target = "purchase.fulfillment-constraint-rule.run"
+  target = "cart.fulfillment-constraints.generate.run"
   input_query = "src/run.graphql"
   export = "run"
 

--- a/order-routing/javascript/fulfillment-constraints/default/src/run.liquid
+++ b/order-routing/javascript/fulfillment-constraints/default/src/run.liquid
@@ -3,11 +3,11 @@
 
 /**
  * @typedef {import("../generated/api").RunInput} RunInput
- * @typedef {import("../generated/api").FunctionRunResult} FunctionRunResult
+ * @typedef {import("../generated/api").CartFulfillmentConstraintsGenerateRunResult} CartFulfillmentConstraintsGenerateRunResult
  */
 
 /**
- * @type {FunctionRunResult}
+ * @type {CartFulfillmentConstraintsGenerateRunResult}
  */
 const NO_CHANGES = {
   operations: [],
@@ -15,7 +15,7 @@ const NO_CHANGES = {
 
 /**
  * @param {RunInput} input
- * @returns {FunctionRunResult}
+ * @returns {CartFulfillmentConstraintsGenerateRunResult}
  */
 export function run(input) {
   const configuration = JSON.parse(
@@ -27,16 +27,16 @@ export function run(input) {
 {%- elsif flavor contains "typescript" -%}
 import type {
   RunInput,
-  FunctionRunResult,
+  CartFulfillmentConstraintsGenerateRunResult,
 } from "../generated/api";
 
-const NO_CHANGES: FunctionRunResult = {
+const NO_CHANGES: CartFulfillmentConstraintsGenerateRunResult = {
   operations: [],
 };
 
 type Configuration = {};
 
-export function run(input: RunInput): FunctionRunResult {
+export function run(input: RunInput): CartFulfillmentConstraintsGenerateRunResult {
   const configuration: Configuration = JSON.parse(
     input?.fulfillmentConstraintRule?.metafield?.value ?? "{}"
   );

--- a/order-routing/javascript/fulfillment-constraints/default/src/run.test.liquid
+++ b/order-routing/javascript/fulfillment-constraints/default/src/run.test.liquid
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { run } from './run';
 
 /**
- * @typedef {import("../generated/api").FunctionRunResult} FunctionRunResult
+ * @typedef {import("../generated/api").CartFulfillmentConstraintsGenerateRunResult} CartFulfillmentConstraintsGenerateRunResult
  */
 
 describe('fulfillment constraint rule function', () => {
@@ -23,7 +23,7 @@ describe('fulfillment constraint rule function', () => {
         metafield: null
       }
     });
-    const expected = /** @type {FunctionRunResult} */ ({ operations: [] });
+    const expected = /** @type {CartFulfillmentConstraintsGenerateRunResult} */ ({ operations: [] });
 
     expect(result).toEqual(expected);
   });
@@ -31,7 +31,7 @@ describe('fulfillment constraint rule function', () => {
 {%- elsif flavor contains "typescript" -%}
 import { describe, it, expect } from 'vitest';
 import { run } from './run';
-import { FunctionRunResult } from '../generated/api';
+import { CartFulfillmentConstraintsGenerateRunResult } from '../generated/api';
 
 describe('fulfillment constraint rule function', () => {
   it('returns no operations without configuration', () => {
@@ -50,7 +50,7 @@ describe('fulfillment constraint rule function', () => {
         metafield: null
       }
     });
-    const expected: FunctionRunResult = { operations: [] };
+    const expected: CartFulfillmentConstraintsGenerateRunResult = { operations: [] };
 
     expect(result).toEqual(expected);
   });

--- a/order-routing/rust/fulfillment-constraints/default/schema.graphql
+++ b/order-routing/rust/fulfillment-constraints/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,154 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
+"""
+input CartFulfillmentConstraintsGenerateRunResult {
+  """
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
+  """
+  operations: [Operation!]!
+}
+
+"""
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +293,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +382,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +473,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +508,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1753,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2564,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2576,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2630,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2665,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2726,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,14 +2747,43 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
+}
+
+"""
+Force a set of items to be fulfilled from a specified location.
+If the cart item isn't stocked at the specified location, then checkout won't return any shipping rates and
+completing checkout will be blocked.
+"""
+input DeliverableLinesMustFulfillFromAddOperation {
+  """
+  The IDs of the deliverable lines for which the constraint is applied.
+  """
+  deliverableLineIds: [ID!]
+
+  """
+  The IDs of the locations for which the cart lines must fulfill from.
+  """
+  locationIds: [ID!]!
+}
+
+"""
+Force a set of items to be fulfilled from the same location.
+If the cart items with constraints aren't stocked at the same location,
+then checkout won't return any shipping rates and completing checkout will be blocked.
+"""
+input DeliverableLinesMustFulfillFromSameLocationAddOperation {
+  """
+  The IDs of the deliverable lines for which the constraint is applied.
+  """
+  deliverableLineIds: [ID!]
 }
 
 """
@@ -2668,43 +2822,143 @@ enum DeliveryMethod {
 }
 
 """
+An operation to apply fulfillment constraints.
+"""
+input DeprecatedOperation @oneOf {
+  """
+  Force a set of items to be fulfilled from a specified location.
+  If the cart item isn't stocked at the specified location, then checkout won't return any shipping rates and
+  completing checkout will be blocked.
+  """
+  mustFulfillFrom: MustFulfillFrom @deprecated(reason: "Use `deliverableLinesMustFulfillFromAdd` instead.")
+
+  """
+  Force a set of items to be fulfilled from the same location.
+  If the cart items with constraints aren't stocked at the same location,
+  then checkout won't return any shipping rates and completing checkout will be blocked.
+  """
+  mustFulfillFromSameLocation: MustFulfillFromSameLocation @deprecated(reason: "Use `deliverableLinesMustFulfillFromSameLocationAdd` instead.")
+}
+
+"""
 A customization which applies constraint rules to order routing and fulfillments.
 """
 type FulfillmentConstraintRule implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
+In API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The fulfillment constraints determined by the function.
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
   """
-  operations: [Operation!]!
+  operations: [DeprecatedOperation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
 """
 input FunctionRunResult {
   """
-  The fulfillment constraints determined by the function.
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
   """
-  operations: [Operation!]!
+  operations: [DeprecatedOperation!]!
+}
+
+"""
+Represents a gate configuration.
+"""
+type GateConfiguration implements HasMetafields {
+  """
+  An optional string identifier.
+  """
+  appId: String
+
+  """
+  A non-unique string used to group gate configurations.
+  """
+  handle: Handle
+
+  """
+  The ID of the gate configuration.
+  """
+  id: ID!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+}
+
+"""
+Represents a connection from a subject to a gate configuration.
+"""
+type GateSubject {
+  """
+  The bound gate configuration.
+  """
+  configuration(
+    """
+    The appId of the gate configurations to search for.
+    """
+    appId: String @deprecated(reason: "Use GateSubject.handle to filter gates instead.")
+  ): GateConfiguration!
+
+  """
+  The ID of the gate subject.
+  """
+  id: ID!
 }
 
 """
@@ -2715,36 +2969,61 @@ Example value: `"10079785100"`
 scalar Handle
 
 """
+Gate subjects associated to the specified resource.
+"""
+interface HasGates {
+  """
+  Returns active gate subjects bound to the resource.
+  """
+  gates(
+    """
+    The handle of the gate configurations to search for.
+    """
+    handle: Handle
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
+}
+
+"""
 Represents information about the metafields associated to the specified resource.
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2762,42 +3041,55 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The fulfillment constraint rule containing the function.
+  The backend logic that the Function uses to determine how to
+  [fulfill orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders). It includes the
+  [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   fulfillmentConstraintRule: FulfillmentConstraintRule!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  A list of all locations for the current shop.
+  A list of all geographical locations where the inventory is stored,
+  including warehouses, retail locations, and distribution centers.
   """
   locations(
     """
-    The list of location GIDs to search for.
+    A list of [globally-unique identifiers](https://shopify.dev/docs/api/usage/gids)
+    for the locations where inventory resides.
     """
-    identifiers: [String!]
+    identifiers: [ID!]
 
     """
-    The list of location names to search for.
+    A list of location names where the inventory resides.
     """
     names: [String!]
   ): [Location!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2820,7 +3112,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3540,7 +3833,18 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+Local pickup settings associated with a location.
+"""
+type LocalPickup {
+  """
+  Whether local pickup is enabled for the location.
+  """
+  enabled: Boolean!
+}
+
+"""
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3620,23 +3924,29 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
   """
   The market of the active localized experience.
   """
-  market: Market!
+  market: Market! @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 }
 
 """
@@ -3667,187 +3977,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3872,16 +4182,29 @@ type Location implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  Local pickup settings associated with a location.
+  """
+  localPickup: LocalPickup!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4009,7 +4332,7 @@ type MailingAddress {
   """
   The market of the address.
   """
-  market: Market
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 
   """
   The full name of the customer, based on firstName and lastName.
@@ -4052,16 +4375,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4098,47 +4429,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4177,6 +4521,16 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
+  Handles the Function result for the cart.fulfillment-constraints.generate.run target.
+  """
+  cartFulfillmentConstraintsGenerateRun(
+    """
+    The result of the Function.
+    """
+    result: CartFulfillmentConstraintsGenerateRunResult!
+  ): Void!
+
+  """
   Handles the Function result.
   """
   handleResult(
@@ -4206,66 +4560,99 @@ input Operation @oneOf {
   If the cart item isn't stocked at the specified location, then checkout won't return any shipping rates and
   completing checkout will be blocked.
   """
-  mustFulfillFrom: MustFulfillFrom
+  deliverableLinesMustFulfillFromAdd: DeliverableLinesMustFulfillFromAddOperation
 
   """
   Force a set of items to be fulfilled from the same location.
   If the cart items with constraints aren't stocked at the same location,
   then checkout won't return any shipping rates and completing checkout will be blocked.
   """
-  mustFulfillFromSameLocation: MustFulfillFromSameLocation
+  deliverableLinesMustFulfillFromSameLocationAdd: DeliverableLinesMustFulfillFromSameLocationAddOperation
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
-type Product implements HasMetafields {
+type Product implements HasGates & HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  Returns active gate subjects bound to the resource.
+  """
+  gates(
+    """
+    The handle of the gate configurations to search for.
+    """
+    handle: Handle
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
+
+  """
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4276,27 +4663,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4307,62 +4706,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4396,16 +4814,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4465,25 +4891,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2025-01"
+api_version = "2025-07"
 
 [[extensions]]
 name = "t:name"
@@ -8,7 +8,7 @@ type = "function"
 description = "t:description"
 
   [[extensions.targeting]]
-  target = "purchase.fulfillment-constraint-rule.run"
+  target = "cart.fulfillment-constraints.generate.run"
   input_query = "src/run.graphql"
   export = "run"
 

--- a/order-routing/rust/fulfillment-constraints/default/src/run.rs
+++ b/order-routing/rust/fulfillment-constraints/default/src/run.rs
@@ -7,12 +7,12 @@ use serde::{Deserialize, Serialize};
 struct Config {}
 
 #[shopify_function_target(query_path = "src/run.graphql", schema_path = "schema.graphql")]
-fn run(_input: input::ResponseData) -> Result<output::FunctionRunResult> {
+fn run(_input: input::ResponseData) -> Result<output::CartFulfillmentConstraintsGenerateRunResult> {
     let operations = vec![];
 
     // Build operations based on the input query response here.
 
-    Ok(output::FunctionRunResult { operations })
+    Ok(output::CartFulfillmentConstraintsGenerateRunResult { operations })
 }
 
 #[cfg(test)]
@@ -45,7 +45,7 @@ mod tests {
             "#,
         )?;
 
-        let expected = FunctionRunResult { operations: vec![] };
+        let expected = CartFulfillmentConstraintsGenerateRunResult { operations: vec![] };
 
         assert_eq!(result, expected);
         Ok(())

--- a/order-routing/wasm/fulfillment-constraints/default/schema.graphql
+++ b/order-routing/wasm/fulfillment-constraints/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,154 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
+"""
+input CartFulfillmentConstraintsGenerateRunResult {
+  """
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
+  """
+  operations: [Operation!]!
+}
+
+"""
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +293,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +382,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +473,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +508,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1753,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2564,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2576,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2630,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2665,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2726,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,14 +2747,43 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
+}
+
+"""
+Force a set of items to be fulfilled from a specified location.
+If the cart item isn't stocked at the specified location, then checkout won't return any shipping rates and
+completing checkout will be blocked.
+"""
+input DeliverableLinesMustFulfillFromAddOperation {
+  """
+  The IDs of the deliverable lines for which the constraint is applied.
+  """
+  deliverableLineIds: [ID!]
+
+  """
+  The IDs of the locations for which the cart lines must fulfill from.
+  """
+  locationIds: [ID!]!
+}
+
+"""
+Force a set of items to be fulfilled from the same location.
+If the cart items with constraints aren't stocked at the same location,
+then checkout won't return any shipping rates and completing checkout will be blocked.
+"""
+input DeliverableLinesMustFulfillFromSameLocationAddOperation {
+  """
+  The IDs of the deliverable lines for which the constraint is applied.
+  """
+  deliverableLineIds: [ID!]
 }
 
 """
@@ -2668,43 +2822,143 @@ enum DeliveryMethod {
 }
 
 """
+An operation to apply fulfillment constraints.
+"""
+input DeprecatedOperation @oneOf {
+  """
+  Force a set of items to be fulfilled from a specified location.
+  If the cart item isn't stocked at the specified location, then checkout won't return any shipping rates and
+  completing checkout will be blocked.
+  """
+  mustFulfillFrom: MustFulfillFrom @deprecated(reason: "Use `deliverableLinesMustFulfillFromAdd` instead.")
+
+  """
+  Force a set of items to be fulfilled from the same location.
+  If the cart items with constraints aren't stocked at the same location,
+  then checkout won't return any shipping rates and completing checkout will be blocked.
+  """
+  mustFulfillFromSameLocation: MustFulfillFromSameLocation @deprecated(reason: "Use `deliverableLinesMustFulfillFromSameLocationAdd` instead.")
+}
+
+"""
 A customization which applies constraint rules to order routing and fulfillments.
 """
 type FulfillmentConstraintRule implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
+In API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The fulfillment constraints determined by the function.
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
   """
-  operations: [Operation!]!
+  operations: [DeprecatedOperation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
 """
 input FunctionRunResult {
   """
-  The fulfillment constraints determined by the function.
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
   """
-  operations: [Operation!]!
+  operations: [DeprecatedOperation!]!
+}
+
+"""
+Represents a gate configuration.
+"""
+type GateConfiguration implements HasMetafields {
+  """
+  An optional string identifier.
+  """
+  appId: String
+
+  """
+  A non-unique string used to group gate configurations.
+  """
+  handle: Handle
+
+  """
+  The ID of the gate configuration.
+  """
+  id: ID!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+}
+
+"""
+Represents a connection from a subject to a gate configuration.
+"""
+type GateSubject {
+  """
+  The bound gate configuration.
+  """
+  configuration(
+    """
+    The appId of the gate configurations to search for.
+    """
+    appId: String @deprecated(reason: "Use GateSubject.handle to filter gates instead.")
+  ): GateConfiguration!
+
+  """
+  The ID of the gate subject.
+  """
+  id: ID!
 }
 
 """
@@ -2715,36 +2969,61 @@ Example value: `"10079785100"`
 scalar Handle
 
 """
+Gate subjects associated to the specified resource.
+"""
+interface HasGates {
+  """
+  Returns active gate subjects bound to the resource.
+  """
+  gates(
+    """
+    The handle of the gate configurations to search for.
+    """
+    handle: Handle
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
+}
+
+"""
 Represents information about the metafields associated to the specified resource.
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2762,42 +3041,55 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The fulfillment constraint rule containing the function.
+  The backend logic that the Function uses to determine how to
+  [fulfill orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders). It includes the
+  [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   fulfillmentConstraintRule: FulfillmentConstraintRule!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  A list of all locations for the current shop.
+  A list of all geographical locations where the inventory is stored,
+  including warehouses, retail locations, and distribution centers.
   """
   locations(
     """
-    The list of location GIDs to search for.
+    A list of [globally-unique identifiers](https://shopify.dev/docs/api/usage/gids)
+    for the locations where inventory resides.
     """
-    identifiers: [String!]
+    identifiers: [ID!]
 
     """
-    The list of location names to search for.
+    A list of location names where the inventory resides.
     """
     names: [String!]
   ): [Location!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2820,7 +3112,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3540,7 +3833,18 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+Local pickup settings associated with a location.
+"""
+type LocalPickup {
+  """
+  Whether local pickup is enabled for the location.
+  """
+  enabled: Boolean!
+}
+
+"""
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3620,23 +3924,29 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
   """
   The market of the active localized experience.
   """
-  market: Market!
+  market: Market! @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 }
 
 """
@@ -3667,187 +3977,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3872,16 +4182,29 @@ type Location implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  Local pickup settings associated with a location.
+  """
+  localPickup: LocalPickup!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4009,7 +4332,7 @@ type MailingAddress {
   """
   The market of the address.
   """
-  market: Market
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 
   """
   The full name of the customer, based on firstName and lastName.
@@ -4052,16 +4375,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4098,47 +4429,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4177,6 +4521,16 @@ The root mutation for the API.
 """
 type MutationRoot {
   """
+  Handles the Function result for the cart.fulfillment-constraints.generate.run target.
+  """
+  cartFulfillmentConstraintsGenerateRun(
+    """
+    The result of the Function.
+    """
+    result: CartFulfillmentConstraintsGenerateRunResult!
+  ): Void!
+
+  """
   Handles the Function result.
   """
   handleResult(
@@ -4206,66 +4560,99 @@ input Operation @oneOf {
   If the cart item isn't stocked at the specified location, then checkout won't return any shipping rates and
   completing checkout will be blocked.
   """
-  mustFulfillFrom: MustFulfillFrom
+  deliverableLinesMustFulfillFromAdd: DeliverableLinesMustFulfillFromAddOperation
 
   """
   Force a set of items to be fulfilled from the same location.
   If the cart items with constraints aren't stocked at the same location,
   then checkout won't return any shipping rates and completing checkout will be blocked.
   """
-  mustFulfillFromSameLocation: MustFulfillFromSameLocation
+  deliverableLinesMustFulfillFromSameLocationAdd: DeliverableLinesMustFulfillFromSameLocationAddOperation
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
-type Product implements HasMetafields {
+type Product implements HasGates & HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  Returns active gate subjects bound to the resource.
+  """
+  gates(
+    """
+    The handle of the gate configurations to search for.
+    """
+    handle: Handle
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
+
+  """
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4276,27 +4663,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4307,62 +4706,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4396,16 +4814,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4465,25 +4891,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/order-routing/wasm/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/wasm/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2025-01"
+api_version = "2025-07"
 
 [[extensions]]
 name = "t:name"
@@ -8,7 +8,7 @@ type = "function"
 description = "t:description"
 
   [[extensions.targeting]]
-  target = "purchase.fulfillment-constraint-rule.run"
+  target = "cart.fulfillment-constraints.generate.run"
   input_query = "run.graphql"
   export = "run"
 


### PR DESCRIPTION
Part of the ongoing project to rationalise the function API 

[gsd#44156](https://vault.shopify.io/gsd/projects/44156-Shopify-Functions-Rename-and-consolidate-Shopify-Function-targets) | [doc](https://docs.google.com/document/d/1q4-JlwgH2hGV0Eq9llZn0kGUB01yY7kRdbgqNHpirk8) | [style guide](https://github.com/Shopify/functions-api-design/blob/main/docs/NAMING.md) | [slack](https://shopify.enterprise.slack.com/archives/C08B8N3KJQH)

This PR updates the Fulfillment Constraints templates

Specifically:

 - Pulled the latest schema. (`shopify app function schema` in a fulfillment constraints extension with the `function_renaming_breaking_changes_api` flag enabled.)
 - Updated the sample code, replacing the target handle and result types. 
 - Bumped the version to `2025-07` where appropriate