### PR TITLE
Regenerate schemas

### DIFF
--- a/checkout/javascript/cart-checkout-validation/default/schema.graphql
+++ b/checkout/javascript/cart-checkout-validation/default/schema.graphql
@@ -14,11 +14,17 @@ Scale the Functions resource limits based on the field's length.
 directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,31 +35,39 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
@@ -83,46 +97,59 @@ enum BuyerJourneyStep {
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -133,113 +160,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -249,59 +303,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -326,16 +392,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -409,16 +483,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -436,7 +518,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1679,9 +1763,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2491,7 +2574,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2500,43 +2586,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2546,27 +2640,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2576,22 +2675,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2629,13 +2736,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2646,12 +2757,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2701,37 +2812,42 @@ input FunctionError {
   localizedMessage: String!
 
   """
-  Specifies the path/target for use by the UI.
+  Specifies the path/target for use by the UI. See [Supported checkout field targets](https://shopify.dev/docs/api/functions/reference/cart-checkout-validation/graphql#supported-checkout-field-targets)
+  for a list of supported targets.
   """
   target: String!
 }
 
 """
-The fetch target result. Refer to network access for Shopify Functions.
+The fetch target result. Your Function must return this data structure when generating the request.
 """
 input FunctionFetchResult {
   """
-  HTTP Request.
+  The attributes associated with an HTTP request.
   """
   request: HttpRequest
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target. The object contains the validation errors
+that display to customers and prevent them from proceeding through checkout. In
+API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  Errors.
+  The validation errors that block a customer from proceeding through checkout.
   """
   errors: [FunctionError!]!
 }
 
 """
-The run target result.
+The output of the Function run target. The object contains the validation errors
+that display to customers and prevent them from proceeding through checkout.
 """
 input FunctionRunResult {
   """
-  Errors.
+  The validation errors that block a customer from proceeding through checkout.
   """
   errors: [FunctionError!]!
 }
@@ -2748,32 +2864,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2926,39 +3052,63 @@ Example value: `"gid://shopify/Product/10079785100"`
 """
 scalar ID
 
+"""
+The `Input` object is the complete GraphQL schema that your Function can receive
+as input to validate cart and checkout. Your Function receives only the fields
+that you request in the input query. To optimize performance, we highly
+recommend that you request only the fields that your Function requires.
+"""
 type Input {
   """
-  The buyer journey step.
+  Information about the current step in the buyer's purchasing process. The
+  buyer journey helps you determine where the customer is in their shopping
+  experience (for example, cart interaction, checkout interaction, or completing
+  a checkout). You can use this information to apply appropriate validation
+  rules based on the customer's current context and create a more tailored and
+  performant shopping experience.
   """
   buyerJourney: BuyerJourney!
 
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The result of the fetch target. Refer to network access for Shopify Functions.
+  The `FunctionFetchResult` object is the result of the fetch target. This is
+  the response that Shopify returns after executing the HTTP request defined in
+  your fetch target, and that is passed as input to the run target. For more
+  information, refer to [network access for Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/network-access).
   """
   fetchResult: HttpResponse @restrictTarget(only: ["purchase.validation.run"])
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 
   """
-  The validation rule that owns the current function.
+  The configuration of the app that owns the Function. This configuration
+  controls how merchants can define validation rules for carts and checkout,
+  such as inventory checks, price validations, or custom purchase restrictions.
   """
   validation: Validation!
 }
@@ -2981,7 +3131,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3701,7 +3852,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3781,16 +3933,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3828,187 +3986,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -4108,16 +4266,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4154,47 +4320,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4235,55 +4414,78 @@ type MutationRoot {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4294,27 +4496,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4325,62 +4539,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4414,16 +4647,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4483,25 +4724,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4528,16 +4779,24 @@ A customization that validates a cart and/or checkout.
 """
 type Validation implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/checkout/javascript/cart-transform/default/schema.graphql
+++ b/checkout/javascript/cart-transform/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,93 +35,119 @@ type Attribute {
 }
 
 """
-Key-value pairs that contains additional information.
+The custom attributes associated with a cart line to store additional information. Cart attributes
+allow you to collect specific information from customers on the **Cart** page, such as order notes,
+gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 """
 input AttributeOutput {
   """
-  Key or name of the attribute.
+  The key of the cart line attribute to retrieve. For example, `"gift_wrapping"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the cart line attribute to retrieve. For example, `"true"`.
   """
   value: String!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -125,51 +157,60 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 input CartLineInput {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
@@ -180,56 +221,84 @@ input CartLineInput {
 }
 
 """
-An operation to apply to the Cart.
+An operation to apply to the cart. For example, you can expand a cart line item to display
+its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+multiple cart lines into a single line representing a bundle, and update the presentation of line items
+in the cart to override their price, title, or image.
 """
 input CartOperation @oneOf {
   """
-  A cart line expand operation.
+  An operation that expands a single cart line item to form a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   expand: ExpandOperation
 
   """
-  A cart line merge operation.
+  An operation that merges multiple cart line items into a
+  single line, representing a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   merge: MergeOperation
 
   """
-  A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+  An operation that allows you to override the price, title,
+  and image of a cart line item. Only stores on a
+  [Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+  can use apps with `update` operations.
   """
   update: UpdateOperation
 }
 
 """
-A customization which applies cart transformations to the merchandise lines.
+A customization that changes the pricing and
+presentation of items in a cart. For example,
+you can modify the appearance of cart items,
+such as updating titles and images,
+or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
 """
 type CartTransform implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -254,16 +323,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -337,16 +414,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -364,7 +449,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1607,9 +1694,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2419,7 +2505,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2428,43 +2517,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2474,27 +2571,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2504,22 +2606,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2553,53 +2663,74 @@ Example values: `"29.99"`, `"29.999"`.
 scalar Decimal
 
 """
-A cart line expand operation.
+An operation that expands a single cart line item to form a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input ExpandOperation {
   """
-  The cart line id to expand.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The cart items to expand.
+  The cart items to expand. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+  bundle is a group of products that are sold together as a single unit.
   """
   expandedCartItems: [ExpandedItem!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  Title override. If title is not provided, variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
 
+"""
+The cart item to expand. Each item is a component of the
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+bundle is a group of products that are sold together as a single unit.
+"""
 input ExpandedItem {
   """
-  The CartLine attributes to be added to component line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The merchandise id of the expanded item.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant that represents the expanded item.
   """
   merchandiseId: ID!
 
   """
-  The price adjustment for the expanded item.
+  A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: ExpandedItemPriceAdjustment
 
   """
-  The quantity of the expanded item.The max quantity is 2000.
+  The quantity of the expanded item. The maximum quantity is
+  2000.
   """
   quantity: Int!
 }
@@ -2615,11 +2746,13 @@ input ExpandedItemFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to the expanded item.
+A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
 """
 input ExpandedItemPriceAdjustment {
   """
-  The price adjustment for the expanded item.
+  The value of the price adjustment to apply to the expanded item.
   """
   adjustment: ExpandedItemPriceAdjustmentValue!
 }
@@ -2635,21 +2768,31 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart.
 """
 input FunctionRunResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
@@ -2666,32 +2809,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2705,7 +2858,8 @@ Example value: `"gid://shopify/Product/10079785100"`
 scalar ID
 
 """
-The image of an object.
+An image that replaces the existing image for a single cart line item or group of cart line items.
+The image must have a publicly accessible URL.
 """
 input ImageInput {
   """
@@ -2716,27 +2870,39 @@ input ImageInput {
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The CartTransform containing the function.
+  A customization that changes the pricing and
+  presentation of items in a cart. For example,
+  you can modify the appearance of cart items,
+  such as updating titles and images,
+  or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartTransform: CartTransform!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2759,7 +2925,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3479,7 +3646,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3559,16 +3727,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3598,16 +3772,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3644,82 +3826,106 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-A cart line merge operation.
+An operation that merges multiple cart line items into a
+single line, representing a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input MergeOperation {
   """
-  The CartLine attributes to be added to the parent line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The list of cart lines to merge.
+  The cart items to merge. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartLines: [CartLineInput!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The product variant that models the group of lines.
+  The [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  of the product variant that represents the collection of cart line items.
   """
   parentVariantId: ID!
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  The name of the group of lines to merge. If it isn't specified, it will use the parent_variant' name.
+  The title that replaces the existing title for a group of cart line items.
+  If you don't provide a title, then the title of the parent variant is used.
   """
   title: String
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -3749,6 +3955,11 @@ type MutationRoot {
   ): Void!
 }
 
+"""
+A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
+"""
 input PriceAdjustment {
   """
   The percentage price decrease of the price adjustment.
@@ -3764,55 +3975,78 @@ input PriceAdjustmentValue {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3823,27 +4057,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3854,62 +4100,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3943,16 +4208,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4012,25 +4285,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4053,26 +4336,35 @@ For example, `"https://example.myshopify.com"` is a valid URL. It includes a sch
 scalar URL
 
 """
-A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+An operation that allows you to override the price, title,
+and image of a cart line item. Only stores on a
+[Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+can use apps with `update` operations.
 """
 input UpdateOperation {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The image override for the cart line item.
+  The image that replaces the existing image for the cart line item.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment for the cart line item.
+  A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+  price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+  for which the customer qualifies.
   """
   price: UpdateOperationPriceAdjustment
 
   """
-  The title override for the cart line item.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
@@ -4088,7 +4380,9 @@ input UpdateOperationFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+for which the customer qualifies.
 """
 input UpdateOperationPriceAdjustment {
   """
@@ -4098,7 +4392,7 @@ input UpdateOperationPriceAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+The value of the price adjustment to apply to the updated item.
 """
 input UpdateOperationPriceAdjustmentValue @oneOf {
   """

--- a/checkout/javascript/delivery-customization/default/schema.graphql
+++ b/checkout/javascript/delivery-customization/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1739,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2550,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2562,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2616,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2651,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2712,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,12 +2733,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2637,16 +2748,24 @@ A customization representing how delivery options will be ordered, hidden, or re
 """
 type DeliveryCustomization implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2688,21 +2807,27 @@ enum DeliveryMethod {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to apply to delivery options in checkout. In
+API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The ordered list of operations to apply to the list of delivery options.
+  The ordered list of operations to apply to the list of
+  [delivery options](https://shopify.dev/docs/apps/build/checkout/delivery-shipping/delivery-options/build-function).
   """
   operations: [Operation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to apply to delivery options in checkout.
 """
 input FunctionRunResult {
   """
-  The ordered list of operations to apply to the list of delivery options.
+  The ordered list of operations to apply to the list of
+  [delivery options](https://shopify.dev/docs/apps/build/checkout/delivery-shipping/delivery-options/build-function).
   """
   operations: [Operation!]!
 }
@@ -2719,38 +2844,48 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
 
 """
-Request to hide a delivery option.
+An operation that hides a delivery option from a list that's offered to customers at checkout.
 """
 input HideOperation {
   """
@@ -2769,27 +2904,39 @@ scalar ID
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The delivery customization that owns the current function.
+  The backend logic that the Function is running to define how
+  [delivery options](https://shopify.dev/apps/build/checkout/delivery-shipping/delivery-options/build-function)
+  are sorted, hidden, or renamed. It includes the
+  [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   deliveryCustomization: DeliveryCustomization!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2812,7 +2959,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3532,7 +3680,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3612,16 +3761,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3659,187 +3814,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3939,16 +4094,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3985,53 +4148,71 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
 
 """
-Request to move a delivery option to a new index.
+An operation that sorts a list of delivery options that are offered to customers at checkout.
+
+If you reorder shipping delivery options, then you are
+[prohibited](https://shopify.dev/docs/apps/launch/app-requirements-checklist#prohibited-app-types).
+from automatically selecting higher-priced delivery alternatives by default. The cheapest shipping delivery option
+must always be the first option selected.
 """
 input MoveOperation {
   """
@@ -4075,71 +4256,104 @@ An operation to apply to the list of delivery options.
 """
 input Operation @oneOf {
   """
-  Request to hide a delivery option.
+  An operation that hides a delivery option from a list that's offered to customers at checkout.
   """
   hide: HideOperation
 
   """
-  Request to move a delivery option to a new index.
+  An operation that sorts a list of delivery options that are offered to customers at checkout.
+
+  If you reorder shipping delivery options, then you are
+  [prohibited](https://shopify.dev/docs/apps/launch/app-requirements-checklist#prohibited-app-types).
+  from automatically selecting higher-priced delivery alternatives by default. The cheapest shipping delivery option
+  must always be the first option selected.
   """
   move: MoveOperation
 
   """
-  Request to rename a delivery option.
+  An operation that renames a delivery option that's offered to customers at checkout.
+
+  The carrier name is automatically prepended to the delivery option title at checkout when using the
+  `RenameOperation` object, and can't be altered or omitted through the API. For example, if the carrier name
+  is **UPS** and the option is **Standard**, then you could change **UPS Standard** to **UPS Standard Shipping**,
+  but you couldn't change **UPS Standard** to **Standard Shipping**.
   """
   rename: RenameOperation
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4150,27 +4364,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4181,62 +4407,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4256,7 +4501,12 @@ type PurchasingCompany {
 }
 
 """
-Request to rename a delivery option.
+An operation that renames a delivery option that's offered to customers at checkout.
+
+The carrier name is automatically prepended to the delivery option title at checkout when using the
+`RenameOperation` object, and can't be altered or omitted through the API. For example, if the carrier name
+is **UPS** and the option is **Standard**, then you could change **UPS Standard** to **UPS Standard Shipping**,
+but you couldn't change **UPS Standard** to **Standard Shipping**.
 """
 input RenameOperation {
   """
@@ -4285,16 +4535,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4354,25 +4612,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/checkout/javascript/payment-customization/default/schema.graphql
+++ b/checkout/javascript/payment-customization/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1739,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2550,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2562,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2616,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2651,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2712,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,12 +2733,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2668,7 +2779,9 @@ enum DeliveryMethod {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target. The object contains the operations to
+apply to payment methods in checkout. In API versions 2023-10 and beyond, this
+type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
@@ -2678,7 +2791,7 @@ input FunctionResult {
 }
 
 """
-The run target result.
+The output of the Function run target. The object contains the operations to apply to payment methods in checkout.
 """
 input FunctionRunResult {
   """
@@ -2699,38 +2812,54 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
 
 """
-Request to hide a payment method.
+A request to hide a payment method during checkout.
+
+When your Function returns this operation, it removes the specified payment method
+from the available options shown to customers during checkout.
+
+Use this operation when you want to conditionally hide payment methods based on
+checkout attributes, customer data, or other business logic implemented in your Function.
 """
 input HideOperation {
   """
@@ -2752,34 +2881,51 @@ Example value: `"gid://shopify/Product/10079785100"`
 """
 scalar ID
 
+"""
+The `Input` object is the complete GraphQL schema that your Function can query
+as an input to customize the payment methods that are available to customers
+during checkout. Your Function receives only the fields that you request in the
+input query. To optimize performance, we highly recommend that you request only
+the fields that your function requires.
+"""
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The payment customization that owns the current function.
+  The configuration of the app that owns the Function. This configuration
+  controls how merchants can modify [payment methods](https://help.shopify.com/manual/checkout-settings/checkout-customization),
+  such as renaming, reordering, or hiding them.
   """
   paymentCustomization: PaymentCustomization!
 
   """
-  The list of payment methods.
+  The list of payment methods that are available to customers during checkout that your Function can customize.
   """
   paymentMethods: [PaymentCustomizationPaymentMethod!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2802,7 +2948,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3522,7 +3669,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3602,16 +3750,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3649,187 +3803,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3929,16 +4083,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3975,53 +4137,72 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
 
 """
-Request to move a payment method to a new index.
+A request to move a payment method to a new position in the checkout display order.
+
+When your Function returns this operation, it changes the display order of payment methods
+by placing the specified payment method at the requested index position.
+
+Use this operation when you want to prioritize certain payment methods based on
+checkout context, customer preferences, or other business logic implemented in your Function.
 """
 input MoveOperation {
   """
@@ -4065,17 +4246,36 @@ An operation to apply to the list of payment methods.
 """
 input Operation @oneOf {
   """
-  Request to hide a payment method.
+  A request to hide a payment method during checkout.
+
+  When your Function returns this operation, it removes the specified payment method
+  from the available options shown to customers during checkout.
+
+  Use this operation when you want to conditionally hide payment methods based on
+  checkout attributes, customer data, or other business logic implemented in your Function.
   """
   hide: HideOperation
 
   """
-  Request to move a payment method to a new index.
+  A request to move a payment method to a new position in the checkout display order.
+
+  When your Function returns this operation, it changes the display order of payment methods
+  by placing the specified payment method at the requested index position.
+
+  Use this operation when you want to prioritize certain payment methods based on
+  checkout context, customer preferences, or other business logic implemented in your Function.
   """
   move: MoveOperation
 
   """
-  Request to rename a payment method.
+  A request to change the displayed name of a payment method during checkout.
+
+  When your Function returns this operation, it replaces the default name of the
+  specified payment method with the custom name that's provided in the request.
+
+  Use this operation when you want to provide more context or clarity about
+  payment methods based on checkout details, locale, or other business logic
+  implemented in your Function.
   """
   rename: RenameOperation
 }
@@ -4085,16 +4285,24 @@ A customization representing how payment methods will be ordered, hidden, or ren
 """
 type PaymentCustomization implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4124,8 +4332,8 @@ Only available for API clients installed on a Shopify Plus store.
 """
 enum PaymentCustomizationPaymentMethodPlacement {
   """
-  Accelerated checkout button in the Express section of checkout. Payment method can be used to accelerate a
-  buyer through checkout by prefilling delivery and payment information.
+  Accelerated checkout button in the Express section of checkout. You can use payment methods to accelerate
+  customers through checkout by prefilling delivery and payment information.
   """
   ACCELERATED_CHECKOUT
 
@@ -4136,55 +4344,78 @@ enum PaymentCustomizationPaymentMethodPlacement {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4195,27 +4426,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4226,62 +4469,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4301,7 +4563,14 @@ type PurchasingCompany {
 }
 
 """
-Request to rename a payment method.
+A request to change the displayed name of a payment method during checkout.
+
+When your Function returns this operation, it replaces the default name of the
+specified payment method with the custom name that's provided in the request.
+
+Use this operation when you want to provide more context or clarity about
+payment methods based on checkout details, locale, or other business logic
+implemented in your Function.
 """
 input RenameOperation {
   """
@@ -4330,16 +4599,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4399,25 +4676,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/checkout/rust/cart-checkout-validation/default/schema.graphql
+++ b/checkout/rust/cart-checkout-validation/default/schema.graphql
@@ -14,11 +14,17 @@ Scale the Functions resource limits based on the field's length.
 directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,31 +35,39 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
@@ -83,46 +97,59 @@ enum BuyerJourneyStep {
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -133,113 +160,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -249,59 +303,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -326,16 +392,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -409,16 +483,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -436,7 +518,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1679,9 +1763,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2491,7 +2574,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2500,43 +2586,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2546,27 +2640,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2576,22 +2675,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2629,13 +2736,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2646,12 +2757,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2701,37 +2812,42 @@ input FunctionError {
   localizedMessage: String!
 
   """
-  Specifies the path/target for use by the UI.
+  Specifies the path/target for use by the UI. See [Supported checkout field targets](https://shopify.dev/docs/api/functions/reference/cart-checkout-validation/graphql#supported-checkout-field-targets)
+  for a list of supported targets.
   """
   target: String!
 }
 
 """
-The fetch target result. Refer to network access for Shopify Functions.
+The fetch target result. Your Function must return this data structure when generating the request.
 """
 input FunctionFetchResult {
   """
-  HTTP Request.
+  The attributes associated with an HTTP request.
   """
   request: HttpRequest
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target. The object contains the validation errors
+that display to customers and prevent them from proceeding through checkout. In
+API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  Errors.
+  The validation errors that block a customer from proceeding through checkout.
   """
   errors: [FunctionError!]!
 }
 
 """
-The run target result.
+The output of the Function run target. The object contains the validation errors
+that display to customers and prevent them from proceeding through checkout.
 """
 input FunctionRunResult {
   """
-  Errors.
+  The validation errors that block a customer from proceeding through checkout.
   """
   errors: [FunctionError!]!
 }
@@ -2748,32 +2864,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2926,39 +3052,63 @@ Example value: `"gid://shopify/Product/10079785100"`
 """
 scalar ID
 
+"""
+The `Input` object is the complete GraphQL schema that your Function can receive
+as input to validate cart and checkout. Your Function receives only the fields
+that you request in the input query. To optimize performance, we highly
+recommend that you request only the fields that your Function requires.
+"""
 type Input {
   """
-  The buyer journey step.
+  Information about the current step in the buyer's purchasing process. The
+  buyer journey helps you determine where the customer is in their shopping
+  experience (for example, cart interaction, checkout interaction, or completing
+  a checkout). You can use this information to apply appropriate validation
+  rules based on the customer's current context and create a more tailored and
+  performant shopping experience.
   """
   buyerJourney: BuyerJourney!
 
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The result of the fetch target. Refer to network access for Shopify Functions.
+  The `FunctionFetchResult` object is the result of the fetch target. This is
+  the response that Shopify returns after executing the HTTP request defined in
+  your fetch target, and that is passed as input to the run target. For more
+  information, refer to [network access for Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/network-access).
   """
   fetchResult: HttpResponse @restrictTarget(only: ["purchase.validation.run"])
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 
   """
-  The validation rule that owns the current function.
+  The configuration of the app that owns the Function. This configuration
+  controls how merchants can define validation rules for carts and checkout,
+  such as inventory checks, price validations, or custom purchase restrictions.
   """
   validation: Validation!
 }
@@ -2981,7 +3131,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3701,7 +3852,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3781,16 +3933,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3828,187 +3986,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -4108,16 +4266,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4154,47 +4320,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4235,55 +4414,78 @@ type MutationRoot {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4294,27 +4496,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4325,62 +4539,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4414,16 +4647,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4483,25 +4724,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4528,16 +4779,24 @@ A customization that validates a cart and/or checkout.
 """
 type Validation implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/checkout/rust/cart-transform/bundles/schema.graphql
+++ b/checkout/rust/cart-transform/bundles/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,93 +35,119 @@ type Attribute {
 }
 
 """
-Key-value pairs that contains additional information.
+The custom attributes associated with a cart line to store additional information. Cart attributes
+allow you to collect specific information from customers on the **Cart** page, such as order notes,
+gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 """
 input AttributeOutput {
   """
-  Key or name of the attribute.
+  The key of the cart line attribute to retrieve. For example, `"gift_wrapping"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the cart line attribute to retrieve. For example, `"true"`.
   """
   value: String!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -125,51 +157,60 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 input CartLineInput {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
@@ -180,56 +221,84 @@ input CartLineInput {
 }
 
 """
-An operation to apply to the Cart.
+An operation to apply to the cart. For example, you can expand a cart line item to display
+its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+multiple cart lines into a single line representing a bundle, and update the presentation of line items
+in the cart to override their price, title, or image.
 """
 input CartOperation @oneOf {
   """
-  A cart line expand operation.
+  An operation that expands a single cart line item to form a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   expand: ExpandOperation
 
   """
-  A cart line merge operation.
+  An operation that merges multiple cart line items into a
+  single line, representing a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   merge: MergeOperation
 
   """
-  A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+  An operation that allows you to override the price, title,
+  and image of a cart line item. Only stores on a
+  [Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+  can use apps with `update` operations.
   """
   update: UpdateOperation
 }
 
 """
-A customization which applies cart transformations to the merchandise lines.
+A customization that changes the pricing and
+presentation of items in a cart. For example,
+you can modify the appearance of cart items,
+such as updating titles and images,
+or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
 """
 type CartTransform implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -254,16 +323,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -337,16 +414,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -364,7 +449,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1607,9 +1694,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2419,7 +2505,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2428,43 +2517,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2474,27 +2571,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2504,22 +2606,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2553,53 +2663,74 @@ Example values: `"29.99"`, `"29.999"`.
 scalar Decimal
 
 """
-A cart line expand operation.
+An operation that expands a single cart line item to form a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input ExpandOperation {
   """
-  The cart line id to expand.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The cart items to expand.
+  The cart items to expand. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+  bundle is a group of products that are sold together as a single unit.
   """
   expandedCartItems: [ExpandedItem!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  Title override. If title is not provided, variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
 
+"""
+The cart item to expand. Each item is a component of the
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+bundle is a group of products that are sold together as a single unit.
+"""
 input ExpandedItem {
   """
-  The CartLine attributes to be added to component line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The merchandise id of the expanded item.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant that represents the expanded item.
   """
   merchandiseId: ID!
 
   """
-  The price adjustment for the expanded item.
+  A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: ExpandedItemPriceAdjustment
 
   """
-  The quantity of the expanded item.The max quantity is 2000.
+  The quantity of the expanded item. The maximum quantity is
+  2000.
   """
   quantity: Int!
 }
@@ -2615,11 +2746,13 @@ input ExpandedItemFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to the expanded item.
+A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
 """
 input ExpandedItemPriceAdjustment {
   """
-  The price adjustment for the expanded item.
+  The value of the price adjustment to apply to the expanded item.
   """
   adjustment: ExpandedItemPriceAdjustmentValue!
 }
@@ -2635,21 +2768,31 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart.
 """
 input FunctionRunResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
@@ -2666,32 +2809,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2705,7 +2858,8 @@ Example value: `"gid://shopify/Product/10079785100"`
 scalar ID
 
 """
-The image of an object.
+An image that replaces the existing image for a single cart line item or group of cart line items.
+The image must have a publicly accessible URL.
 """
 input ImageInput {
   """
@@ -2716,27 +2870,39 @@ input ImageInput {
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The CartTransform containing the function.
+  A customization that changes the pricing and
+  presentation of items in a cart. For example,
+  you can modify the appearance of cart items,
+  such as updating titles and images,
+  or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartTransform: CartTransform!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2759,7 +2925,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3479,7 +3646,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3559,16 +3727,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3598,16 +3772,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3644,82 +3826,106 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-A cart line merge operation.
+An operation that merges multiple cart line items into a
+single line, representing a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input MergeOperation {
   """
-  The CartLine attributes to be added to the parent line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The list of cart lines to merge.
+  The cart items to merge. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartLines: [CartLineInput!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The product variant that models the group of lines.
+  The [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  of the product variant that represents the collection of cart line items.
   """
   parentVariantId: ID!
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  The name of the group of lines to merge. If it isn't specified, it will use the parent_variant' name.
+  The title that replaces the existing title for a group of cart line items.
+  If you don't provide a title, then the title of the parent variant is used.
   """
   title: String
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -3749,6 +3955,11 @@ type MutationRoot {
   ): Void!
 }
 
+"""
+A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
+"""
 input PriceAdjustment {
   """
   The percentage price decrease of the price adjustment.
@@ -3764,55 +3975,78 @@ input PriceAdjustmentValue {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3823,27 +4057,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3854,62 +4100,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3943,16 +4208,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4012,25 +4285,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4053,26 +4336,35 @@ For example, `"https://example.myshopify.com"` is a valid URL. It includes a sch
 scalar URL
 
 """
-A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+An operation that allows you to override the price, title,
+and image of a cart line item. Only stores on a
+[Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+can use apps with `update` operations.
 """
 input UpdateOperation {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The image override for the cart line item.
+  The image that replaces the existing image for the cart line item.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment for the cart line item.
+  A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+  price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+  for which the customer qualifies.
   """
   price: UpdateOperationPriceAdjustment
 
   """
-  The title override for the cart line item.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
@@ -4088,7 +4380,9 @@ input UpdateOperationFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+for which the customer qualifies.
 """
 input UpdateOperationPriceAdjustment {
   """
@@ -4098,7 +4392,7 @@ input UpdateOperationPriceAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+The value of the price adjustment to apply to the updated item.
 """
 input UpdateOperationPriceAdjustmentValue @oneOf {
   """

--- a/checkout/rust/cart-transform/default/schema.graphql
+++ b/checkout/rust/cart-transform/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,93 +35,119 @@ type Attribute {
 }
 
 """
-Key-value pairs that contains additional information.
+The custom attributes associated with a cart line to store additional information. Cart attributes
+allow you to collect specific information from customers on the **Cart** page, such as order notes,
+gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 """
 input AttributeOutput {
   """
-  Key or name of the attribute.
+  The key of the cart line attribute to retrieve. For example, `"gift_wrapping"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the cart line attribute to retrieve. For example, `"true"`.
   """
   value: String!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -125,51 +157,60 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 input CartLineInput {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
@@ -180,56 +221,84 @@ input CartLineInput {
 }
 
 """
-An operation to apply to the Cart.
+An operation to apply to the cart. For example, you can expand a cart line item to display
+its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+multiple cart lines into a single line representing a bundle, and update the presentation of line items
+in the cart to override their price, title, or image.
 """
 input CartOperation @oneOf {
   """
-  A cart line expand operation.
+  An operation that expands a single cart line item to form a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   expand: ExpandOperation
 
   """
-  A cart line merge operation.
+  An operation that merges multiple cart line items into a
+  single line, representing a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   merge: MergeOperation
 
   """
-  A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+  An operation that allows you to override the price, title,
+  and image of a cart line item. Only stores on a
+  [Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+  can use apps with `update` operations.
   """
   update: UpdateOperation
 }
 
 """
-A customization which applies cart transformations to the merchandise lines.
+A customization that changes the pricing and
+presentation of items in a cart. For example,
+you can modify the appearance of cart items,
+such as updating titles and images,
+or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
 """
 type CartTransform implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -254,16 +323,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -337,16 +414,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -364,7 +449,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1607,9 +1694,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2419,7 +2505,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2428,43 +2517,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2474,27 +2571,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2504,22 +2606,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2553,53 +2663,74 @@ Example values: `"29.99"`, `"29.999"`.
 scalar Decimal
 
 """
-A cart line expand operation.
+An operation that expands a single cart line item to form a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input ExpandOperation {
   """
-  The cart line id to expand.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The cart items to expand.
+  The cart items to expand. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+  bundle is a group of products that are sold together as a single unit.
   """
   expandedCartItems: [ExpandedItem!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  Title override. If title is not provided, variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
 
+"""
+The cart item to expand. Each item is a component of the
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+bundle is a group of products that are sold together as a single unit.
+"""
 input ExpandedItem {
   """
-  The CartLine attributes to be added to component line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The merchandise id of the expanded item.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant that represents the expanded item.
   """
   merchandiseId: ID!
 
   """
-  The price adjustment for the expanded item.
+  A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: ExpandedItemPriceAdjustment
 
   """
-  The quantity of the expanded item.The max quantity is 2000.
+  The quantity of the expanded item. The maximum quantity is
+  2000.
   """
   quantity: Int!
 }
@@ -2615,11 +2746,13 @@ input ExpandedItemFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to the expanded item.
+A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
 """
 input ExpandedItemPriceAdjustment {
   """
-  The price adjustment for the expanded item.
+  The value of the price adjustment to apply to the expanded item.
   """
   adjustment: ExpandedItemPriceAdjustmentValue!
 }
@@ -2635,21 +2768,31 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart.
 """
 input FunctionRunResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
@@ -2666,32 +2809,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2705,7 +2858,8 @@ Example value: `"gid://shopify/Product/10079785100"`
 scalar ID
 
 """
-The image of an object.
+An image that replaces the existing image for a single cart line item or group of cart line items.
+The image must have a publicly accessible URL.
 """
 input ImageInput {
   """
@@ -2716,27 +2870,39 @@ input ImageInput {
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The CartTransform containing the function.
+  A customization that changes the pricing and
+  presentation of items in a cart. For example,
+  you can modify the appearance of cart items,
+  such as updating titles and images,
+  or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartTransform: CartTransform!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2759,7 +2925,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3479,7 +3646,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3559,16 +3727,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3598,16 +3772,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3644,82 +3826,106 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-A cart line merge operation.
+An operation that merges multiple cart line items into a
+single line, representing a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input MergeOperation {
   """
-  The CartLine attributes to be added to the parent line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The list of cart lines to merge.
+  The cart items to merge. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartLines: [CartLineInput!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The product variant that models the group of lines.
+  The [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  of the product variant that represents the collection of cart line items.
   """
   parentVariantId: ID!
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  The name of the group of lines to merge. If it isn't specified, it will use the parent_variant' name.
+  The title that replaces the existing title for a group of cart line items.
+  If you don't provide a title, then the title of the parent variant is used.
   """
   title: String
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -3749,6 +3955,11 @@ type MutationRoot {
   ): Void!
 }
 
+"""
+A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
+"""
 input PriceAdjustment {
   """
   The percentage price decrease of the price adjustment.
@@ -3764,55 +3975,78 @@ input PriceAdjustmentValue {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3823,27 +4057,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3854,62 +4100,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3943,16 +4208,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4012,25 +4285,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4053,26 +4336,35 @@ For example, `"https://example.myshopify.com"` is a valid URL. It includes a sch
 scalar URL
 
 """
-A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+An operation that allows you to override the price, title,
+and image of a cart line item. Only stores on a
+[Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+can use apps with `update` operations.
 """
 input UpdateOperation {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The image override for the cart line item.
+  The image that replaces the existing image for the cart line item.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment for the cart line item.
+  A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+  price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+  for which the customer qualifies.
   """
   price: UpdateOperationPriceAdjustment
 
   """
-  The title override for the cart line item.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
@@ -4088,7 +4380,9 @@ input UpdateOperationFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+for which the customer qualifies.
 """
 input UpdateOperationPriceAdjustment {
   """
@@ -4098,7 +4392,7 @@ input UpdateOperationPriceAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+The value of the price adjustment to apply to the updated item.
 """
 input UpdateOperationPriceAdjustmentValue @oneOf {
   """

--- a/checkout/rust/delivery-customization/default/schema.graphql
+++ b/checkout/rust/delivery-customization/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1739,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2550,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2562,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2616,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2651,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2712,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,12 +2733,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2637,16 +2748,24 @@ A customization representing how delivery options will be ordered, hidden, or re
 """
 type DeliveryCustomization implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2688,21 +2807,27 @@ enum DeliveryMethod {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to apply to delivery options in checkout. In
+API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The ordered list of operations to apply to the list of delivery options.
+  The ordered list of operations to apply to the list of
+  [delivery options](https://shopify.dev/docs/apps/build/checkout/delivery-shipping/delivery-options/build-function).
   """
   operations: [Operation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to apply to delivery options in checkout.
 """
 input FunctionRunResult {
   """
-  The ordered list of operations to apply to the list of delivery options.
+  The ordered list of operations to apply to the list of
+  [delivery options](https://shopify.dev/docs/apps/build/checkout/delivery-shipping/delivery-options/build-function).
   """
   operations: [Operation!]!
 }
@@ -2719,38 +2844,48 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
 
 """
-Request to hide a delivery option.
+An operation that hides a delivery option from a list that's offered to customers at checkout.
 """
 input HideOperation {
   """
@@ -2769,27 +2904,39 @@ scalar ID
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The delivery customization that owns the current function.
+  The backend logic that the Function is running to define how
+  [delivery options](https://shopify.dev/apps/build/checkout/delivery-shipping/delivery-options/build-function)
+  are sorted, hidden, or renamed. It includes the
+  [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   deliveryCustomization: DeliveryCustomization!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2812,7 +2959,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3532,7 +3680,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3612,16 +3761,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3659,187 +3814,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3939,16 +4094,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3985,53 +4148,71 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
 
 """
-Request to move a delivery option to a new index.
+An operation that sorts a list of delivery options that are offered to customers at checkout.
+
+If you reorder shipping delivery options, then you are
+[prohibited](https://shopify.dev/docs/apps/launch/app-requirements-checklist#prohibited-app-types).
+from automatically selecting higher-priced delivery alternatives by default. The cheapest shipping delivery option
+must always be the first option selected.
 """
 input MoveOperation {
   """
@@ -4075,71 +4256,104 @@ An operation to apply to the list of delivery options.
 """
 input Operation @oneOf {
   """
-  Request to hide a delivery option.
+  An operation that hides a delivery option from a list that's offered to customers at checkout.
   """
   hide: HideOperation
 
   """
-  Request to move a delivery option to a new index.
+  An operation that sorts a list of delivery options that are offered to customers at checkout.
+
+  If you reorder shipping delivery options, then you are
+  [prohibited](https://shopify.dev/docs/apps/launch/app-requirements-checklist#prohibited-app-types).
+  from automatically selecting higher-priced delivery alternatives by default. The cheapest shipping delivery option
+  must always be the first option selected.
   """
   move: MoveOperation
 
   """
-  Request to rename a delivery option.
+  An operation that renames a delivery option that's offered to customers at checkout.
+
+  The carrier name is automatically prepended to the delivery option title at checkout when using the
+  `RenameOperation` object, and can't be altered or omitted through the API. For example, if the carrier name
+  is **UPS** and the option is **Standard**, then you could change **UPS Standard** to **UPS Standard Shipping**,
+  but you couldn't change **UPS Standard** to **Standard Shipping**.
   """
   rename: RenameOperation
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4150,27 +4364,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4181,62 +4407,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4256,7 +4501,12 @@ type PurchasingCompany {
 }
 
 """
-Request to rename a delivery option.
+An operation that renames a delivery option that's offered to customers at checkout.
+
+The carrier name is automatically prepended to the delivery option title at checkout when using the
+`RenameOperation` object, and can't be altered or omitted through the API. For example, if the carrier name
+is **UPS** and the option is **Standard**, then you could change **UPS Standard** to **UPS Standard Shipping**,
+but you couldn't change **UPS Standard** to **Standard Shipping**.
 """
 input RenameOperation {
   """
@@ -4285,16 +4535,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4354,25 +4612,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/checkout/rust/payment-customization/default/schema.graphql
+++ b/checkout/rust/payment-customization/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1739,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2550,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2562,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2616,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2651,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2712,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,12 +2733,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2668,7 +2779,9 @@ enum DeliveryMethod {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target. The object contains the operations to
+apply to payment methods in checkout. In API versions 2023-10 and beyond, this
+type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
@@ -2678,7 +2791,7 @@ input FunctionResult {
 }
 
 """
-The run target result.
+The output of the Function run target. The object contains the operations to apply to payment methods in checkout.
 """
 input FunctionRunResult {
   """
@@ -2699,38 +2812,54 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
 
 """
-Request to hide a payment method.
+A request to hide a payment method during checkout.
+
+When your Function returns this operation, it removes the specified payment method
+from the available options shown to customers during checkout.
+
+Use this operation when you want to conditionally hide payment methods based on
+checkout attributes, customer data, or other business logic implemented in your Function.
 """
 input HideOperation {
   """
@@ -2752,34 +2881,51 @@ Example value: `"gid://shopify/Product/10079785100"`
 """
 scalar ID
 
+"""
+The `Input` object is the complete GraphQL schema that your Function can query
+as an input to customize the payment methods that are available to customers
+during checkout. Your Function receives only the fields that you request in the
+input query. To optimize performance, we highly recommend that you request only
+the fields that your function requires.
+"""
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The payment customization that owns the current function.
+  The configuration of the app that owns the Function. This configuration
+  controls how merchants can modify [payment methods](https://help.shopify.com/manual/checkout-settings/checkout-customization),
+  such as renaming, reordering, or hiding them.
   """
   paymentCustomization: PaymentCustomization!
 
   """
-  The list of payment methods.
+  The list of payment methods that are available to customers during checkout that your Function can customize.
   """
   paymentMethods: [PaymentCustomizationPaymentMethod!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2802,7 +2948,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3522,7 +3669,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3602,16 +3750,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3649,187 +3803,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3929,16 +4083,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3975,53 +4137,72 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
 
 """
-Request to move a payment method to a new index.
+A request to move a payment method to a new position in the checkout display order.
+
+When your Function returns this operation, it changes the display order of payment methods
+by placing the specified payment method at the requested index position.
+
+Use this operation when you want to prioritize certain payment methods based on
+checkout context, customer preferences, or other business logic implemented in your Function.
 """
 input MoveOperation {
   """
@@ -4065,17 +4246,36 @@ An operation to apply to the list of payment methods.
 """
 input Operation @oneOf {
   """
-  Request to hide a payment method.
+  A request to hide a payment method during checkout.
+
+  When your Function returns this operation, it removes the specified payment method
+  from the available options shown to customers during checkout.
+
+  Use this operation when you want to conditionally hide payment methods based on
+  checkout attributes, customer data, or other business logic implemented in your Function.
   """
   hide: HideOperation
 
   """
-  Request to move a payment method to a new index.
+  A request to move a payment method to a new position in the checkout display order.
+
+  When your Function returns this operation, it changes the display order of payment methods
+  by placing the specified payment method at the requested index position.
+
+  Use this operation when you want to prioritize certain payment methods based on
+  checkout context, customer preferences, or other business logic implemented in your Function.
   """
   move: MoveOperation
 
   """
-  Request to rename a payment method.
+  A request to change the displayed name of a payment method during checkout.
+
+  When your Function returns this operation, it replaces the default name of the
+  specified payment method with the custom name that's provided in the request.
+
+  Use this operation when you want to provide more context or clarity about
+  payment methods based on checkout details, locale, or other business logic
+  implemented in your Function.
   """
   rename: RenameOperation
 }
@@ -4085,16 +4285,24 @@ A customization representing how payment methods will be ordered, hidden, or ren
 """
 type PaymentCustomization implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4124,8 +4332,8 @@ Only available for API clients installed on a Shopify Plus store.
 """
 enum PaymentCustomizationPaymentMethodPlacement {
   """
-  Accelerated checkout button in the Express section of checkout. Payment method can be used to accelerate a
-  buyer through checkout by prefilling delivery and payment information.
+  Accelerated checkout button in the Express section of checkout. You can use payment methods to accelerate
+  customers through checkout by prefilling delivery and payment information.
   """
   ACCELERATED_CHECKOUT
 
@@ -4136,55 +4344,78 @@ enum PaymentCustomizationPaymentMethodPlacement {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4195,27 +4426,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4226,62 +4469,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4301,7 +4563,14 @@ type PurchasingCompany {
 }
 
 """
-Request to rename a payment method.
+A request to change the displayed name of a payment method during checkout.
+
+When your Function returns this operation, it replaces the default name of the
+specified payment method with the custom name that's provided in the request.
+
+Use this operation when you want to provide more context or clarity about
+payment methods based on checkout details, locale, or other business logic
+implemented in your Function.
 """
 input RenameOperation {
   """
@@ -4330,16 +4599,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4399,25 +4676,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/checkout/wasm/cart-checkout-validation/default/schema.graphql
+++ b/checkout/wasm/cart-checkout-validation/default/schema.graphql
@@ -14,11 +14,17 @@ Scale the Functions resource limits based on the field's length.
 directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,31 +35,39 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
@@ -83,46 +97,59 @@ enum BuyerJourneyStep {
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -133,113 +160,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -249,59 +303,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -326,16 +392,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -409,16 +483,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -436,7 +518,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1679,9 +1763,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2491,7 +2574,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2500,43 +2586,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2546,27 +2640,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2576,22 +2675,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2629,13 +2736,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2646,12 +2757,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2701,37 +2812,42 @@ input FunctionError {
   localizedMessage: String!
 
   """
-  Specifies the path/target for use by the UI.
+  Specifies the path/target for use by the UI. See [Supported checkout field targets](https://shopify.dev/docs/api/functions/reference/cart-checkout-validation/graphql#supported-checkout-field-targets)
+  for a list of supported targets.
   """
   target: String!
 }
 
 """
-The fetch target result. Refer to network access for Shopify Functions.
+The fetch target result. Your Function must return this data structure when generating the request.
 """
 input FunctionFetchResult {
   """
-  HTTP Request.
+  The attributes associated with an HTTP request.
   """
   request: HttpRequest
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target. The object contains the validation errors
+that display to customers and prevent them from proceeding through checkout. In
+API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  Errors.
+  The validation errors that block a customer from proceeding through checkout.
   """
   errors: [FunctionError!]!
 }
 
 """
-The run target result.
+The output of the Function run target. The object contains the validation errors
+that display to customers and prevent them from proceeding through checkout.
 """
 input FunctionRunResult {
   """
-  Errors.
+  The validation errors that block a customer from proceeding through checkout.
   """
   errors: [FunctionError!]!
 }
@@ -2748,32 +2864,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2926,39 +3052,63 @@ Example value: `"gid://shopify/Product/10079785100"`
 """
 scalar ID
 
+"""
+The `Input` object is the complete GraphQL schema that your Function can receive
+as input to validate cart and checkout. Your Function receives only the fields
+that you request in the input query. To optimize performance, we highly
+recommend that you request only the fields that your Function requires.
+"""
 type Input {
   """
-  The buyer journey step.
+  Information about the current step in the buyer's purchasing process. The
+  buyer journey helps you determine where the customer is in their shopping
+  experience (for example, cart interaction, checkout interaction, or completing
+  a checkout). You can use this information to apply appropriate validation
+  rules based on the customer's current context and create a more tailored and
+  performant shopping experience.
   """
   buyerJourney: BuyerJourney!
 
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The result of the fetch target. Refer to network access for Shopify Functions.
+  The `FunctionFetchResult` object is the result of the fetch target. This is
+  the response that Shopify returns after executing the HTTP request defined in
+  your fetch target, and that is passed as input to the run target. For more
+  information, refer to [network access for Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/network-access).
   """
   fetchResult: HttpResponse @restrictTarget(only: ["purchase.validation.run"])
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 
   """
-  The validation rule that owns the current function.
+  The configuration of the app that owns the Function. This configuration
+  controls how merchants can define validation rules for carts and checkout,
+  such as inventory checks, price validations, or custom purchase restrictions.
   """
   validation: Validation!
 }
@@ -2981,7 +3131,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3701,7 +3852,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3781,16 +3933,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3828,187 +3986,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -4108,16 +4266,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4154,47 +4320,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4235,55 +4414,78 @@ type MutationRoot {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4294,27 +4496,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4325,62 +4539,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4414,16 +4647,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4483,25 +4724,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4528,16 +4779,24 @@ A customization that validates a cart and/or checkout.
 """
 type Validation implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/checkout/wasm/cart-transform/default/schema.graphql
+++ b/checkout/wasm/cart-transform/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,93 +35,119 @@ type Attribute {
 }
 
 """
-Key-value pairs that contains additional information.
+The custom attributes associated with a cart line to store additional information. Cart attributes
+allow you to collect specific information from customers on the **Cart** page, such as order notes,
+gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 """
 input AttributeOutput {
   """
-  Key or name of the attribute.
+  The key of the cart line attribute to retrieve. For example, `"gift_wrapping"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the cart line attribute to retrieve. For example, `"true"`.
   """
   value: String!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -125,51 +157,60 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 input CartLineInput {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
@@ -180,56 +221,84 @@ input CartLineInput {
 }
 
 """
-An operation to apply to the Cart.
+An operation to apply to the cart. For example, you can expand a cart line item to display
+its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+multiple cart lines into a single line representing a bundle, and update the presentation of line items
+in the cart to override their price, title, or image.
 """
 input CartOperation @oneOf {
   """
-  A cart line expand operation.
+  An operation that expands a single cart line item to form a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   expand: ExpandOperation
 
   """
-  A cart line merge operation.
+  An operation that merges multiple cart line items into a
+  single line, representing a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   merge: MergeOperation
 
   """
-  A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+  An operation that allows you to override the price, title,
+  and image of a cart line item. Only stores on a
+  [Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+  can use apps with `update` operations.
   """
   update: UpdateOperation
 }
 
 """
-A customization which applies cart transformations to the merchandise lines.
+A customization that changes the pricing and
+presentation of items in a cart. For example,
+you can modify the appearance of cart items,
+such as updating titles and images,
+or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
 """
 type CartTransform implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -254,16 +323,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -337,16 +414,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -364,7 +449,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1607,9 +1694,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2419,7 +2505,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2428,43 +2517,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2474,27 +2571,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2504,22 +2606,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2553,53 +2663,74 @@ Example values: `"29.99"`, `"29.999"`.
 scalar Decimal
 
 """
-A cart line expand operation.
+An operation that expands a single cart line item to form a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input ExpandOperation {
   """
-  The cart line id to expand.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The cart items to expand.
+  The cart items to expand. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+  bundle is a group of products that are sold together as a single unit.
   """
   expandedCartItems: [ExpandedItem!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  Title override. If title is not provided, variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
 
+"""
+The cart item to expand. Each item is a component of the
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+bundle is a group of products that are sold together as a single unit.
+"""
 input ExpandedItem {
   """
-  The CartLine attributes to be added to component line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The merchandise id of the expanded item.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant that represents the expanded item.
   """
   merchandiseId: ID!
 
   """
-  The price adjustment for the expanded item.
+  A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: ExpandedItemPriceAdjustment
 
   """
-  The quantity of the expanded item.The max quantity is 2000.
+  The quantity of the expanded item. The maximum quantity is
+  2000.
   """
   quantity: Int!
 }
@@ -2615,11 +2746,13 @@ input ExpandedItemFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to the expanded item.
+A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
 """
 input ExpandedItemPriceAdjustment {
   """
-  The price adjustment for the expanded item.
+  The value of the price adjustment to apply to the expanded item.
   """
   adjustment: ExpandedItemPriceAdjustmentValue!
 }
@@ -2635,21 +2768,31 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart.
 """
 input FunctionRunResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
@@ -2666,32 +2809,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2705,7 +2858,8 @@ Example value: `"gid://shopify/Product/10079785100"`
 scalar ID
 
 """
-The image of an object.
+An image that replaces the existing image for a single cart line item or group of cart line items.
+The image must have a publicly accessible URL.
 """
 input ImageInput {
   """
@@ -2716,27 +2870,39 @@ input ImageInput {
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The CartTransform containing the function.
+  A customization that changes the pricing and
+  presentation of items in a cart. For example,
+  you can modify the appearance of cart items,
+  such as updating titles and images,
+  or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartTransform: CartTransform!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2759,7 +2925,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3479,7 +3646,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3559,16 +3727,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3598,16 +3772,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3644,82 +3826,106 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-A cart line merge operation.
+An operation that merges multiple cart line items into a
+single line, representing a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input MergeOperation {
   """
-  The CartLine attributes to be added to the parent line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The list of cart lines to merge.
+  The cart items to merge. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartLines: [CartLineInput!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The product variant that models the group of lines.
+  The [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  of the product variant that represents the collection of cart line items.
   """
   parentVariantId: ID!
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  The name of the group of lines to merge. If it isn't specified, it will use the parent_variant' name.
+  The title that replaces the existing title for a group of cart line items.
+  If you don't provide a title, then the title of the parent variant is used.
   """
   title: String
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -3749,6 +3955,11 @@ type MutationRoot {
   ): Void!
 }
 
+"""
+A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
+"""
 input PriceAdjustment {
   """
   The percentage price decrease of the price adjustment.
@@ -3764,55 +3975,78 @@ input PriceAdjustmentValue {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3823,27 +4057,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3854,62 +4100,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3943,16 +4208,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4012,25 +4285,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4053,26 +4336,35 @@ For example, `"https://example.myshopify.com"` is a valid URL. It includes a sch
 scalar URL
 
 """
-A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+An operation that allows you to override the price, title,
+and image of a cart line item. Only stores on a
+[Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+can use apps with `update` operations.
 """
 input UpdateOperation {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The image override for the cart line item.
+  The image that replaces the existing image for the cart line item.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment for the cart line item.
+  A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+  price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+  for which the customer qualifies.
   """
   price: UpdateOperationPriceAdjustment
 
   """
-  The title override for the cart line item.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
@@ -4088,7 +4380,9 @@ input UpdateOperationFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+for which the customer qualifies.
 """
 input UpdateOperationPriceAdjustment {
   """
@@ -4098,7 +4392,7 @@ input UpdateOperationPriceAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+The value of the price adjustment to apply to the updated item.
 """
 input UpdateOperationPriceAdjustmentValue @oneOf {
   """

--- a/checkout/wasm/delivery-customization/default/schema.graphql
+++ b/checkout/wasm/delivery-customization/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1739,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2550,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2562,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2616,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2651,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2712,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,12 +2733,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2637,16 +2748,24 @@ A customization representing how delivery options will be ordered, hidden, or re
 """
 type DeliveryCustomization implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2688,21 +2807,27 @@ enum DeliveryMethod {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to apply to delivery options in checkout. In
+API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The ordered list of operations to apply to the list of delivery options.
+  The ordered list of operations to apply to the list of
+  [delivery options](https://shopify.dev/docs/apps/build/checkout/delivery-shipping/delivery-options/build-function).
   """
   operations: [Operation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to apply to delivery options in checkout.
 """
 input FunctionRunResult {
   """
-  The ordered list of operations to apply to the list of delivery options.
+  The ordered list of operations to apply to the list of
+  [delivery options](https://shopify.dev/docs/apps/build/checkout/delivery-shipping/delivery-options/build-function).
   """
   operations: [Operation!]!
 }
@@ -2719,38 +2844,48 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
 
 """
-Request to hide a delivery option.
+An operation that hides a delivery option from a list that's offered to customers at checkout.
 """
 input HideOperation {
   """
@@ -2769,27 +2904,39 @@ scalar ID
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The delivery customization that owns the current function.
+  The backend logic that the Function is running to define how
+  [delivery options](https://shopify.dev/apps/build/checkout/delivery-shipping/delivery-options/build-function)
+  are sorted, hidden, or renamed. It includes the
+  [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   deliveryCustomization: DeliveryCustomization!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2812,7 +2959,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3532,7 +3680,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3612,16 +3761,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3659,187 +3814,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3939,16 +4094,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3985,53 +4148,71 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
 
 """
-Request to move a delivery option to a new index.
+An operation that sorts a list of delivery options that are offered to customers at checkout.
+
+If you reorder shipping delivery options, then you are
+[prohibited](https://shopify.dev/docs/apps/launch/app-requirements-checklist#prohibited-app-types).
+from automatically selecting higher-priced delivery alternatives by default. The cheapest shipping delivery option
+must always be the first option selected.
 """
 input MoveOperation {
   """
@@ -4075,71 +4256,104 @@ An operation to apply to the list of delivery options.
 """
 input Operation @oneOf {
   """
-  Request to hide a delivery option.
+  An operation that hides a delivery option from a list that's offered to customers at checkout.
   """
   hide: HideOperation
 
   """
-  Request to move a delivery option to a new index.
+  An operation that sorts a list of delivery options that are offered to customers at checkout.
+
+  If you reorder shipping delivery options, then you are
+  [prohibited](https://shopify.dev/docs/apps/launch/app-requirements-checklist#prohibited-app-types).
+  from automatically selecting higher-priced delivery alternatives by default. The cheapest shipping delivery option
+  must always be the first option selected.
   """
   move: MoveOperation
 
   """
-  Request to rename a delivery option.
+  An operation that renames a delivery option that's offered to customers at checkout.
+
+  The carrier name is automatically prepended to the delivery option title at checkout when using the
+  `RenameOperation` object, and can't be altered or omitted through the API. For example, if the carrier name
+  is **UPS** and the option is **Standard**, then you could change **UPS Standard** to **UPS Standard Shipping**,
+  but you couldn't change **UPS Standard** to **Standard Shipping**.
   """
   rename: RenameOperation
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4150,27 +4364,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4181,62 +4407,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4256,7 +4501,12 @@ type PurchasingCompany {
 }
 
 """
-Request to rename a delivery option.
+An operation that renames a delivery option that's offered to customers at checkout.
+
+The carrier name is automatically prepended to the delivery option title at checkout when using the
+`RenameOperation` object, and can't be altered or omitted through the API. For example, if the carrier name
+is **UPS** and the option is **Standard**, then you could change **UPS Standard** to **UPS Standard Shipping**,
+but you couldn't change **UPS Standard** to **Standard Shipping**.
 """
 input RenameOperation {
   """
@@ -4285,16 +4535,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4354,25 +4612,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/checkout/wasm/payment-customization/default/schema.graphql
+++ b/checkout/wasm/payment-customization/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1739,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2550,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2562,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2616,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2651,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2712,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,12 +2733,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2668,7 +2779,9 @@ enum DeliveryMethod {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target. The object contains the operations to
+apply to payment methods in checkout. In API versions 2023-10 and beyond, this
+type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
@@ -2678,7 +2791,7 @@ input FunctionResult {
 }
 
 """
-The run target result.
+The output of the Function run target. The object contains the operations to apply to payment methods in checkout.
 """
 input FunctionRunResult {
   """
@@ -2699,38 +2812,54 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
 
 """
-Request to hide a payment method.
+A request to hide a payment method during checkout.
+
+When your Function returns this operation, it removes the specified payment method
+from the available options shown to customers during checkout.
+
+Use this operation when you want to conditionally hide payment methods based on
+checkout attributes, customer data, or other business logic implemented in your Function.
 """
 input HideOperation {
   """
@@ -2752,34 +2881,51 @@ Example value: `"gid://shopify/Product/10079785100"`
 """
 scalar ID
 
+"""
+The `Input` object is the complete GraphQL schema that your Function can query
+as an input to customize the payment methods that are available to customers
+during checkout. Your Function receives only the fields that you request in the
+input query. To optimize performance, we highly recommend that you request only
+the fields that your function requires.
+"""
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The payment customization that owns the current function.
+  The configuration of the app that owns the Function. This configuration
+  controls how merchants can modify [payment methods](https://help.shopify.com/manual/checkout-settings/checkout-customization),
+  such as renaming, reordering, or hiding them.
   """
   paymentCustomization: PaymentCustomization!
 
   """
-  The list of payment methods.
+  The list of payment methods that are available to customers during checkout that your Function can customize.
   """
   paymentMethods: [PaymentCustomizationPaymentMethod!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2802,7 +2948,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3522,7 +3669,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3602,16 +3750,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3649,187 +3803,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3929,16 +4083,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3975,53 +4137,72 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
 
 """
-Request to move a payment method to a new index.
+A request to move a payment method to a new position in the checkout display order.
+
+When your Function returns this operation, it changes the display order of payment methods
+by placing the specified payment method at the requested index position.
+
+Use this operation when you want to prioritize certain payment methods based on
+checkout context, customer preferences, or other business logic implemented in your Function.
 """
 input MoveOperation {
   """
@@ -4065,17 +4246,36 @@ An operation to apply to the list of payment methods.
 """
 input Operation @oneOf {
   """
-  Request to hide a payment method.
+  A request to hide a payment method during checkout.
+
+  When your Function returns this operation, it removes the specified payment method
+  from the available options shown to customers during checkout.
+
+  Use this operation when you want to conditionally hide payment methods based on
+  checkout attributes, customer data, or other business logic implemented in your Function.
   """
   hide: HideOperation
 
   """
-  Request to move a payment method to a new index.
+  A request to move a payment method to a new position in the checkout display order.
+
+  When your Function returns this operation, it changes the display order of payment methods
+  by placing the specified payment method at the requested index position.
+
+  Use this operation when you want to prioritize certain payment methods based on
+  checkout context, customer preferences, or other business logic implemented in your Function.
   """
   move: MoveOperation
 
   """
-  Request to rename a payment method.
+  A request to change the displayed name of a payment method during checkout.
+
+  When your Function returns this operation, it replaces the default name of the
+  specified payment method with the custom name that's provided in the request.
+
+  Use this operation when you want to provide more context or clarity about
+  payment methods based on checkout details, locale, or other business logic
+  implemented in your Function.
   """
   rename: RenameOperation
 }
@@ -4085,16 +4285,24 @@ A customization representing how payment methods will be ordered, hidden, or ren
 """
 type PaymentCustomization implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4124,8 +4332,8 @@ Only available for API clients installed on a Shopify Plus store.
 """
 enum PaymentCustomizationPaymentMethodPlacement {
   """
-  Accelerated checkout button in the Express section of checkout. Payment method can be used to accelerate a
-  buyer through checkout by prefilling delivery and payment information.
+  Accelerated checkout button in the Express section of checkout. You can use payment methods to accelerate
+  customers through checkout by prefilling delivery and payment information.
   """
   ACCELERATED_CHECKOUT
 
@@ -4136,55 +4344,78 @@ enum PaymentCustomizationPaymentMethodPlacement {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4195,27 +4426,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4226,62 +4469,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4301,7 +4563,14 @@ type PurchasingCompany {
 }
 
 """
-Request to rename a payment method.
+A request to change the displayed name of a payment method during checkout.
+
+When your Function returns this operation, it replaces the default name of the
+specified payment method with the custom name that's provided in the request.
+
+Use this operation when you want to provide more context or clarity about
+payment methods based on checkout details, locale, or other business logic
+implemented in your Function.
 """
 input RenameOperation {
   """
@@ -4330,16 +4599,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4399,25 +4676,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/discounts/javascript/discount/default/schema.graphql
+++ b/discounts/javascript/discount/default/schema.graphql
@@ -29,11 +29,17 @@ input AssociatedDiscountCode {
 }
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -44,76 +50,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -124,102 +151,121 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-The cart.delivery-options.discounts.generate.fetch target result. Refer to
-[network access](https://shopify.dev/apps/build/functions/input-output/network-access/graphql) for Shopify Functions.
+The cart.delivery-options.discounts.generate.fetch target result. Refer to [network access](https://shopify.dev/apps/build/functions/input-output/network-access/graphql)
+for Shopify Functions.
 """
 input CartDeliveryOptionsDiscountsGenerateFetchResult {
   """
-  The http request.
+  The attributes associated with an HTTP request.
   """
   request: HttpRequest
 }
@@ -229,29 +275,37 @@ The cart.delivery-options.discounts.generate.run target result.
 """
 input CartDeliveryOptionsDiscountsGenerateRunResult {
   """
-  The list of operations to apply discounts to the delivery lines.
+  An ordered list of operations to generate delivery discounts, such as validating and applying discounts to the cart.
   """
   operations: [DeliveryOperation!]!
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -261,44 +315,51 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
@@ -314,7 +375,7 @@ input CartLineMinimumQuantity {
   ids: [ID!]!
 
   """
-  The minimum quantity of a product.
+  The minimum quantity of a cart line to be eligible for a discount candidate.
   """
   minimumQuantity: Int!
 }
@@ -330,13 +391,15 @@ input CartLineMinimumSubtotal {
   ids: [ID!]!
 
   """
-  The minimum subtotal amount of the product.
+  The minimum subtotal amount of the cart line to be eligible for a discount candidate.
   """
   minimumAmount: Decimal!
 }
 
 """
-A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that applies to a specific cart line, up to an optional quantity limit.
+A method for applying a discount to a specific line item in the cart. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 input CartLineTarget {
   """
@@ -354,12 +417,12 @@ input CartLineTarget {
 }
 
 """
-The cart.lines.discounts.generate.fetch target result. Refer to [network access]
-(https://shopify.dev/apps/build/functions/input-output/network-access/graphql) for Shopify Functions.
+The cart.lines.discounts.generate.fetch target result. Refer to [network access](https://shopify.dev/apps/build/functions/input-output/network-access/graphql)
+for Shopify Functions.
 """
 input CartLinesDiscountsGenerateFetchResult {
   """
-  The http request.
+  The HTTP request object.
   """
   request: HttpRequest
 }
@@ -396,16 +459,21 @@ input CartOperation @oneOf {
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -430,16 +498,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -513,16 +589,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -540,7 +624,7 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-The condition to apply the discount candidate.
+The conditions that satisfy the discount candidate to be applied to a cart line.
 """
 input Condition @oneOf {
   """
@@ -560,7 +644,9 @@ input Condition @oneOf {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1803,9 +1889,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2615,7 +2700,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2624,43 +2712,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2670,27 +2766,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2700,22 +2801,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2753,13 +2862,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2770,58 +2883,64 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
 
 """
-The delivery discount candidate to be applied.
+The discount that's eligible to be applied to a delivery.
 """
 input DeliveryDiscountCandidate {
   """
-  The discount code associated with this discount candidate, for code-based discounts.
+  The discount code that's eligible to be applied to a delivery.
   """
   associatedDiscountCode: AssociatedDiscountCode
 
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the delivery discount candidate.
+  The targets of the discount that are eligible to be applied to a delivery.
   """
   targets: [DeliveryDiscountCandidateTarget!]!
 
   """
-  The value of the delivery discount candidate.
+  The value of the discount that's eligible to be applied to a delivery.
   """
   value: DeliveryDiscountCandidateValue!
 }
 
 """
-The target of the delivery discount candidate.
+The target of the eligible delivery discount.
 """
 input DeliveryDiscountCandidateTarget @oneOf {
   """
-  The target delivery group.
+  A method for applying a discount to a delivery group. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's shipping address.
+  For example, if a customer orders a t-shirt and a pair of shoes that can be shipped together, then the
+  items are included in the same delivery group.
   """
   deliveryGroup: DeliveryGroupTarget
 
   """
-  The target delivery option.
+  A method for applying a discount to a delivery option within a delivery group.
+  Delivery options are the different ways that customers can choose to have their
+  orders shipped. Examples of delivery options include express shipping or standard shipping.
   """
   deliveryOption: DeliveryOptionTarget
 }
 
 """
-The delivery discount candidate value.
+The value of the eligible delivery discount.
 """
 input DeliveryDiscountCandidateValue @oneOf {
   """
@@ -2836,33 +2955,43 @@ input DeliveryDiscountCandidateValue @oneOf {
 }
 
 """
-The strategy that's applied to the list of delivery discount candidates.
+The strategy that's applied to the list of discounts that are eligible to be applied to a delivery.
 """
 enum DeliveryDiscountSelectionStrategy {
   """
-  Apply all delivery discount candidates with conditions that are satisfied. This does not override
+  Apply all discounts that are eligible to be applied to a delivery with
+  conditions that are satisfied. This doesn't override
   discount combination or stacking rules.
   """
   ALL
 }
 
 """
-An operation that applies delivery discounts to a cart that share a selection strategy.
+Applies delivery discounts to a cart that share a method for determining which
+shipping and delivery discounts to apply when multiple discounts are eligible.
 """
 input DeliveryDiscountsAddOperation {
   """
-  The list of delivery discount candidates to be applied.
+  The list of discounts that are eligible to be applied to a delivery.
   """
   candidates: [DeliveryDiscountCandidate!]!
 
   """
-  The strategy that's applied to the list of discounts.
+  The method for determining which shipping and delivery discounts to apply when
+  multiple discounts are eligible. For example, when the "ALL" strategy is
+  selected, every shipping and delivery discount that qualifies is applied to
+  the cart (for example, free shipping on orders over $50 and $5 off express
+  shipping). This controls how shipping and delivery discounts interact when
+  multiple conditions are satisfied simultaneously.
   """
   selectionStrategy: DeliveryDiscountSelectionStrategy!
 }
 
 """
-The target delivery group.
+A method for applying a discount to a delivery group. Delivery groups streamline
+fulfillment by organizing items that can be shipped together, based on the customer's shipping address.
+For example, if a customer orders a t-shirt and a pair of shoes that can be shipped together, then the
+items are included in the same delivery group.
 """
 input DeliveryGroupTarget {
   """
@@ -2907,11 +3036,16 @@ enum DeliveryMethod {
 }
 
 """
-The operations that can be performed to apply discounts to the delivery lines.
+The operations to apply discounts to shipping and delivery charges in a
+customer's cart. These operations allow you to reduce the cost of shipping by
+applying percentage or fixed-amount discounts to specific delivery options (such
+as standard shipping and express shipping) or delivery groups (such as
+collections of delivery options).
 """
 input DeliveryOperation @oneOf {
   """
-  An operation that applies delivery discounts to a cart that share a selection strategy.
+  Applies delivery discounts to a cart that share a method for determining which
+  shipping and delivery discounts to apply when multiple discounts are eligible.
   """
   deliveryDiscountsAdd: DeliveryDiscountsAddOperation
 
@@ -2923,7 +3057,9 @@ input DeliveryOperation @oneOf {
 }
 
 """
-The target delivery option.
+A method for applying a discount to a delivery option within a delivery group.
+Delivery options are the different ways that customers can choose to have their
+orders shipped. Examples of delivery options include express shipping or standard shipping.
 """
 input DeliveryOptionTarget {
   """
@@ -2933,25 +3069,33 @@ input DeliveryOptionTarget {
 }
 
 """
-The discount that invoked the Function.
+The discount that invoked the [Discount Function](https://shopify.dev/docs/apps/build/discounts#build-with-shopify-functions)).
 """
 type Discount implements HasMetafields {
   """
-  The discount classes supported by the discount node.
+  The [discount classes](https://shopify.dev/docs/apps/build/discounts/#discount-classes)) that the [discountNode](https://shopify.dev/docs/api/admin-graphql/latest/queries/discountNode)) supports.
   """
   discountClasses: [DiscountClass!]!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3017,61 +3161,6 @@ input FixedAmount {
 }
 
 """
-Represents a gate configuration.
-"""
-type GateConfiguration implements HasMetafields {
-  """
-  An optional string identifier.
-  """
-  appId: String
-
-  """
-  A non-unique string used to group gate configurations.
-  """
-  handle: Handle
-
-  """
-  The ID of the gate configuration.
-  """
-  id: ID!
-
-  """
-  Returns a metafield by namespace and key that belongs to the resource.
-  """
-  metafield(
-    """
-    The key for the metafield.
-    """
-    key: String!
-
-    """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
-    """
-    namespace: String
-  ): Metafield
-}
-
-"""
-Represents a connection from a subject to a gate configuration.
-"""
-type GateSubject {
-  """
-  The bound gate configuration.
-  """
-  configuration(
-    """
-    The appId of the gate configurations to search for.
-    """
-    appId: String @deprecated(reason: "Use GateSubject.handle to filter gates instead.")
-  ): GateConfiguration!
-
-  """
-  The ID of the gate subject.
-  """
-  id: ID!
-}
-
-"""
 A function-scoped handle to a refer a resource.
 The Handle type appears in a JSON response as a String, but it is not intended to be human-readable.
 Example value: `"10079785100"`
@@ -3079,51 +3168,46 @@ Example value: `"10079785100"`
 scalar Handle
 
 """
-Gate subjects associated to the specified resource.
-"""
-interface HasGates {
-  """
-  Returns active gate subjects bound to the resource.
-  """
-  gates(
-    """
-    The handle of the gate configurations to search for.
-    """
-    handle: Handle
-  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
-}
-
-"""
 Represents information about the metafields associated to the specified resource.
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -3236,9 +3320,9 @@ type HttpResponse {
   headers: [HttpResponseHeader!]! @deprecated(reason: "Use `header` instead.")
 
   """
-  The HTTP response body parsed as JSON.
-  If the body is valid JSON, it will be parsed and returned as a JSON object.
-  If parsing fails, then raw body is returned as a string.
+  The HTTP response body parsed as JSON. 
+  If the body is valid JSON, it will be parsed and returned as a JSON object. 
+  If parsing fails, then raw body is returned as a string. 
   Use this field when you expect the response to be JSON, or when you're dealing
   with mixed response types, meaning both JSON and non-JSON.
   Using this field reduces function instruction consumption and ensures that the data is formatted in logs.
@@ -3281,18 +3365,24 @@ The input object for the Function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The discount node executing the Function.
+  The discount node that owns the [Shopify
+  Function](https://shopify.dev/docs/apps/build/functions)). Discounts are a way
+  for merchants to promote sales and special offers, or as customer loyalty
+  rewards. A single discount can be automatic or code-based, and can be applied
+  to a cart lines, orders, and delivery.
   """
   discount: Discount!
 
   """
-  Discount codes entered by the buyer as an array of strings, excluding gift cards.
-  Codes are not validated in any way other than gift card filtering.
+  The discount codes that customers enter at checkout. Customers can enter codes
+  as an array of strings, excluding gift cards.
+  Codes aren't validated in any way other than to verify they aren't gift cards.
   """
   enteredDiscountCodes: [String!]! @restrictTarget(only: ["cart.lines.discounts.generate.fetch", "cart.delivery-options.discounts.generate.fetch"])
 
@@ -3303,24 +3393,31 @@ type Input {
   fetchResult: HttpResponse @restrictTarget(only: ["cart.lines.discounts.generate.run", "cart.delivery-options.discounts.generate.run"])
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 
   """
-  The discount code entered by the buyer that caused the Function to run.
-  This input is only available in the cart.lines.discounts.generate.run
-  and cart.delivery-options.discounts.generate.run extension targets.
+  The discount code entered by a customer, which caused the [Discount Function](https://shopify.dev/docs/apps/build/discounts#build-with-shopify-functions)) to run.
+  This input is only available in the `cart.lines.discounts.generate.run` and
+  `cart.delivery-options.discounts.generate.run` extension targets.
   """
   triggeringDiscountCode: String @restrictTarget(only: ["cart.lines.discounts.generate.run", "cart.delivery-options.discounts.generate.run"])
 }
@@ -3343,7 +3440,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -4063,7 +4161,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -4143,16 +4242,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -4470,16 +4575,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4516,47 +4629,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4607,7 +4733,7 @@ type MutationRoot {
 }
 
 """
-The order discount candidate to be applied.
+A discount candidate to be applied to an eligible order.
 """
 input OrderDiscountCandidate {
   """
@@ -4616,12 +4742,13 @@ input OrderDiscountCandidate {
   associatedDiscountCode: AssociatedDiscountCode
 
   """
-  The conditions that must be satisfied to apply the order discount candidate.
+  The conditions that must be satisfied for an order to be eligible for a discount candidate.
   """
   conditions: [Condition!]
 
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
@@ -4637,17 +4764,19 @@ input OrderDiscountCandidate {
 }
 
 """
-A target of a order discount candidate.
+A target of an order to be eligible for a discount candidate.
 """
 input OrderDiscountCandidateTarget @oneOf {
   """
-  If used, the discount targets the entire order subtotal after product discounts are applied.
+  A method for applying a discount to the entire order subtotal. The subtotal is the total amount of the
+  order before any taxes, shipping fees, or discounts are applied. For example, if a customer places an order
+  for a t-shirt and a pair of shoes, then the subtotal is the sum of the prices of those items.
   """
   orderSubtotal: OrderSubtotalTarget
 }
 
 """
-The order discount candidate value.
+The value of the order discount candidate.
 """
 input OrderDiscountCandidateValue @oneOf {
   """
@@ -4681,7 +4810,7 @@ An operation that applies order discounts to a cart that share a selection strat
 """
 input OrderDiscountsAddOperation {
   """
-  The list of order discount candidates to be applied.
+  The list of discounts that can be applied to an order.
   """
   candidates: [OrderDiscountCandidate!]!
 
@@ -4701,13 +4830,15 @@ input OrderMinimumSubtotal {
   excludedCartLineIds: [ID!]!
 
   """
-  The minimum subtotal amount of the order.
+  The minimum subtotal amount of the order to be eligible for the discount.
   """
   minimumAmount: Decimal!
 }
 
 """
-If used, the discount targets the entire order subtotal after product discounts are applied.
+A method for applying a discount to the entire order subtotal. The subtotal is the total amount of the
+order before any taxes, shipping fees, or discounts are applied. For example, if a customer places an order
+for a t-shirt and a pair of shoes, then the subtotal is the sum of the prices of those items.
 """
 input OrderSubtotalTarget {
   """
@@ -4730,65 +4861,78 @@ input Percentage {
 }
 
 """
-Represents a product.
-"""
-type Product implements HasGates & HasMetafields {
-  """
-  Returns active gate subjects bound to the resource.
-  """
-  gates(
-    """
-    The handle of the gate configurations to search for.
-    """
-    handle: Handle
-  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
 
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
+"""
+type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4799,27 +4943,39 @@ type Product implements HasGates & HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4830,7 +4986,7 @@ type Product implements HasGates & HasMetafields {
 }
 
 """
-The product discount candidate to be applied.
+The target and value of the discount to be applied to a cart line.
 """
 input ProductDiscountCandidate {
   """
@@ -4839,34 +4995,37 @@ input ProductDiscountCandidate {
   associatedDiscountCode: AssociatedDiscountCode
 
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the product discount candidate.
+  The targets of the discount to be applied to a cart line.
   """
   targets: [ProductDiscountCandidateTarget!]!
 
   """
-  The value of the product discount candidate.
+  The value of the discount to be applied to a cart line. For example, a fixed
+  amount of $5 off or percentage value of 20% off.
   """
   value: ProductDiscountCandidateValue!
 }
 
 """
-A product discount candidate fixed amount value.
+The [fixed-amount](https://help.shopify.com/manual/international/pricing/discounts)
+value of the discount to be applied to a cart line. For example, if the cart
+total is $100 and the discount is $10, then the fixed amount is $10.
 """
 input ProductDiscountCandidateFixedAmount {
   """
-  The fixed amount value of the product discount candidate, in the currency of the cart.
-
-  The amount must be greater than or equal to 0.
+  The [fixed-amount](https://help.shopify.com/manual/international/pricing/discounts) value of the discount to be applied to a cart line, in the currency of the
+  cart. The amount must be greater than or equal to 0.
   """
   amount: Decimal!
 
   """
-  Whether to apply the value to each entitled item.
+  Whether to apply the value of each eligible discount to each eligible cart line.
 
   The default value is `false`, which causes the value to be applied once across the entitled items.
   When the value is `true`, the value will be applied to each of the entitled items.
@@ -4875,26 +5034,30 @@ input ProductDiscountCandidateFixedAmount {
 }
 
 """
-A target of a product discount candidate, which determines which cart line(s) the discount will affect.
+Defines discount candidates, which are cart lines that may be eligible for
+potential discounts. Use discount candidates to identify items in a customer's
+cart that could receive discounts based on conditions in the selection strategy.
 
-Multiple targets with the same type and ID are the same as a single target of that type and ID with their
-quantities added together, or `null` if any of those targets have a quantity of `null`.
-
-See the [Discounts API reference](https://shopify.dev/docs/api/functions/reference/discount/graphql/functioncartrunresult) for examples.
+When multiple cart lines share the same type and ID, the system treats them as a
+single target and combines their quantities. The combined quantity becomes null
+if any individual target has a `null` quantity.
 """
 input ProductDiscountCandidateTarget @oneOf {
   """
-  A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that applies to a specific cart line, up to an optional quantity limit.
+  A method for applying a discount to a specific line item in the cart. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLine: CartLineTarget
 }
 
 """
-The value of the product discount candidate.
+The value of the discount candidate to be applied to a cart line.
 """
 input ProductDiscountCandidateValue @oneOf {
   """
-  A product discount candidate fixed amount value.
+  The [fixed-amount](https://help.shopify.com/manual/international/pricing/discounts) value of the discount to be applied to a cart line. For example, if the cart
+  total is $100 and the discount is $10, then the fixed amount is $10.
   """
   fixedAmount: ProductDiscountCandidateFixedAmount
 
@@ -4905,22 +5068,21 @@ input ProductDiscountCandidateValue @oneOf {
 }
 
 """
-The strategy that's applied to the list of product discount candidates.
+The selection strategy that's applied to the list of discounts that are eligible for cart lines.
 """
 enum ProductDiscountSelectionStrategy {
   """
-  Apply all product discount candidates with conditions that are satisfied. This
-  does not override discount combination or stacking rules.
+  Apply all the discount candidates to eligible cart lines. This doesn't override discount combination or stacking rules.
   """
   ALL
 
   """
-  Only apply the first product discount candidate with conditions that are satisfied.
+  Apply the first discount candidate to cart lines that satisfies conditions.
   """
   FIRST
 
   """
-  Only apply the product discount candidate that offers the maximum reduction.
+  Apply the discount to the cart line that offers the maximum reduction.
   """
   MAXIMUM
 }
@@ -4930,73 +5092,92 @@ An operation that applies product discounts to a cart that share a selection str
 """
 input ProductDiscountsAddOperation {
   """
-  The list of product discount candidates to be applied.
+  The list of products that are eligible for the discount.
   """
   candidates: [ProductDiscountCandidate!]!
 
   """
-  The strategy that's applied to the list of product discount candidates.
+  The strategy that's applied to the list of products that are eligible for the cart line discount.
   """
   selectionStrategy: ProductDiscountSelectionStrategy!
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -5030,16 +5211,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -5099,25 +5288,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/discounts/javascript/discounts-allocator/default/schema.graphql
+++ b/discounts/javascript/discounts-allocator/default/schema.graphql
@@ -9,11 +9,17 @@ Scale the Functions resource limits based on the field's length.
 directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -24,76 +30,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
-type Cart {
+type Cart implements HasMetafields {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -101,116 +128,171 @@ type Cart {
     """
     keys: [LocalizedFieldKey!]! = []
   ): [LocalizedField!]!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The physical location where a retail order is created or completed.
+  """
+  retailLocation: Location
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -220,44 +302,51 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
@@ -275,16 +364,21 @@ type CartLineTarget {
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -309,16 +403,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -392,16 +494,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -419,7 +529,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1662,9 +1774,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2474,7 +2585,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2483,43 +2597,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2529,27 +2651,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2559,22 +2686,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2612,13 +2747,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2629,12 +2768,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2701,16 +2840,24 @@ type Discount implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2722,21 +2869,33 @@ type Discount implements HasMetafields {
 }
 
 """
-The strategy that's applied to the list of discounts.
+The approach that determines how multiple discounts are evaluated and
+applied to a cart. You can apply all discounts with conditions that are met,
+apply a discount only to the first line item in a cart that meets conditions,
+or apply only the discount that offers a maximum price reduction.
 """
 enum DiscountApplicationStrategy {
   """
-  Apply all discounts with conditions that are satisfied. This does not override discount combination or stacking rules.
+  Apply all discounts with conditions that are met. For example, you can use the `ALL` strategy to apply a
+  20% discount on a t-shirt, a $5 discount on a pair of shoes, and a 10% discount on a hat. The total
+  discount would be the sum of all three discounts, which would be applied to the order total. This strategy
+  doesn't override [discount combination](https://help.shopify.com/manual/discounts/discount-combinations)
+  rules.
   """
   ALL
 
   """
-  Only apply the first discount with conditions that are satisfied.
+  Only apply the discount to the first line item in a cart that meets conditions.
+  For example, you can use the `FIRST` strategy to apply a 20% discount to the first line item in a cart
+  and ensure no other discounts are applied.
   """
   FIRST
 
   """
-  Only apply the discount that offers the maximum reduction.
+  Only apply the discount that provides the greatest savings. For example, you can use the `MAXIMUM` strategy
+  to apply the higher of two discounts. If you have a 20% discount on a $30 t-shirt and a $5 discount on $40
+  shoes, then the 20% discount saves you $6 (20% of $30), while the $5 discount stays the same.
+  Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
 }
@@ -2776,7 +2935,7 @@ type DiscountProposal {
   targets: [CartLineTarget!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
@@ -2810,16 +2969,27 @@ type FixedAmount {
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains a list of discounts that apply to each item in a cart.
 """
 input FunctionRunResult {
   """
-  The list of displayable errors.
+  A list of errors that display if a discount can't be applied to one or more
+  items in a cart. Errors lock checkout, and the customer has to remove the discount code to
+  proceed through checkout.
+
+  Shopify shows errors for only
+  [code discounts](https://shopify.dev/docs/api/admin-graphql/latest/objects/DiscountCodeNode).
+  Custom error messages aren't currently supported. If errors are returned with a custom reason,
+  then the error won't display and the discount won't be added.
   """
   displayableErrors: [DisplayableError!]
 
   """
-  The list of applied line discounts.
+  The list of discounts that are applied to each item in a cart.
+  It includes data such as the ID of the cart line associated with the discount,
+  the quantity of items that the discount applies to,
+  and how the discount is allocated to each item.
   """
   lineDiscounts: [LineDiscount!]
 }
@@ -2844,16 +3014,24 @@ type GateConfiguration implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2898,7 +3076,7 @@ interface HasGates {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 }
 
 """
@@ -2906,32 +3084,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2949,27 +3137,41 @@ The input object for the Function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The list of discounts to be allocated.
+  The information about promotional offers that are applied to items in a cart,
+  such as the discount's name that displays to merchants in the
+  Shopify admin and to customers,
+  the [discount code](https://help.shopify.com/manual/discounts/discount-types/discount-codes),
+  the [discount class](https://help.shopify.com/manual/discounts/combining-discounts/discount-combinations),
+  and [metafields](https://shopify.dev/docs/apps/build/custom-data) that are associated
+  with discounts.
   """
   discounts: [Discount!]
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2992,7 +3194,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3729,7 +3932,18 @@ input LineDiscount {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+Local pickup settings associated with a location.
+"""
+type LocalPickup {
+  """
+  Whether local pickup is enabled for the location.
+  """
+  enabled: Boolean!
+}
+
+"""
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3809,23 +4023,29 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
   """
   The market of the active localized experience.
   """
-  market: Market!
+  market: Market! @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 }
 
 """
@@ -3856,189 +4076,307 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
+}
+
+"""
+Represents the location where the inventory resides.
+"""
+type Location implements HasMetafields {
+  """
+  The address of this location.
+  """
+  address: LocationAddress!
+
+  """
+  The location handle.
+  """
+  handle: Handle!
+
+  """
+  The location id.
+  """
+  id: ID!
+
+  """
+  Local pickup settings associated with a location.
+  """
+  localPickup: LocalPickup!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The name of the location.
+  """
+  name: String!
+}
+
+"""
+Represents the address of a location.
+"""
+type LocationAddress {
+  """
+  The first line of the address for the location.
+  """
+  address1: String
+
+  """
+  The second line of the address for the location.
+  """
+  address2: String
+
+  """
+  The city of the location.
+  """
+  city: String
+
+  """
+  The country of the location.
+  """
+  country: String
+
+  """
+  The country code of the location.
+  """
+  countryCode: String
+
+  """
+  A formatted version of the address for the location.
+  """
+  formatted: [String!]!
+
+  """
+  The approximate latitude coordinates of the location.
+  """
+  latitude: Float
+
+  """
+  The approximate longitude coordinates of the location.
+  """
+  longitude: Float
+
+  """
+  The phone number of the location.
+  """
+  phone: String
+
+  """
+  The province of the location.
+  """
+  province: String
+
+  """
+  The code for the province, state, or district of the address of the location.
+  """
+  provinceCode: String
+
+  """
+  The ZIP code of the location.
+  """
+  zip: String
 }
 
 """
@@ -4093,7 +4431,7 @@ type MailingAddress {
   """
   The market of the address.
   """
-  market: Market
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 
   """
   The full name of the customer, based on firstName and lastName.
@@ -4136,16 +4474,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4182,47 +4528,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4265,7 +4624,11 @@ type Percentage {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasGates & HasMetafields {
   """
@@ -4276,54 +4639,73 @@ type Product implements HasGates & HasMetafields {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4334,27 +4716,39 @@ type Product implements HasGates & HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4365,62 +4759,81 @@ type Product implements HasGates & HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4454,16 +4867,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4523,25 +4944,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4555,7 +4986,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The value of the discount.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 union Value = FixedAmount | Percentage
 

--- a/discounts/javascript/order-discounts/default/schema.graphql
+++ b/discounts/javascript/order-discounts/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-The condition to apply the discount.
+The criteria or rules that must be met for a discount to be applied to an order.
+For example, conditions can include minimum purchase amounts, specific product selections, or
+customer eligibility.
 """
 input Condition @oneOf {
   """
@@ -432,7 +516,9 @@ input Condition @oneOf {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1675,9 +1761,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2487,7 +2572,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2496,43 +2584,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2542,27 +2638,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2572,22 +2673,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2625,13 +2734,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2642,12 +2755,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2688,45 +2801,66 @@ enum DeliveryMethod {
 }
 
 """
-The discount to be applied.
+A price reduction applied to an order.
+
+Discounts can be offered in various forms, such as a percentage off, a fixed amount off, or free shipping.
+They can be applied automatically at checkout if certain conditions are met, or through a discount code that
+customers enter during checkout. Discounts are often used during promotional events or to attract first-time
+customers.
 """
 input Discount {
   """
-  The condition to apply the discount.
+  The criteria or rules that must be met for a discount to be applied to an order.
+  For example, conditions can include minimum purchase amounts, specific product selections, or
+  customer eligibility.
   """
   conditions: [Condition!]
 
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the discount.
+  The method for applying the discount to an order. This argument accepts either a single
+  `OrderSubtotalTarget` or one or more `ProductVariantTarget`s, but not both.
 
-  The value is validated against: targets should contain only one type of `Target`.
-  Only a list that contains either a single `OrderSubtotalTarget` or one or more
-  `ProductVariantTarget`s is valid.
+  The `OrderSubtotalTarget` is used to target the subtotal of the order. The subtotal is the total amount
+  of the order before any taxes, shipping fees, or discounts are applied. For example, if a customer
+  places an order for a t-shirt and a pair of shoes, then the subtotal is the sum of the prices of those items.
+
+  The `ProductVariantTarget` is used to target specific product variants within the order. Product variants
+  are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+  in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+  product variants in the order, or to specific product variants that meet certain criteria.
   """
   targets: [Target!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
 
 """
-The strategy that's applied to the list of discounts.
+The approach that determines how multiple discounts are evaluated and
+applied to a cart. You can apply a discount to the first line item in a cart that meets conditions,
+or apply the discount that offers the maximum price reduction.
 """
 enum DiscountApplicationStrategy {
   """
-  Only apply the first discount with conditions that are satisfied.
+  Only apply the discount to the first line item in a cart that meets conditions.
+  For example, you can use the `FIRST` strategy to apply a 20% discount to the first line item in a cart
+  and ensure no other discounts are applied.
   """
   FIRST
 
   """
-  Only apply the discount that offers the maximum reduction.
+  Only apply the discount that provides the greatest savings. For example, you can use the `MAXIMUM` strategy
+  to apply the higher of two discounts. If you have a 20% discount on a $30 t-shirt and a $5 discount on $40
+  shoes, then the 20% discount saves you $6 (20% of $30), while the $5 discount stays the same.
+  Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
 }
@@ -2736,16 +2870,24 @@ A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2764,31 +2906,41 @@ input FixedAmount {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply a discount to the first line item in a cart that meets conditions,
+  or apply the discount that offers the maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart.
 """
 input FunctionRunResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply a discount to the first line item in a cart that meets conditions,
+  or apply the discount that offers the maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
@@ -2805,32 +2957,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2848,27 +3010,37 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The discount node executing the function.
+  A wrapper around the discount that executes the Function. The `discountNode` field
+  enables you to manage [discounts](https://help.shopify.com/manual/discounts),
+  which are applied at checkout or on a cart.
   """
   discountNode: DiscountNode!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2891,7 +3063,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3611,7 +3784,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3691,16 +3865,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3738,187 +3918,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -4018,16 +4198,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4064,47 +4252,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4157,7 +4358,9 @@ input OrderMinimumSubtotal {
 }
 
 """
-If used, the discount targets the entire order subtotal after product discounts are applied.
+A method for applying a discount to the entire order subtotal. The subtotal is the total amount of the
+order before any taxes, shipping fees, or discounts are applied. For example, if a customer places an order
+for a t-shirt and a pair of shoes, then the subtotal is the sum of the prices of those items.
 """
 input OrderSubtotalTarget {
   """
@@ -4180,55 +4383,78 @@ input Percentage {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4239,27 +4465,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4314,63 +4552,84 @@ input ProductMinimumSubtotal {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
-optional quantity limit.
+A method for applying a discount to a
+[product variant](https://help.shopify.com/manual/products/variants). Product variants
+are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+product variants in the order, or to specific product variants that meet certain criteria.
 """
 input ProductVariantTarget {
   """
@@ -4388,7 +4647,8 @@ input ProductVariantTarget {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4422,16 +4682,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4491,44 +4759,58 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-A target of a discount.
-
-A discount can either have a single `OrderSubtotalTarget`, or one or more `ProductVariantTarget`s.
+The method for applying the discount to an order. This argument accepts either a single
+`OrderSubtotalTarget` or one or more `ProductVariantTarget`s, but not both.
 """
 input Target @oneOf {
   """
-  If used, the discount targets the entire order subtotal after product discounts are applied.
+  A method for applying a discount to the entire order subtotal. The subtotal is the total amount of the
+  order before any taxes, shipping fees, or discounts are applied. For example, if a customer places an order
+  for a t-shirt and a pair of shoes, then the subtotal is the sum of the prices of those items.
   """
   orderSubtotal: OrderSubtotalTarget
 
   """
-  A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
-  optional quantity limit.
+  A method for applying a discount to a
+  [product variant](https://help.shopify.com/manual/products/variants). Product variants
+  are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+  in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+  product variants in the order, or to specific product variants that meet certain criteria.
   """
   productVariant: ProductVariantTarget
 }
@@ -4556,7 +4838,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The discount value.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 input Value @oneOf {
   """

--- a/discounts/javascript/product-discounts/default/schema.graphql
+++ b/discounts/javascript/product-discounts/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,50 +279,59 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that applies to a specific cart line, up to an optional quantity limit.
+A method for applying a discount to a specific line item in the cart. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 input CartLineTarget {
   """
@@ -286,16 +349,21 @@ input CartLineTarget {
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -320,16 +388,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -403,16 +479,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -430,7 +514,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1673,9 +1759,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2485,7 +2570,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2494,43 +2582,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2540,27 +2636,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2570,22 +2671,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2623,13 +2732,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2640,12 +2753,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2686,43 +2799,69 @@ enum DeliveryMethod {
 }
 
 """
-The discount to be applied.
+A price reduction applied to a product.
+
+Discounts can be offered in various forms, such as a percentage off, a fixed amount off, or free shipping.
+They can be applied automatically at checkout if certain conditions are met, or through a discount code that
+customers enter during checkout. Discounts are often used during promotional events or to attract first-time
+customers.
 """
 input Discount {
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the discount.
+  The method for applying the discount to products. This argument accepts a collection of either
+  `ProductVariantTarget` or `CartLineTarget`, but not both.
 
-  This argument accepts a collection of either `ProductVariantTarget`s or `CartLineTarget`s, but not both.
+  The `ProductVariantTarget` is used to target a specific product variant. A product variant is a specific
+  version of a product that comes in more than one option, such as size or color. For example, if a merchant
+  sells t-shirts with options for size and color, then a small, blue t-shirt would be one product variant
+  and a large, blue t-shirt would be another.
+
+  The `CartLineTarget` is used to target a specific line item in the cart. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   targets: [Target!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
 
 """
-The strategy that's applied to the list of discounts.
+The approach that determines how multiple discounts are evaluated and
+applied to a cart. You can apply all discounts with conditions that are met,
+apply a discount only to the first line item in a cart that meets conditions,
+or apply only the discount that offers a maximum price reduction.
 """
 enum DiscountApplicationStrategy {
   """
-  Apply all discounts with conditions that are satisfied. This does not override discount combination or stacking rules.
+  Apply all discounts with conditions that are met. For example, you can use the `ALL` strategy to apply a
+  20% discount on a t-shirt, a $5 discount on a pair of shoes, and a 10% discount on a hat. The total
+  discount would be the sum of all three discounts, which would be applied to the order total. This strategy
+  doesn't override [discount combination](https://help.shopify.com/manual/discounts/discount-combinations)
+  rules.
   """
   ALL
 
   """
-  Only apply the first discount with conditions that are satisfied.
+  Only apply the discount to the first line item in a cart that meets conditions.
+  For example, you can use the `FIRST` strategy to apply a 20% discount to the first line item in a cart
+  and ensure no other discounts are applied.
   """
   FIRST
 
   """
-  Only apply the discount that offers the maximum reduction.
+  Only apply the discount that provides the greatest savings. For example, you can use the `MAXIMUM` strategy
+  to apply the higher of two discounts. If you have a 20% discount on a $30 t-shirt and a $5 discount on $40
+  shoes, then the 20% discount saves you $6 (20% of $30), while the $5 discount stays the same.
+  Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
 }
@@ -2732,16 +2871,24 @@ A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2768,31 +2915,43 @@ input FixedAmount {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply all discounts with conditions that are met,
+  apply a discount only to the first line item in a cart that meets conditions,
+  or apply only the discount that offers a maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart.
 """
 input FunctionRunResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply all discounts with conditions that are met,
+  apply a discount only to the first line item in a cart that meets conditions,
+  or apply only the discount that offers a maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
@@ -2809,32 +2968,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2852,27 +3021,37 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The discount node executing the function.
+  A wrapper around the discount that executes the Function. The `discountNode` field
+  enables you to manage [discounts](https://help.shopify.com/manual/discounts),
+  which are applied at checkout or on a cart.
   """
   discountNode: DiscountNode!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2895,7 +3074,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3615,7 +3795,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3695,16 +3876,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3742,187 +3929,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -4022,16 +4209,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4068,47 +4263,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4151,55 +4359,78 @@ input Percentage {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4210,27 +4441,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4241,63 +4484,84 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
-optional quantity limit.
+A method for applying a discount to a
+[product variant](https://help.shopify.com/manual/products/variants). Product variants
+are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+product variants in the order, or to specific product variants that meet certain criteria.
 """
 input ProductVariantTarget {
   """
@@ -4315,7 +4579,8 @@ input ProductVariantTarget {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4349,16 +4614,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4418,49 +4691,58 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-A target of a discount, which determines which cart line(s) the discount will affect.
-
-A discount can have a collection of either `ProductVariantTarget`s or `CartLineTarget`s, but not both.
-
-Multiple targets with the same type and ID are the same as a single target of that type and ID with their
-quantities added together, or `null` if any of those targets have a quantity of `null`.
-
-See the [Product Discount API reference](https://shopify.dev/docs/api/functions/reference/product-discounts/graphql#functionrunresult) for examples.
+The method for applying the discount to products. This argument accepts a collection of either
+`ProductVariantTarget` or `CartLineTarget`, but not both.
 """
 input Target @oneOf {
   """
-  A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that applies to a specific cart line, up to an optional quantity limit.
+  A method for applying a discount to a specific line item in the cart. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLine: CartLineTarget
 
   """
-  A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
-  optional quantity limit.
+  A method for applying a discount to a
+  [product variant](https://help.shopify.com/manual/products/variants). Product variants
+  are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+  in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+  product variants in the order, or to specific product variants that meet certain criteria.
   """
   productVariant: ProductVariantTarget
 }
@@ -4473,7 +4755,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The value of the discount.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 input Value @oneOf {
   """

--- a/discounts/javascript/shipping-discounts/default/schema.graphql
+++ b/discounts/javascript/shipping-discounts/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1739,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2550,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2562,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2616,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2651,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2712,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,18 +2733,21 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
 
 """
-The target delivery group.
+A method for applying a discount to a delivery group. Delivery groups streamline
+fulfillment by organizing items that can be shipped together, based on the customer's shipping address.
+For example, if a customer orders a t-shirt and a pair of shoes that can be shipped together, then the
+items are included in the same delivery group.
 """
 input DeliveryGroupTarget {
   """
@@ -2678,7 +2792,9 @@ enum DeliveryMethod {
 }
 
 """
-The target delivery option.
+A method for applying a discount to a delivery option within a delivery group.
+Delivery options are the different ways that customers can choose to have their
+orders shipped. Examples of delivery options include express shipping or standard shipping.
 """
 input DeliveryOptionTarget {
   """
@@ -2688,21 +2804,37 @@ input DeliveryOptionTarget {
 }
 
 """
-The discount to be applied.
+A price reduction applied to shipping costs.
+
+Discounts can be offered in various forms, such as a percentage off, a fixed amount off, or free shipping.
+They can be applied automatically at checkout if certain conditions are met, or through a discount code that
+customers enter during checkout. Discounts are often used during promotional events or to attract first-time
+customers.
 """
 input Discount {
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the discount.
+  The method for applying the discount to shipping costs. This argument accepts a collection of either
+  `DeliveryGroupTarget` or `DeliveryOptionTarget`, but not both.
+
+  The `DeliveryGroupTarget` is used to target a specific delivery group. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's shipping address.
+  For example, if a customer orders a t-shirt and a pair of shoes that can be shipped together, then the
+  items are included in the same delivery group.
+
+  The `DeliveryOptionTarget` is used to target a specific delivery option within a delivery group.
+  Delivery options are the different ways that customers can choose to have their
+  orders shipped. Examples of delivery options include express shipping or standard shipping.
   """
   targets: [Target!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
@@ -2712,16 +2844,24 @@ A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2740,21 +2880,27 @@ input FixedAmount {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the list of discounts to apply to shipping costs. In API
+versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the list of discounts to apply to shipping costs.
 """
 input FunctionRunResult {
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
@@ -2771,32 +2917,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2814,27 +2970,37 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The discount node executing the function.
+  A wrapper around the discount that executes the Function. The `discountNode` field
+  enables you to manage [discounts](https://help.shopify.com/manual/discounts),
+  which are applied at checkout or on a cart.
   """
   discountNode: DiscountNode!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2857,7 +3023,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3577,7 +3744,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3657,16 +3825,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3704,187 +3878,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3984,16 +4158,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4030,47 +4212,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4113,55 +4308,78 @@ input Percentage {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4172,27 +4390,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4203,62 +4433,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4292,16 +4541,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4361,41 +4618,57 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-The target of the discount.
+The method for applying the discount to shipping costs. This argument accepts a collection of either
+`DeliveryGroupTarget` or `DeliveryOptionTarget`, but not both.
 """
 input Target @oneOf {
   """
-  The target delivery group.
+  A method for applying a discount to a delivery group. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's shipping address.
+  For example, if a customer orders a t-shirt and a pair of shoes that can be shipped together, then the
+  items are included in the same delivery group.
   """
   deliveryGroup: DeliveryGroupTarget
 
   """
-  The target delivery option.
+  A method for applying a discount to a delivery option within a delivery group.
+  Delivery options are the different ways that customers can choose to have their
+  orders shipped. Examples of delivery options include express shipping or standard shipping.
   """
   deliveryOption: DeliveryOptionTarget
 }
@@ -4408,7 +4681,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The discount value.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 input Value @oneOf {
   """

--- a/discounts/rust/discount/default/schema.graphql
+++ b/discounts/rust/discount/default/schema.graphql
@@ -29,11 +29,17 @@ input AssociatedDiscountCode {
 }
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -44,76 +50,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
-type Cart {
+type Cart implements HasMetafields {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -121,105 +148,152 @@ type Cart {
     """
     keys: [LocalizedFieldKey!]! = []
   ): [LocalizedField!]!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The physical location where a retail order is created or completed.
+  """
+  retailLocation: Location
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-The cart.delivery-options.discounts.generate.fetch target result. Refer to
-[network access](https://shopify.dev/apps/build/functions/input-output/network-access/graphql) for Shopify Functions.
+The cart.delivery-options.discounts.generate.fetch target result. Refer to [network access](https://shopify.dev/apps/build/functions/input-output/network-access/graphql)
+for Shopify Functions.
 """
 input CartDeliveryOptionsDiscountsGenerateFetchResult {
   """
-  The http request.
+  The attributes associated with an HTTP request.
   """
   request: HttpRequest
 }
@@ -229,29 +303,37 @@ The cart.delivery-options.discounts.generate.run target result.
 """
 input CartDeliveryOptionsDiscountsGenerateRunResult {
   """
-  The list of operations to apply discounts to the delivery lines.
+  An ordered list of operations to generate delivery discounts, such as validating and applying discounts to the cart.
   """
   operations: [DeliveryOperation!]!
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -261,44 +343,51 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
@@ -314,7 +403,7 @@ input CartLineMinimumQuantity {
   ids: [ID!]!
 
   """
-  The minimum quantity of a product.
+  The minimum quantity of a cart line to be eligible for a discount candidate.
   """
   minimumQuantity: Int!
 }
@@ -330,13 +419,15 @@ input CartLineMinimumSubtotal {
   ids: [ID!]!
 
   """
-  The minimum subtotal amount of the product.
+  The minimum subtotal amount of the cart line to be eligible for a discount candidate.
   """
   minimumAmount: Decimal!
 }
 
 """
-A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that applies to a specific cart line, up to an optional quantity limit.
+A method for applying a discount to a specific line item in the cart. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 input CartLineTarget {
   """
@@ -354,12 +445,12 @@ input CartLineTarget {
 }
 
 """
-The cart.lines.discounts.generate.fetch target result. Refer to [network access]
-(https://shopify.dev/apps/build/functions/input-output/network-access/graphql) for Shopify Functions.
+The cart.lines.discounts.generate.fetch target result. Refer to [network access](https://shopify.dev/apps/build/functions/input-output/network-access/graphql)
+for Shopify Functions.
 """
 input CartLinesDiscountsGenerateFetchResult {
   """
-  The http request.
+  The HTTP request object.
   """
   request: HttpRequest
 }
@@ -396,16 +487,21 @@ input CartOperation @oneOf {
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -430,16 +526,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -513,16 +617,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -540,7 +652,7 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-The condition to apply the discount candidate.
+The conditions that satisfy the discount candidate to be applied to a cart line.
 """
 input Condition @oneOf {
   """
@@ -560,7 +672,9 @@ input Condition @oneOf {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1803,9 +1917,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2615,7 +2728,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2624,43 +2740,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2670,27 +2794,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2700,22 +2829,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2753,13 +2890,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2770,58 +2911,64 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
 
 """
-The delivery discount candidate to be applied.
+The discount that's eligible to be applied to a delivery.
 """
 input DeliveryDiscountCandidate {
   """
-  The discount code associated with this discount candidate, for code-based discounts.
+  The discount code that's eligible to be applied to a delivery.
   """
   associatedDiscountCode: AssociatedDiscountCode
 
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the delivery discount candidate.
+  The targets of the discount that are eligible to be applied to a delivery.
   """
   targets: [DeliveryDiscountCandidateTarget!]!
 
   """
-  The value of the delivery discount candidate.
+  The value of the discount that's eligible to be applied to a delivery.
   """
   value: DeliveryDiscountCandidateValue!
 }
 
 """
-The target of the delivery discount candidate.
+The target of the eligible delivery discount.
 """
 input DeliveryDiscountCandidateTarget @oneOf {
   """
-  The target delivery group.
+  A method for applying a discount to a delivery group. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's shipping address.
+  For example, if a customer orders a t-shirt and a pair of shoes that can be shipped together, then the
+  items are included in the same delivery group.
   """
   deliveryGroup: DeliveryGroupTarget
 
   """
-  The target delivery option.
+  A method for applying a discount to a delivery option within a delivery group.
+  Delivery options are the different ways that customers can choose to have their
+  orders shipped. Examples of delivery options include express shipping or standard shipping.
   """
   deliveryOption: DeliveryOptionTarget
 }
 
 """
-The delivery discount candidate value.
+The value of the eligible delivery discount.
 """
 input DeliveryDiscountCandidateValue @oneOf {
   """
@@ -2836,33 +2983,43 @@ input DeliveryDiscountCandidateValue @oneOf {
 }
 
 """
-The strategy that's applied to the list of delivery discount candidates.
+The strategy that's applied to the list of discounts that are eligible to be applied to a delivery.
 """
 enum DeliveryDiscountSelectionStrategy {
   """
-  Apply all delivery discount candidates with conditions that are satisfied. This does not override
+  Apply all discounts that are eligible to be applied to a delivery with
+  conditions that are satisfied. This doesn't override
   discount combination or stacking rules.
   """
   ALL
 }
 
 """
-An operation that applies delivery discounts to a cart that share a selection strategy.
+Applies delivery discounts to a cart that share a method for determining which
+shipping and delivery discounts to apply when multiple discounts are eligible.
 """
 input DeliveryDiscountsAddOperation {
   """
-  The list of delivery discount candidates to be applied.
+  The list of discounts that are eligible to be applied to a delivery.
   """
   candidates: [DeliveryDiscountCandidate!]!
 
   """
-  The strategy that's applied to the list of discounts.
+  The method for determining which shipping and delivery discounts to apply when
+  multiple discounts are eligible. For example, when the "ALL" strategy is
+  selected, every shipping and delivery discount that qualifies is applied to
+  the cart (for example, free shipping on orders over $50 and $5 off express
+  shipping). This controls how shipping and delivery discounts interact when
+  multiple conditions are satisfied simultaneously.
   """
   selectionStrategy: DeliveryDiscountSelectionStrategy!
 }
 
 """
-The target delivery group.
+A method for applying a discount to a delivery group. Delivery groups streamline
+fulfillment by organizing items that can be shipped together, based on the customer's shipping address.
+For example, if a customer orders a t-shirt and a pair of shoes that can be shipped together, then the
+items are included in the same delivery group.
 """
 input DeliveryGroupTarget {
   """
@@ -2907,11 +3064,16 @@ enum DeliveryMethod {
 }
 
 """
-The operations that can be performed to apply discounts to the delivery lines.
+The operations to apply discounts to shipping and delivery charges in a
+customer's cart. These operations allow you to reduce the cost of shipping by
+applying percentage or fixed-amount discounts to specific delivery options (such
+as standard shipping and express shipping) or delivery groups (such as
+collections of delivery options).
 """
 input DeliveryOperation @oneOf {
   """
-  An operation that applies delivery discounts to a cart that share a selection strategy.
+  Applies delivery discounts to a cart that share a method for determining which
+  shipping and delivery discounts to apply when multiple discounts are eligible.
   """
   deliveryDiscountsAdd: DeliveryDiscountsAddOperation
 
@@ -2923,7 +3085,9 @@ input DeliveryOperation @oneOf {
 }
 
 """
-The target delivery option.
+A method for applying a discount to a delivery option within a delivery group.
+Delivery options are the different ways that customers can choose to have their
+orders shipped. Examples of delivery options include express shipping or standard shipping.
 """
 input DeliveryOptionTarget {
   """
@@ -2933,25 +3097,33 @@ input DeliveryOptionTarget {
 }
 
 """
-The discount that invoked the Function.
+The discount that invoked the [Discount Function](https://shopify.dev/docs/apps/build/discounts#build-with-shopify-functions)).
 """
 type Discount implements HasMetafields {
   """
-  The discount classes supported by the discount node.
+  The [discount classes](https://shopify.dev/docs/apps/build/discounts/#discount-classes)) that the [discountNode](https://shopify.dev/docs/api/admin-graphql/latest/queries/discountNode)) supports.
   """
   discountClasses: [DiscountClass!]!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3036,16 +3208,24 @@ type GateConfiguration implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3098,32 +3278,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -3236,9 +3426,9 @@ type HttpResponse {
   headers: [HttpResponseHeader!]! @deprecated(reason: "Use `header` instead.")
 
   """
-  The HTTP response body parsed as JSON.
-  If the body is valid JSON, it will be parsed and returned as a JSON object.
-  If parsing fails, then raw body is returned as a string.
+  The HTTP response body parsed as JSON. 
+  If the body is valid JSON, it will be parsed and returned as a JSON object. 
+  If parsing fails, then raw body is returned as a string. 
   Use this field when you expect the response to be JSON, or when you're dealing
   with mixed response types, meaning both JSON and non-JSON.
   Using this field reduces function instruction consumption and ensures that the data is formatted in logs.
@@ -3281,18 +3471,24 @@ The input object for the Function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The discount node executing the Function.
+  The discount node that owns the [Shopify
+  Function](https://shopify.dev/docs/apps/build/functions)). Discounts are a way
+  for merchants to promote sales and special offers, or as customer loyalty
+  rewards. A single discount can be automatic or code-based, and can be applied
+  to a cart lines, orders, and delivery.
   """
   discount: Discount!
 
   """
-  Discount codes entered by the buyer as an array of strings, excluding gift cards.
-  Codes are not validated in any way other than gift card filtering.
+  The discount codes that customers enter at checkout. Customers can enter codes
+  as an array of strings, excluding gift cards.
+  Codes aren't validated in any way other than to verify they aren't gift cards.
   """
   enteredDiscountCodes: [String!]! @restrictTarget(only: ["cart.lines.discounts.generate.fetch", "cart.delivery-options.discounts.generate.fetch"])
 
@@ -3303,24 +3499,31 @@ type Input {
   fetchResult: HttpResponse @restrictTarget(only: ["cart.lines.discounts.generate.run", "cart.delivery-options.discounts.generate.run"])
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 
   """
-  The discount code entered by the buyer that caused the Function to run.
-  This input is only available in the cart.lines.discounts.generate.run
-  and cart.delivery-options.discounts.generate.run extension targets.
+  The discount code entered by a customer, which caused the [Discount Function](https://shopify.dev/docs/apps/build/discounts#build-with-shopify-functions)) to run.
+  This input is only available in the `cart.lines.discounts.generate.run` and
+  `cart.delivery-options.discounts.generate.run` extension targets.
   """
   triggeringDiscountCode: String @restrictTarget(only: ["cart.lines.discounts.generate.run", "cart.delivery-options.discounts.generate.run"])
 }
@@ -3343,7 +3546,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -4063,7 +4267,18 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+Local pickup settings associated with a location.
+"""
+type LocalPickup {
+  """
+  Whether local pickup is enabled for the location.
+  """
+  enabled: Boolean!
+}
+
+"""
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -4143,16 +4358,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -4376,6 +4597,124 @@ enum LocalizedFieldKey {
 }
 
 """
+Represents the location where the inventory resides.
+"""
+type Location implements HasMetafields {
+  """
+  The address of this location.
+  """
+  address: LocationAddress!
+
+  """
+  The location handle.
+  """
+  handle: Handle!
+
+  """
+  The location id.
+  """
+  id: ID!
+
+  """
+  Local pickup settings associated with a location.
+  """
+  localPickup: LocalPickup!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The name of the location.
+  """
+  name: String!
+}
+
+"""
+Represents the address of a location.
+"""
+type LocationAddress {
+  """
+  The first line of the address for the location.
+  """
+  address1: String
+
+  """
+  The second line of the address for the location.
+  """
+  address2: String
+
+  """
+  The city of the location.
+  """
+  city: String
+
+  """
+  The country of the location.
+  """
+  country: String
+
+  """
+  The country code of the location.
+  """
+  countryCode: String
+
+  """
+  A formatted version of the address for the location.
+  """
+  formatted: [String!]!
+
+  """
+  The approximate latitude coordinates of the location.
+  """
+  latitude: Float
+
+  """
+  The approximate longitude coordinates of the location.
+  """
+  longitude: Float
+
+  """
+  The phone number of the location.
+  """
+  phone: String
+
+  """
+  The province of the location.
+  """
+  province: String
+
+  """
+  The code for the province, state, or district of the address of the location.
+  """
+  provinceCode: String
+
+  """
+  The ZIP code of the location.
+  """
+  zip: String
+}
+
+"""
 Represents a mailing address.
 """
 type MailingAddress {
@@ -4470,16 +4809,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4516,47 +4863,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4607,7 +4967,7 @@ type MutationRoot {
 }
 
 """
-The order discount candidate to be applied.
+A discount candidate to be applied to an eligible order.
 """
 input OrderDiscountCandidate {
   """
@@ -4616,12 +4976,13 @@ input OrderDiscountCandidate {
   associatedDiscountCode: AssociatedDiscountCode
 
   """
-  The conditions that must be satisfied to apply the order discount candidate.
+  The conditions that must be satisfied for an order to be eligible for a discount candidate.
   """
   conditions: [Condition!]
 
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
@@ -4637,17 +4998,19 @@ input OrderDiscountCandidate {
 }
 
 """
-A target of a order discount candidate.
+A target of an order to be eligible for a discount candidate.
 """
 input OrderDiscountCandidateTarget @oneOf {
   """
-  If used, the discount targets the entire order subtotal after product discounts are applied.
+  A method for applying a discount to the entire order subtotal. The subtotal is the total amount of the
+  order before any taxes, shipping fees, or discounts are applied. For example, if a customer places an order
+  for a t-shirt and a pair of shoes, then the subtotal is the sum of the prices of those items.
   """
   orderSubtotal: OrderSubtotalTarget
 }
 
 """
-The order discount candidate value.
+The value of the order discount candidate.
 """
 input OrderDiscountCandidateValue @oneOf {
   """
@@ -4681,7 +5044,7 @@ An operation that applies order discounts to a cart that share a selection strat
 """
 input OrderDiscountsAddOperation {
   """
-  The list of order discount candidates to be applied.
+  The list of discounts that can be applied to an order.
   """
   candidates: [OrderDiscountCandidate!]!
 
@@ -4701,13 +5064,15 @@ input OrderMinimumSubtotal {
   excludedCartLineIds: [ID!]!
 
   """
-  The minimum subtotal amount of the order.
+  The minimum subtotal amount of the order to be eligible for the discount.
   """
   minimumAmount: Decimal!
 }
 
 """
-If used, the discount targets the entire order subtotal after product discounts are applied.
+A method for applying a discount to the entire order subtotal. The subtotal is the total amount of the
+order before any taxes, shipping fees, or discounts are applied. For example, if a customer places an order
+for a t-shirt and a pair of shoes, then the subtotal is the sum of the prices of those items.
 """
 input OrderSubtotalTarget {
   """
@@ -4730,7 +5095,11 @@ input Percentage {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasGates & HasMetafields {
   """
@@ -4744,51 +5113,70 @@ type Product implements HasGates & HasMetafields {
   ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4799,27 +5187,39 @@ type Product implements HasGates & HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4830,7 +5230,7 @@ type Product implements HasGates & HasMetafields {
 }
 
 """
-The product discount candidate to be applied.
+The target and value of the discount to be applied to a cart line.
 """
 input ProductDiscountCandidate {
   """
@@ -4839,34 +5239,37 @@ input ProductDiscountCandidate {
   associatedDiscountCode: AssociatedDiscountCode
 
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the product discount candidate.
+  The targets of the discount to be applied to a cart line.
   """
   targets: [ProductDiscountCandidateTarget!]!
 
   """
-  The value of the product discount candidate.
+  The value of the discount to be applied to a cart line. For example, a fixed
+  amount of $5 off or percentage value of 20% off.
   """
   value: ProductDiscountCandidateValue!
 }
 
 """
-A product discount candidate fixed amount value.
+The [fixed-amount](https://help.shopify.com/manual/international/pricing/discounts)
+value of the discount to be applied to a cart line. For example, if the cart
+total is $100 and the discount is $10, then the fixed amount is $10.
 """
 input ProductDiscountCandidateFixedAmount {
   """
-  The fixed amount value of the product discount candidate, in the currency of the cart.
-
-  The amount must be greater than or equal to 0.
+  The [fixed-amount](https://help.shopify.com/manual/international/pricing/discounts) value of the discount to be applied to a cart line, in the currency of the
+  cart. The amount must be greater than or equal to 0.
   """
   amount: Decimal!
 
   """
-  Whether to apply the value to each entitled item.
+  Whether to apply the value of each eligible discount to each eligible cart line.
 
   The default value is `false`, which causes the value to be applied once across the entitled items.
   When the value is `true`, the value will be applied to each of the entitled items.
@@ -4875,26 +5278,30 @@ input ProductDiscountCandidateFixedAmount {
 }
 
 """
-A target of a product discount candidate, which determines which cart line(s) the discount will affect.
+Defines discount candidates, which are cart lines that may be eligible for
+potential discounts. Use discount candidates to identify items in a customer's
+cart that could receive discounts based on conditions in the selection strategy.
 
-Multiple targets with the same type and ID are the same as a single target of that type and ID with their
-quantities added together, or `null` if any of those targets have a quantity of `null`.
-
-See the [Discounts API reference](https://shopify.dev/docs/api/functions/reference/discount/graphql/functioncartrunresult) for examples.
+When multiple cart lines share the same type and ID, the system treats them as a
+single target and combines their quantities. The combined quantity becomes null
+if any individual target has a `null` quantity.
 """
 input ProductDiscountCandidateTarget @oneOf {
   """
-  A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that applies to a specific cart line, up to an optional quantity limit.
+  A method for applying a discount to a specific line item in the cart. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLine: CartLineTarget
 }
 
 """
-The value of the product discount candidate.
+The value of the discount candidate to be applied to a cart line.
 """
 input ProductDiscountCandidateValue @oneOf {
   """
-  A product discount candidate fixed amount value.
+  The [fixed-amount](https://help.shopify.com/manual/international/pricing/discounts) value of the discount to be applied to a cart line. For example, if the cart
+  total is $100 and the discount is $10, then the fixed amount is $10.
   """
   fixedAmount: ProductDiscountCandidateFixedAmount
 
@@ -4905,22 +5312,21 @@ input ProductDiscountCandidateValue @oneOf {
 }
 
 """
-The strategy that's applied to the list of product discount candidates.
+The selection strategy that's applied to the list of discounts that are eligible for cart lines.
 """
 enum ProductDiscountSelectionStrategy {
   """
-  Apply all product discount candidates with conditions that are satisfied. This
-  does not override discount combination or stacking rules.
+  Apply all the discount candidates to eligible cart lines. This doesn't override discount combination or stacking rules.
   """
   ALL
 
   """
-  Only apply the first product discount candidate with conditions that are satisfied.
+  Apply the first discount candidate to cart lines that satisfies conditions.
   """
   FIRST
 
   """
-  Only apply the product discount candidate that offers the maximum reduction.
+  Apply the discount to the cart line that offers the maximum reduction.
   """
   MAXIMUM
 }
@@ -4930,73 +5336,92 @@ An operation that applies product discounts to a cart that share a selection str
 """
 input ProductDiscountsAddOperation {
   """
-  The list of product discount candidates to be applied.
+  The list of products that are eligible for the discount.
   """
   candidates: [ProductDiscountCandidate!]!
 
   """
-  The strategy that's applied to the list of product discount candidates.
+  The strategy that's applied to the list of products that are eligible for the cart line discount.
   """
   selectionStrategy: ProductDiscountSelectionStrategy!
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -5030,16 +5455,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -5099,25 +5532,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/discounts/rust/discounts-allocator/default/schema.graphql
+++ b/discounts/rust/discounts-allocator/default/schema.graphql
@@ -9,11 +9,17 @@ Scale the Functions resource limits based on the field's length.
 directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -24,76 +30,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
-type Cart {
+type Cart implements HasMetafields {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -101,116 +128,171 @@ type Cart {
     """
     keys: [LocalizedFieldKey!]! = []
   ): [LocalizedField!]!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The physical location where a retail order is created or completed.
+  """
+  retailLocation: Location
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -220,44 +302,51 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
@@ -275,16 +364,21 @@ type CartLineTarget {
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -309,16 +403,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -392,16 +494,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -419,7 +529,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1662,9 +1774,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2474,7 +2585,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2483,43 +2597,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2529,27 +2651,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2559,22 +2686,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2612,13 +2747,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2629,12 +2768,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2701,16 +2840,24 @@ type Discount implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2722,21 +2869,33 @@ type Discount implements HasMetafields {
 }
 
 """
-The strategy that's applied to the list of discounts.
+The approach that determines how multiple discounts are evaluated and
+applied to a cart. You can apply all discounts with conditions that are met,
+apply a discount only to the first line item in a cart that meets conditions,
+or apply only the discount that offers a maximum price reduction.
 """
 enum DiscountApplicationStrategy {
   """
-  Apply all discounts with conditions that are satisfied. This does not override discount combination or stacking rules.
+  Apply all discounts with conditions that are met. For example, you can use the `ALL` strategy to apply a
+  20% discount on a t-shirt, a $5 discount on a pair of shoes, and a 10% discount on a hat. The total
+  discount would be the sum of all three discounts, which would be applied to the order total. This strategy
+  doesn't override [discount combination](https://help.shopify.com/manual/discounts/discount-combinations)
+  rules.
   """
   ALL
 
   """
-  Only apply the first discount with conditions that are satisfied.
+  Only apply the discount to the first line item in a cart that meets conditions.
+  For example, you can use the `FIRST` strategy to apply a 20% discount to the first line item in a cart
+  and ensure no other discounts are applied.
   """
   FIRST
 
   """
-  Only apply the discount that offers the maximum reduction.
+  Only apply the discount that provides the greatest savings. For example, you can use the `MAXIMUM` strategy
+  to apply the higher of two discounts. If you have a 20% discount on a $30 t-shirt and a $5 discount on $40
+  shoes, then the 20% discount saves you $6 (20% of $30), while the $5 discount stays the same.
+  Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
 }
@@ -2776,7 +2935,7 @@ type DiscountProposal {
   targets: [CartLineTarget!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
@@ -2810,16 +2969,27 @@ type FixedAmount {
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains a list of discounts that apply to each item in a cart.
 """
 input FunctionRunResult {
   """
-  The list of displayable errors.
+  A list of errors that display if a discount can't be applied to one or more
+  items in a cart. Errors lock checkout, and the customer has to remove the discount code to
+  proceed through checkout.
+
+  Shopify shows errors for only
+  [code discounts](https://shopify.dev/docs/api/admin-graphql/latest/objects/DiscountCodeNode).
+  Custom error messages aren't currently supported. If errors are returned with a custom reason,
+  then the error won't display and the discount won't be added.
   """
   displayableErrors: [DisplayableError!]
 
   """
-  The list of applied line discounts.
+  The list of discounts that are applied to each item in a cart.
+  It includes data such as the ID of the cart line associated with the discount,
+  the quantity of items that the discount applies to,
+  and how the discount is allocated to each item.
   """
   lineDiscounts: [LineDiscount!]
 }
@@ -2844,16 +3014,24 @@ type GateConfiguration implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2898,7 +3076,7 @@ interface HasGates {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 }
 
 """
@@ -2906,32 +3084,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2949,27 +3137,41 @@ The input object for the Function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The list of discounts to be allocated.
+  The information about promotional offers that are applied to items in a cart,
+  such as the discount's name that displays to merchants in the
+  Shopify admin and to customers,
+  the [discount code](https://help.shopify.com/manual/discounts/discount-types/discount-codes),
+  the [discount class](https://help.shopify.com/manual/discounts/combining-discounts/discount-combinations),
+  and [metafields](https://shopify.dev/docs/apps/build/custom-data) that are associated
+  with discounts.
   """
   discounts: [Discount!]
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2992,7 +3194,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3729,7 +3932,18 @@ input LineDiscount {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+Local pickup settings associated with a location.
+"""
+type LocalPickup {
+  """
+  Whether local pickup is enabled for the location.
+  """
+  enabled: Boolean!
+}
+
+"""
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3809,23 +4023,29 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
   """
   The market of the active localized experience.
   """
-  market: Market!
+  market: Market! @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 }
 
 """
@@ -3856,189 +4076,307 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
+}
+
+"""
+Represents the location where the inventory resides.
+"""
+type Location implements HasMetafields {
+  """
+  The address of this location.
+  """
+  address: LocationAddress!
+
+  """
+  The location handle.
+  """
+  handle: Handle!
+
+  """
+  The location id.
+  """
+  id: ID!
+
+  """
+  Local pickup settings associated with a location.
+  """
+  localPickup: LocalPickup!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The name of the location.
+  """
+  name: String!
+}
+
+"""
+Represents the address of a location.
+"""
+type LocationAddress {
+  """
+  The first line of the address for the location.
+  """
+  address1: String
+
+  """
+  The second line of the address for the location.
+  """
+  address2: String
+
+  """
+  The city of the location.
+  """
+  city: String
+
+  """
+  The country of the location.
+  """
+  country: String
+
+  """
+  The country code of the location.
+  """
+  countryCode: String
+
+  """
+  A formatted version of the address for the location.
+  """
+  formatted: [String!]!
+
+  """
+  The approximate latitude coordinates of the location.
+  """
+  latitude: Float
+
+  """
+  The approximate longitude coordinates of the location.
+  """
+  longitude: Float
+
+  """
+  The phone number of the location.
+  """
+  phone: String
+
+  """
+  The province of the location.
+  """
+  province: String
+
+  """
+  The code for the province, state, or district of the address of the location.
+  """
+  provinceCode: String
+
+  """
+  The ZIP code of the location.
+  """
+  zip: String
 }
 
 """
@@ -4093,7 +4431,7 @@ type MailingAddress {
   """
   The market of the address.
   """
-  market: Market
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 
   """
   The full name of the customer, based on firstName and lastName.
@@ -4136,16 +4474,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4182,47 +4528,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4265,7 +4624,11 @@ type Percentage {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasGates & HasMetafields {
   """
@@ -4276,54 +4639,73 @@ type Product implements HasGates & HasMetafields {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4334,27 +4716,39 @@ type Product implements HasGates & HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4365,62 +4759,81 @@ type Product implements HasGates & HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4454,16 +4867,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4523,25 +4944,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4555,7 +4986,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The value of the discount.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 union Value = FixedAmount | Percentage
 

--- a/discounts/rust/order-discounts/default/schema.graphql
+++ b/discounts/rust/order-discounts/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-The condition to apply the discount.
+The criteria or rules that must be met for a discount to be applied to an order.
+For example, conditions can include minimum purchase amounts, specific product selections, or
+customer eligibility.
 """
 input Condition @oneOf {
   """
@@ -432,7 +516,9 @@ input Condition @oneOf {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1675,9 +1761,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2487,7 +2572,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2496,43 +2584,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2542,27 +2638,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2572,22 +2673,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2625,13 +2734,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2642,12 +2755,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2688,45 +2801,66 @@ enum DeliveryMethod {
 }
 
 """
-The discount to be applied.
+A price reduction applied to an order.
+
+Discounts can be offered in various forms, such as a percentage off, a fixed amount off, or free shipping.
+They can be applied automatically at checkout if certain conditions are met, or through a discount code that
+customers enter during checkout. Discounts are often used during promotional events or to attract first-time
+customers.
 """
 input Discount {
   """
-  The condition to apply the discount.
+  The criteria or rules that must be met for a discount to be applied to an order.
+  For example, conditions can include minimum purchase amounts, specific product selections, or
+  customer eligibility.
   """
   conditions: [Condition!]
 
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the discount.
+  The method for applying the discount to an order. This argument accepts either a single
+  `OrderSubtotalTarget` or one or more `ProductVariantTarget`s, but not both.
 
-  The value is validated against: targets should contain only one type of `Target`.
-  Only a list that contains either a single `OrderSubtotalTarget` or one or more
-  `ProductVariantTarget`s is valid.
+  The `OrderSubtotalTarget` is used to target the subtotal of the order. The subtotal is the total amount
+  of the order before any taxes, shipping fees, or discounts are applied. For example, if a customer
+  places an order for a t-shirt and a pair of shoes, then the subtotal is the sum of the prices of those items.
+
+  The `ProductVariantTarget` is used to target specific product variants within the order. Product variants
+  are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+  in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+  product variants in the order, or to specific product variants that meet certain criteria.
   """
   targets: [Target!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
 
 """
-The strategy that's applied to the list of discounts.
+The approach that determines how multiple discounts are evaluated and
+applied to a cart. You can apply a discount to the first line item in a cart that meets conditions,
+or apply the discount that offers the maximum price reduction.
 """
 enum DiscountApplicationStrategy {
   """
-  Only apply the first discount with conditions that are satisfied.
+  Only apply the discount to the first line item in a cart that meets conditions.
+  For example, you can use the `FIRST` strategy to apply a 20% discount to the first line item in a cart
+  and ensure no other discounts are applied.
   """
   FIRST
 
   """
-  Only apply the discount that offers the maximum reduction.
+  Only apply the discount that provides the greatest savings. For example, you can use the `MAXIMUM` strategy
+  to apply the higher of two discounts. If you have a 20% discount on a $30 t-shirt and a $5 discount on $40
+  shoes, then the 20% discount saves you $6 (20% of $30), while the $5 discount stays the same.
+  Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
 }
@@ -2736,16 +2870,24 @@ A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2764,31 +2906,41 @@ input FixedAmount {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply a discount to the first line item in a cart that meets conditions,
+  or apply the discount that offers the maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart.
 """
 input FunctionRunResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply a discount to the first line item in a cart that meets conditions,
+  or apply the discount that offers the maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
@@ -2805,32 +2957,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2848,27 +3010,37 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The discount node executing the function.
+  A wrapper around the discount that executes the Function. The `discountNode` field
+  enables you to manage [discounts](https://help.shopify.com/manual/discounts),
+  which are applied at checkout or on a cart.
   """
   discountNode: DiscountNode!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2891,7 +3063,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3611,7 +3784,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3691,16 +3865,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3738,187 +3918,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -4018,16 +4198,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4064,47 +4252,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4157,7 +4358,9 @@ input OrderMinimumSubtotal {
 }
 
 """
-If used, the discount targets the entire order subtotal after product discounts are applied.
+A method for applying a discount to the entire order subtotal. The subtotal is the total amount of the
+order before any taxes, shipping fees, or discounts are applied. For example, if a customer places an order
+for a t-shirt and a pair of shoes, then the subtotal is the sum of the prices of those items.
 """
 input OrderSubtotalTarget {
   """
@@ -4180,55 +4383,78 @@ input Percentage {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4239,27 +4465,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4314,63 +4552,84 @@ input ProductMinimumSubtotal {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
-optional quantity limit.
+A method for applying a discount to a
+[product variant](https://help.shopify.com/manual/products/variants). Product variants
+are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+product variants in the order, or to specific product variants that meet certain criteria.
 """
 input ProductVariantTarget {
   """
@@ -4388,7 +4647,8 @@ input ProductVariantTarget {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4422,16 +4682,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4491,44 +4759,58 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-A target of a discount.
-
-A discount can either have a single `OrderSubtotalTarget`, or one or more `ProductVariantTarget`s.
+The method for applying the discount to an order. This argument accepts either a single
+`OrderSubtotalTarget` or one or more `ProductVariantTarget`s, but not both.
 """
 input Target @oneOf {
   """
-  If used, the discount targets the entire order subtotal after product discounts are applied.
+  A method for applying a discount to the entire order subtotal. The subtotal is the total amount of the
+  order before any taxes, shipping fees, or discounts are applied. For example, if a customer places an order
+  for a t-shirt and a pair of shoes, then the subtotal is the sum of the prices of those items.
   """
   orderSubtotal: OrderSubtotalTarget
 
   """
-  A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
-  optional quantity limit.
+  A method for applying a discount to a
+  [product variant](https://help.shopify.com/manual/products/variants). Product variants
+  are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+  in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+  product variants in the order, or to specific product variants that meet certain criteria.
   """
   productVariant: ProductVariantTarget
 }
@@ -4556,7 +4838,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The discount value.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 input Value @oneOf {
   """

--- a/discounts/rust/product-discounts/default/schema.graphql
+++ b/discounts/rust/product-discounts/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,50 +279,59 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that applies to a specific cart line, up to an optional quantity limit.
+A method for applying a discount to a specific line item in the cart. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 input CartLineTarget {
   """
@@ -286,16 +349,21 @@ input CartLineTarget {
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -320,16 +388,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -403,16 +479,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -430,7 +514,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1673,9 +1759,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2485,7 +2570,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2494,43 +2582,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2540,27 +2636,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2570,22 +2671,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2623,13 +2732,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2640,12 +2753,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2686,43 +2799,69 @@ enum DeliveryMethod {
 }
 
 """
-The discount to be applied.
+A price reduction applied to a product.
+
+Discounts can be offered in various forms, such as a percentage off, a fixed amount off, or free shipping.
+They can be applied automatically at checkout if certain conditions are met, or through a discount code that
+customers enter during checkout. Discounts are often used during promotional events or to attract first-time
+customers.
 """
 input Discount {
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the discount.
+  The method for applying the discount to products. This argument accepts a collection of either
+  `ProductVariantTarget` or `CartLineTarget`, but not both.
 
-  This argument accepts a collection of either `ProductVariantTarget`s or `CartLineTarget`s, but not both.
+  The `ProductVariantTarget` is used to target a specific product variant. A product variant is a specific
+  version of a product that comes in more than one option, such as size or color. For example, if a merchant
+  sells t-shirts with options for size and color, then a small, blue t-shirt would be one product variant
+  and a large, blue t-shirt would be another.
+
+  The `CartLineTarget` is used to target a specific line item in the cart. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   targets: [Target!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
 
 """
-The strategy that's applied to the list of discounts.
+The approach that determines how multiple discounts are evaluated and
+applied to a cart. You can apply all discounts with conditions that are met,
+apply a discount only to the first line item in a cart that meets conditions,
+or apply only the discount that offers a maximum price reduction.
 """
 enum DiscountApplicationStrategy {
   """
-  Apply all discounts with conditions that are satisfied. This does not override discount combination or stacking rules.
+  Apply all discounts with conditions that are met. For example, you can use the `ALL` strategy to apply a
+  20% discount on a t-shirt, a $5 discount on a pair of shoes, and a 10% discount on a hat. The total
+  discount would be the sum of all three discounts, which would be applied to the order total. This strategy
+  doesn't override [discount combination](https://help.shopify.com/manual/discounts/discount-combinations)
+  rules.
   """
   ALL
 
   """
-  Only apply the first discount with conditions that are satisfied.
+  Only apply the discount to the first line item in a cart that meets conditions.
+  For example, you can use the `FIRST` strategy to apply a 20% discount to the first line item in a cart
+  and ensure no other discounts are applied.
   """
   FIRST
 
   """
-  Only apply the discount that offers the maximum reduction.
+  Only apply the discount that provides the greatest savings. For example, you can use the `MAXIMUM` strategy
+  to apply the higher of two discounts. If you have a 20% discount on a $30 t-shirt and a $5 discount on $40
+  shoes, then the 20% discount saves you $6 (20% of $30), while the $5 discount stays the same.
+  Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
 }
@@ -2732,16 +2871,24 @@ A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2768,31 +2915,43 @@ input FixedAmount {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply all discounts with conditions that are met,
+  apply a discount only to the first line item in a cart that meets conditions,
+  or apply only the discount that offers a maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart.
 """
 input FunctionRunResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply all discounts with conditions that are met,
+  apply a discount only to the first line item in a cart that meets conditions,
+  or apply only the discount that offers a maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
@@ -2809,32 +2968,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2852,27 +3021,37 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The discount node executing the function.
+  A wrapper around the discount that executes the Function. The `discountNode` field
+  enables you to manage [discounts](https://help.shopify.com/manual/discounts),
+  which are applied at checkout or on a cart.
   """
   discountNode: DiscountNode!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2895,7 +3074,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3615,7 +3795,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3695,16 +3876,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3742,187 +3929,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -4022,16 +4209,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4068,47 +4263,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4151,55 +4359,78 @@ input Percentage {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4210,27 +4441,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4241,63 +4484,84 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
-optional quantity limit.
+A method for applying a discount to a
+[product variant](https://help.shopify.com/manual/products/variants). Product variants
+are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+product variants in the order, or to specific product variants that meet certain criteria.
 """
 input ProductVariantTarget {
   """
@@ -4315,7 +4579,8 @@ input ProductVariantTarget {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4349,16 +4614,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4418,49 +4691,58 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-A target of a discount, which determines which cart line(s) the discount will affect.
-
-A discount can have a collection of either `ProductVariantTarget`s or `CartLineTarget`s, but not both.
-
-Multiple targets with the same type and ID are the same as a single target of that type and ID with their
-quantities added together, or `null` if any of those targets have a quantity of `null`.
-
-See the [Product Discount API reference](https://shopify.dev/docs/api/functions/reference/product-discounts/graphql#functionrunresult) for examples.
+The method for applying the discount to products. This argument accepts a collection of either
+`ProductVariantTarget` or `CartLineTarget`, but not both.
 """
 input Target @oneOf {
   """
-  A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that applies to a specific cart line, up to an optional quantity limit.
+  A method for applying a discount to a specific line item in the cart. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLine: CartLineTarget
 
   """
-  A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
-  optional quantity limit.
+  A method for applying a discount to a
+  [product variant](https://help.shopify.com/manual/products/variants). Product variants
+  are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+  in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+  product variants in the order, or to specific product variants that meet certain criteria.
   """
   productVariant: ProductVariantTarget
 }
@@ -4473,7 +4755,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The value of the discount.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 input Value @oneOf {
   """

--- a/discounts/rust/shipping-discounts/default/schema.graphql
+++ b/discounts/rust/shipping-discounts/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1739,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2550,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2562,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2616,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2651,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2712,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,18 +2733,21 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
 
 """
-The target delivery group.
+A method for applying a discount to a delivery group. Delivery groups streamline
+fulfillment by organizing items that can be shipped together, based on the customer's shipping address.
+For example, if a customer orders a t-shirt and a pair of shoes that can be shipped together, then the
+items are included in the same delivery group.
 """
 input DeliveryGroupTarget {
   """
@@ -2678,7 +2792,9 @@ enum DeliveryMethod {
 }
 
 """
-The target delivery option.
+A method for applying a discount to a delivery option within a delivery group.
+Delivery options are the different ways that customers can choose to have their
+orders shipped. Examples of delivery options include express shipping or standard shipping.
 """
 input DeliveryOptionTarget {
   """
@@ -2688,21 +2804,37 @@ input DeliveryOptionTarget {
 }
 
 """
-The discount to be applied.
+A price reduction applied to shipping costs.
+
+Discounts can be offered in various forms, such as a percentage off, a fixed amount off, or free shipping.
+They can be applied automatically at checkout if certain conditions are met, or through a discount code that
+customers enter during checkout. Discounts are often used during promotional events or to attract first-time
+customers.
 """
 input Discount {
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the discount.
+  The method for applying the discount to shipping costs. This argument accepts a collection of either
+  `DeliveryGroupTarget` or `DeliveryOptionTarget`, but not both.
+
+  The `DeliveryGroupTarget` is used to target a specific delivery group. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's shipping address.
+  For example, if a customer orders a t-shirt and a pair of shoes that can be shipped together, then the
+  items are included in the same delivery group.
+
+  The `DeliveryOptionTarget` is used to target a specific delivery option within a delivery group.
+  Delivery options are the different ways that customers can choose to have their
+  orders shipped. Examples of delivery options include express shipping or standard shipping.
   """
   targets: [Target!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
@@ -2712,16 +2844,24 @@ A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2740,21 +2880,27 @@ input FixedAmount {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the list of discounts to apply to shipping costs. In API
+versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the list of discounts to apply to shipping costs.
 """
 input FunctionRunResult {
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
@@ -2771,32 +2917,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2814,27 +2970,37 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The discount node executing the function.
+  A wrapper around the discount that executes the Function. The `discountNode` field
+  enables you to manage [discounts](https://help.shopify.com/manual/discounts),
+  which are applied at checkout or on a cart.
   """
   discountNode: DiscountNode!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2857,7 +3023,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3577,7 +3744,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3657,16 +3825,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3704,187 +3878,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3984,16 +4158,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4030,47 +4212,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4113,55 +4308,78 @@ input Percentage {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4172,27 +4390,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4203,62 +4433,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4292,16 +4541,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4361,41 +4618,57 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-The target of the discount.
+The method for applying the discount to shipping costs. This argument accepts a collection of either
+`DeliveryGroupTarget` or `DeliveryOptionTarget`, but not both.
 """
 input Target @oneOf {
   """
-  The target delivery group.
+  A method for applying a discount to a delivery group. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's shipping address.
+  For example, if a customer orders a t-shirt and a pair of shoes that can be shipped together, then the
+  items are included in the same delivery group.
   """
   deliveryGroup: DeliveryGroupTarget
 
   """
-  The target delivery option.
+  A method for applying a discount to a delivery option within a delivery group.
+  Delivery options are the different ways that customers can choose to have their
+  orders shipped. Examples of delivery options include express shipping or standard shipping.
   """
   deliveryOption: DeliveryOptionTarget
 }
@@ -4408,7 +4681,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The discount value.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 input Value @oneOf {
   """

--- a/discounts/wasm/discounts-allocator/default/schema.graphql
+++ b/discounts/wasm/discounts-allocator/default/schema.graphql
@@ -9,11 +9,17 @@ Scale the Functions resource limits based on the field's length.
 directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -24,76 +30,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
-type Cart {
+type Cart implements HasMetafields {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -101,116 +128,171 @@ type Cart {
     """
     keys: [LocalizedFieldKey!]! = []
   ): [LocalizedField!]!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The physical location where a retail order is created or completed.
+  """
+  retailLocation: Location
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -220,44 +302,51 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
@@ -275,16 +364,21 @@ type CartLineTarget {
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -309,16 +403,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -392,16 +494,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -419,7 +529,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1662,9 +1774,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2474,7 +2585,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2483,43 +2597,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2529,27 +2651,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2559,22 +2686,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2612,13 +2747,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2629,12 +2768,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2701,16 +2840,24 @@ type Discount implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2722,21 +2869,33 @@ type Discount implements HasMetafields {
 }
 
 """
-The strategy that's applied to the list of discounts.
+The approach that determines how multiple discounts are evaluated and
+applied to a cart. You can apply all discounts with conditions that are met,
+apply a discount only to the first line item in a cart that meets conditions,
+or apply only the discount that offers a maximum price reduction.
 """
 enum DiscountApplicationStrategy {
   """
-  Apply all discounts with conditions that are satisfied. This does not override discount combination or stacking rules.
+  Apply all discounts with conditions that are met. For example, you can use the `ALL` strategy to apply a
+  20% discount on a t-shirt, a $5 discount on a pair of shoes, and a 10% discount on a hat. The total
+  discount would be the sum of all three discounts, which would be applied to the order total. This strategy
+  doesn't override [discount combination](https://help.shopify.com/manual/discounts/discount-combinations)
+  rules.
   """
   ALL
 
   """
-  Only apply the first discount with conditions that are satisfied.
+  Only apply the discount to the first line item in a cart that meets conditions.
+  For example, you can use the `FIRST` strategy to apply a 20% discount to the first line item in a cart
+  and ensure no other discounts are applied.
   """
   FIRST
 
   """
-  Only apply the discount that offers the maximum reduction.
+  Only apply the discount that provides the greatest savings. For example, you can use the `MAXIMUM` strategy
+  to apply the higher of two discounts. If you have a 20% discount on a $30 t-shirt and a $5 discount on $40
+  shoes, then the 20% discount saves you $6 (20% of $30), while the $5 discount stays the same.
+  Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
 }
@@ -2776,7 +2935,7 @@ type DiscountProposal {
   targets: [CartLineTarget!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
@@ -2810,16 +2969,27 @@ type FixedAmount {
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains a list of discounts that apply to each item in a cart.
 """
 input FunctionRunResult {
   """
-  The list of displayable errors.
+  A list of errors that display if a discount can't be applied to one or more
+  items in a cart. Errors lock checkout, and the customer has to remove the discount code to
+  proceed through checkout.
+
+  Shopify shows errors for only
+  [code discounts](https://shopify.dev/docs/api/admin-graphql/latest/objects/DiscountCodeNode).
+  Custom error messages aren't currently supported. If errors are returned with a custom reason,
+  then the error won't display and the discount won't be added.
   """
   displayableErrors: [DisplayableError!]
 
   """
-  The list of applied line discounts.
+  The list of discounts that are applied to each item in a cart.
+  It includes data such as the ID of the cart line associated with the discount,
+  the quantity of items that the discount applies to,
+  and how the discount is allocated to each item.
   """
   lineDiscounts: [LineDiscount!]
 }
@@ -2844,16 +3014,24 @@ type GateConfiguration implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2898,7 +3076,7 @@ interface HasGates {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 }
 
 """
@@ -2906,32 +3084,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2949,27 +3137,41 @@ The input object for the Function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The list of discounts to be allocated.
+  The information about promotional offers that are applied to items in a cart,
+  such as the discount's name that displays to merchants in the
+  Shopify admin and to customers,
+  the [discount code](https://help.shopify.com/manual/discounts/discount-types/discount-codes),
+  the [discount class](https://help.shopify.com/manual/discounts/combining-discounts/discount-combinations),
+  and [metafields](https://shopify.dev/docs/apps/build/custom-data) that are associated
+  with discounts.
   """
   discounts: [Discount!]
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2992,7 +3194,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3729,7 +3932,18 @@ input LineDiscount {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+Local pickup settings associated with a location.
+"""
+type LocalPickup {
+  """
+  Whether local pickup is enabled for the location.
+  """
+  enabled: Boolean!
+}
+
+"""
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3809,23 +4023,29 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
   """
   The market of the active localized experience.
   """
-  market: Market!
+  market: Market! @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 }
 
 """
@@ -3856,189 +4076,307 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
+}
+
+"""
+Represents the location where the inventory resides.
+"""
+type Location implements HasMetafields {
+  """
+  The address of this location.
+  """
+  address: LocationAddress!
+
+  """
+  The location handle.
+  """
+  handle: Handle!
+
+  """
+  The location id.
+  """
+  id: ID!
+
+  """
+  Local pickup settings associated with a location.
+  """
+  localPickup: LocalPickup!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The name of the location.
+  """
+  name: String!
+}
+
+"""
+Represents the address of a location.
+"""
+type LocationAddress {
+  """
+  The first line of the address for the location.
+  """
+  address1: String
+
+  """
+  The second line of the address for the location.
+  """
+  address2: String
+
+  """
+  The city of the location.
+  """
+  city: String
+
+  """
+  The country of the location.
+  """
+  country: String
+
+  """
+  The country code of the location.
+  """
+  countryCode: String
+
+  """
+  A formatted version of the address for the location.
+  """
+  formatted: [String!]!
+
+  """
+  The approximate latitude coordinates of the location.
+  """
+  latitude: Float
+
+  """
+  The approximate longitude coordinates of the location.
+  """
+  longitude: Float
+
+  """
+  The phone number of the location.
+  """
+  phone: String
+
+  """
+  The province of the location.
+  """
+  province: String
+
+  """
+  The code for the province, state, or district of the address of the location.
+  """
+  provinceCode: String
+
+  """
+  The ZIP code of the location.
+  """
+  zip: String
 }
 
 """
@@ -4093,7 +4431,7 @@ type MailingAddress {
   """
   The market of the address.
   """
-  market: Market
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 
   """
   The full name of the customer, based on firstName and lastName.
@@ -4136,16 +4474,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4182,47 +4528,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4265,7 +4624,11 @@ type Percentage {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasGates & HasMetafields {
   """
@@ -4276,54 +4639,73 @@ type Product implements HasGates & HasMetafields {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4334,27 +4716,39 @@ type Product implements HasGates & HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4365,62 +4759,81 @@ type Product implements HasGates & HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4454,16 +4867,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4523,25 +4944,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4555,7 +4986,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The value of the discount.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 union Value = FixedAmount | Percentage
 

--- a/discounts/wasm/order-discounts/default/schema.graphql
+++ b/discounts/wasm/order-discounts/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-The condition to apply the discount.
+The criteria or rules that must be met for a discount to be applied to an order.
+For example, conditions can include minimum purchase amounts, specific product selections, or
+customer eligibility.
 """
 input Condition @oneOf {
   """
@@ -432,7 +516,9 @@ input Condition @oneOf {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1675,9 +1761,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2487,7 +2572,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2496,43 +2584,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2542,27 +2638,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2572,22 +2673,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2625,13 +2734,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2642,12 +2755,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2688,45 +2801,66 @@ enum DeliveryMethod {
 }
 
 """
-The discount to be applied.
+A price reduction applied to an order.
+
+Discounts can be offered in various forms, such as a percentage off, a fixed amount off, or free shipping.
+They can be applied automatically at checkout if certain conditions are met, or through a discount code that
+customers enter during checkout. Discounts are often used during promotional events or to attract first-time
+customers.
 """
 input Discount {
   """
-  The condition to apply the discount.
+  The criteria or rules that must be met for a discount to be applied to an order.
+  For example, conditions can include minimum purchase amounts, specific product selections, or
+  customer eligibility.
   """
   conditions: [Condition!]
 
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the discount.
+  The method for applying the discount to an order. This argument accepts either a single
+  `OrderSubtotalTarget` or one or more `ProductVariantTarget`s, but not both.
 
-  The value is validated against: targets should contain only one type of `Target`.
-  Only a list that contains either a single `OrderSubtotalTarget` or one or more
-  `ProductVariantTarget`s is valid.
+  The `OrderSubtotalTarget` is used to target the subtotal of the order. The subtotal is the total amount
+  of the order before any taxes, shipping fees, or discounts are applied. For example, if a customer
+  places an order for a t-shirt and a pair of shoes, then the subtotal is the sum of the prices of those items.
+
+  The `ProductVariantTarget` is used to target specific product variants within the order. Product variants
+  are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+  in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+  product variants in the order, or to specific product variants that meet certain criteria.
   """
   targets: [Target!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
 
 """
-The strategy that's applied to the list of discounts.
+The approach that determines how multiple discounts are evaluated and
+applied to a cart. You can apply a discount to the first line item in a cart that meets conditions,
+or apply the discount that offers the maximum price reduction.
 """
 enum DiscountApplicationStrategy {
   """
-  Only apply the first discount with conditions that are satisfied.
+  Only apply the discount to the first line item in a cart that meets conditions.
+  For example, you can use the `FIRST` strategy to apply a 20% discount to the first line item in a cart
+  and ensure no other discounts are applied.
   """
   FIRST
 
   """
-  Only apply the discount that offers the maximum reduction.
+  Only apply the discount that provides the greatest savings. For example, you can use the `MAXIMUM` strategy
+  to apply the higher of two discounts. If you have a 20% discount on a $30 t-shirt and a $5 discount on $40
+  shoes, then the 20% discount saves you $6 (20% of $30), while the $5 discount stays the same.
+  Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
 }
@@ -2736,16 +2870,24 @@ A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2764,31 +2906,41 @@ input FixedAmount {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply a discount to the first line item in a cart that meets conditions,
+  or apply the discount that offers the maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart.
 """
 input FunctionRunResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply a discount to the first line item in a cart that meets conditions,
+  or apply the discount that offers the maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
@@ -2805,32 +2957,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2848,27 +3010,37 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The discount node executing the function.
+  A wrapper around the discount that executes the Function. The `discountNode` field
+  enables you to manage [discounts](https://help.shopify.com/manual/discounts),
+  which are applied at checkout or on a cart.
   """
   discountNode: DiscountNode!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2891,7 +3063,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3611,7 +3784,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3691,16 +3865,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3738,187 +3918,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -4018,16 +4198,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4064,47 +4252,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4157,7 +4358,9 @@ input OrderMinimumSubtotal {
 }
 
 """
-If used, the discount targets the entire order subtotal after product discounts are applied.
+A method for applying a discount to the entire order subtotal. The subtotal is the total amount of the
+order before any taxes, shipping fees, or discounts are applied. For example, if a customer places an order
+for a t-shirt and a pair of shoes, then the subtotal is the sum of the prices of those items.
 """
 input OrderSubtotalTarget {
   """
@@ -4180,55 +4383,78 @@ input Percentage {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4239,27 +4465,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4314,63 +4552,84 @@ input ProductMinimumSubtotal {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
-optional quantity limit.
+A method for applying a discount to a
+[product variant](https://help.shopify.com/manual/products/variants). Product variants
+are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+product variants in the order, or to specific product variants that meet certain criteria.
 """
 input ProductVariantTarget {
   """
@@ -4388,7 +4647,8 @@ input ProductVariantTarget {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4422,16 +4682,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4491,44 +4759,58 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-A target of a discount.
-
-A discount can either have a single `OrderSubtotalTarget`, or one or more `ProductVariantTarget`s.
+The method for applying the discount to an order. This argument accepts either a single
+`OrderSubtotalTarget` or one or more `ProductVariantTarget`s, but not both.
 """
 input Target @oneOf {
   """
-  If used, the discount targets the entire order subtotal after product discounts are applied.
+  A method for applying a discount to the entire order subtotal. The subtotal is the total amount of the
+  order before any taxes, shipping fees, or discounts are applied. For example, if a customer places an order
+  for a t-shirt and a pair of shoes, then the subtotal is the sum of the prices of those items.
   """
   orderSubtotal: OrderSubtotalTarget
 
   """
-  A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
-  optional quantity limit.
+  A method for applying a discount to a
+  [product variant](https://help.shopify.com/manual/products/variants). Product variants
+  are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+  in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+  product variants in the order, or to specific product variants that meet certain criteria.
   """
   productVariant: ProductVariantTarget
 }
@@ -4556,7 +4838,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The discount value.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 input Value @oneOf {
   """

--- a/discounts/wasm/product-discounts/default/schema.graphql
+++ b/discounts/wasm/product-discounts/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,50 +279,59 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that applies to a specific cart line, up to an optional quantity limit.
+A method for applying a discount to a specific line item in the cart. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 input CartLineTarget {
   """
@@ -286,16 +349,21 @@ input CartLineTarget {
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -320,16 +388,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -403,16 +479,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -430,7 +514,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1673,9 +1759,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2485,7 +2570,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2494,43 +2582,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2540,27 +2636,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2570,22 +2671,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2623,13 +2732,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2640,12 +2753,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2686,43 +2799,69 @@ enum DeliveryMethod {
 }
 
 """
-The discount to be applied.
+A price reduction applied to a product.
+
+Discounts can be offered in various forms, such as a percentage off, a fixed amount off, or free shipping.
+They can be applied automatically at checkout if certain conditions are met, or through a discount code that
+customers enter during checkout. Discounts are often used during promotional events or to attract first-time
+customers.
 """
 input Discount {
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the discount.
+  The method for applying the discount to products. This argument accepts a collection of either
+  `ProductVariantTarget` or `CartLineTarget`, but not both.
 
-  This argument accepts a collection of either `ProductVariantTarget`s or `CartLineTarget`s, but not both.
+  The `ProductVariantTarget` is used to target a specific product variant. A product variant is a specific
+  version of a product that comes in more than one option, such as size or color. For example, if a merchant
+  sells t-shirts with options for size and color, then a small, blue t-shirt would be one product variant
+  and a large, blue t-shirt would be another.
+
+  The `CartLineTarget` is used to target a specific line item in the cart. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   targets: [Target!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
 
 """
-The strategy that's applied to the list of discounts.
+The approach that determines how multiple discounts are evaluated and
+applied to a cart. You can apply all discounts with conditions that are met,
+apply a discount only to the first line item in a cart that meets conditions,
+or apply only the discount that offers a maximum price reduction.
 """
 enum DiscountApplicationStrategy {
   """
-  Apply all discounts with conditions that are satisfied. This does not override discount combination or stacking rules.
+  Apply all discounts with conditions that are met. For example, you can use the `ALL` strategy to apply a
+  20% discount on a t-shirt, a $5 discount on a pair of shoes, and a 10% discount on a hat. The total
+  discount would be the sum of all three discounts, which would be applied to the order total. This strategy
+  doesn't override [discount combination](https://help.shopify.com/manual/discounts/discount-combinations)
+  rules.
   """
   ALL
 
   """
-  Only apply the first discount with conditions that are satisfied.
+  Only apply the discount to the first line item in a cart that meets conditions.
+  For example, you can use the `FIRST` strategy to apply a 20% discount to the first line item in a cart
+  and ensure no other discounts are applied.
   """
   FIRST
 
   """
-  Only apply the discount that offers the maximum reduction.
+  Only apply the discount that provides the greatest savings. For example, you can use the `MAXIMUM` strategy
+  to apply the higher of two discounts. If you have a 20% discount on a $30 t-shirt and a $5 discount on $40
+  shoes, then the 20% discount saves you $6 (20% of $30), while the $5 discount stays the same.
+  Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
 }
@@ -2732,16 +2871,24 @@ A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2768,31 +2915,43 @@ input FixedAmount {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply all discounts with conditions that are met,
+  apply a discount only to the first line item in a cart that meets conditions,
+  or apply only the discount that offers a maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart.
 """
 input FunctionRunResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply all discounts with conditions that are met,
+  apply a discount only to the first line item in a cart that meets conditions,
+  or apply only the discount that offers a maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
@@ -2809,32 +2968,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2852,27 +3021,37 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The discount node executing the function.
+  A wrapper around the discount that executes the Function. The `discountNode` field
+  enables you to manage [discounts](https://help.shopify.com/manual/discounts),
+  which are applied at checkout or on a cart.
   """
   discountNode: DiscountNode!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2895,7 +3074,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3615,7 +3795,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3695,16 +3876,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3742,187 +3929,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -4022,16 +4209,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4068,47 +4263,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4151,55 +4359,78 @@ input Percentage {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4210,27 +4441,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4241,63 +4484,84 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
-optional quantity limit.
+A method for applying a discount to a
+[product variant](https://help.shopify.com/manual/products/variants). Product variants
+are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+product variants in the order, or to specific product variants that meet certain criteria.
 """
 input ProductVariantTarget {
   """
@@ -4315,7 +4579,8 @@ input ProductVariantTarget {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4349,16 +4614,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4418,49 +4691,58 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-A target of a discount, which determines which cart line(s) the discount will affect.
-
-A discount can have a collection of either `ProductVariantTarget`s or `CartLineTarget`s, but not both.
-
-Multiple targets with the same type and ID are the same as a single target of that type and ID with their
-quantities added together, or `null` if any of those targets have a quantity of `null`.
-
-See the [Product Discount API reference](https://shopify.dev/docs/api/functions/reference/product-discounts/graphql#functionrunresult) for examples.
+The method for applying the discount to products. This argument accepts a collection of either
+`ProductVariantTarget` or `CartLineTarget`, but not both.
 """
 input Target @oneOf {
   """
-  A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that applies to a specific cart line, up to an optional quantity limit.
+  A method for applying a discount to a specific line item in the cart. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLine: CartLineTarget
 
   """
-  A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
-  optional quantity limit.
+  A method for applying a discount to a
+  [product variant](https://help.shopify.com/manual/products/variants). Product variants
+  are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+  in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+  product variants in the order, or to specific product variants that meet certain criteria.
   """
   productVariant: ProductVariantTarget
 }
@@ -4473,7 +4755,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The value of the discount.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 input Value @oneOf {
   """

--- a/discounts/wasm/shipping-discounts/default/schema.graphql
+++ b/discounts/wasm/shipping-discounts/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1739,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2550,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2562,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2616,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2651,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2712,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,18 +2733,21 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
 
 """
-The target delivery group.
+A method for applying a discount to a delivery group. Delivery groups streamline
+fulfillment by organizing items that can be shipped together, based on the customer's shipping address.
+For example, if a customer orders a t-shirt and a pair of shoes that can be shipped together, then the
+items are included in the same delivery group.
 """
 input DeliveryGroupTarget {
   """
@@ -2678,7 +2792,9 @@ enum DeliveryMethod {
 }
 
 """
-The target delivery option.
+A method for applying a discount to a delivery option within a delivery group.
+Delivery options are the different ways that customers can choose to have their
+orders shipped. Examples of delivery options include express shipping or standard shipping.
 """
 input DeliveryOptionTarget {
   """
@@ -2688,21 +2804,37 @@ input DeliveryOptionTarget {
 }
 
 """
-The discount to be applied.
+A price reduction applied to shipping costs.
+
+Discounts can be offered in various forms, such as a percentage off, a fixed amount off, or free shipping.
+They can be applied automatically at checkout if certain conditions are met, or through a discount code that
+customers enter during checkout. Discounts are often used during promotional events or to attract first-time
+customers.
 """
 input Discount {
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the discount.
+  The method for applying the discount to shipping costs. This argument accepts a collection of either
+  `DeliveryGroupTarget` or `DeliveryOptionTarget`, but not both.
+
+  The `DeliveryGroupTarget` is used to target a specific delivery group. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's shipping address.
+  For example, if a customer orders a t-shirt and a pair of shoes that can be shipped together, then the
+  items are included in the same delivery group.
+
+  The `DeliveryOptionTarget` is used to target a specific delivery option within a delivery group.
+  Delivery options are the different ways that customers can choose to have their
+  orders shipped. Examples of delivery options include express shipping or standard shipping.
   """
   targets: [Target!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
@@ -2712,16 +2844,24 @@ A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2740,21 +2880,27 @@ input FixedAmount {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the list of discounts to apply to shipping costs. In API
+versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the list of discounts to apply to shipping costs.
 """
 input FunctionRunResult {
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
@@ -2771,32 +2917,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2814,27 +2970,37 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The discount node executing the function.
+  A wrapper around the discount that executes the Function. The `discountNode` field
+  enables you to manage [discounts](https://help.shopify.com/manual/discounts),
+  which are applied at checkout or on a cart.
   """
   discountNode: DiscountNode!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2857,7 +3023,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3577,7 +3744,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3657,16 +3825,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3704,187 +3878,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3984,16 +4158,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4030,47 +4212,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4113,55 +4308,78 @@ input Percentage {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4172,27 +4390,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4203,62 +4433,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4292,16 +4541,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4361,41 +4618,57 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-The target of the discount.
+The method for applying the discount to shipping costs. This argument accepts a collection of either
+`DeliveryGroupTarget` or `DeliveryOptionTarget`, but not both.
 """
 input Target @oneOf {
   """
-  The target delivery group.
+  A method for applying a discount to a delivery group. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's shipping address.
+  For example, if a customer orders a t-shirt and a pair of shoes that can be shipped together, then the
+  items are included in the same delivery group.
   """
   deliveryGroup: DeliveryGroupTarget
 
   """
-  The target delivery option.
+  A method for applying a discount to a delivery option within a delivery group.
+  Delivery options are the different ways that customers can choose to have their
+  orders shipped. Examples of delivery options include express shipping or standard shipping.
   """
   deliveryOption: DeliveryOptionTarget
 }
@@ -4408,7 +4681,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The discount value.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 input Value @oneOf {
   """

--- a/order-routing/javascript/fulfillment-constraints/default/schema.graphql
+++ b/order-routing/javascript/fulfillment-constraints/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1739,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2550,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2562,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2616,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2651,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2712,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,12 +2733,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2672,37 +2783,55 @@ A customization which applies constraint rules to order routing and fulfillments
 """
 type FulfillmentConstraintRule implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
+In API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The fulfillment constraints determined by the function.
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
   """
   operations: [Operation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
 """
 input FunctionRunResult {
   """
-  The fulfillment constraints determined by the function.
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
   """
   operations: [Operation!]!
 }
@@ -2719,32 +2848,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2762,42 +2901,55 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The fulfillment constraint rule containing the function.
+  The backend logic that the Function uses to determine how to
+  [fulfill orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders). It includes the
+  [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   fulfillmentConstraintRule: FulfillmentConstraintRule!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  A list of all locations for the current shop.
+  A list of all geographical locations where the inventory is stored,
+  including warehouses, retail locations, and distribution centers.
   """
   locations(
     """
-    The list of location GIDs to search for.
+    A list of [globally-unique identifiers](https://shopify.dev/docs/api/usage/gids)
+    for the locations where inventory resides.
     """
     identifiers: [String!]
 
     """
-    The list of location names to search for.
+    A list of location names where the inventory resides.
     """
     names: [String!]
   ): [Location!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2820,7 +2972,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3540,7 +3693,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3620,16 +3774,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3667,187 +3827,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3872,16 +4032,24 @@ type Location implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4052,16 +4220,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4098,47 +4274,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4217,55 +4406,78 @@ input Operation @oneOf {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4276,27 +4488,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4307,62 +4531,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4396,16 +4639,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4465,25 +4716,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/order-routing/javascript/local-pickup-delivery-option-generators/default/schema.graphql
+++ b/order-routing/javascript/local-pickup-delivery-option-generators/default/schema.graphql
@@ -14,11 +14,17 @@ Scale the Functions resource limits based on the field's length.
 directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
-type Cart {
+type Cart implements HasMetafields {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -106,116 +133,171 @@ type Cart {
     """
     keys: [LocalizedFieldKey!]! = []
   ): [LocalizedField!]!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The physical location where a retail order is created or completed.
+  """
+  retailLocation: Location
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +307,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +396,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +487,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +522,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1767,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2578,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2590,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2644,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2679,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2740,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,12 +2761,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2672,16 +2811,24 @@ A customization representing how delivery options are generated.
 """
 type DeliveryOptionGenerator implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2723,21 +2870,29 @@ type FulfillmentGroup {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to generate local pickup options in checkout.
+In API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The ordered list of operations to apply for local pickup delivery option generation.
+  The ordered list of operations to apply when generating
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store)
+  options.
   """
   operations: [Operation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to generate local pickup options in checkout.
 """
 input FunctionRunResult {
   """
-  The ordered list of operations to apply for local pickup delivery option generation.
+  The ordered list of operations to apply when generating
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store)
+  options.
   """
   operations: [Operation!]!
 }
@@ -2762,16 +2917,24 @@ type GateConfiguration implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2816,7 +2979,7 @@ interface HasGates {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 }
 
 """
@@ -2824,32 +2987,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2864,37 +3037,53 @@ scalar ID
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The delivery option generator that owns the current function.
+  The backend logic that the Function uses to generate
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store)
+  options. It includes the [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   deliveryOptionGenerator: DeliveryOptionGenerator!
 
   """
-  A list of fulfillment groups.
+  A list of
+  [fulfillment locations](https://shopify.dev/manual/fulfillment/setup/shipping-profiles/managing-fulfillment-locations)
+  that contain one or more items to be shipped together. Each item in the cart is assigned to one
+  fulfillment group.
   """
   fulfillmentGroups: [FulfillmentGroup!]!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The locations that can fulfill the items in the cart or that offer local pickup.
+  A list of all geographical locations where the inventory is stored,
+  including warehouses, retail locations, and distribution centers.
+  The list captures the locations that can fulfill items in the cart or that offer local pickup.
   """
   locations: [Location!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2917,7 +3106,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3672,7 +3862,8 @@ input LocalPickupDeliveryOption {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3752,23 +3943,29 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
   """
   The market of the active localized experience.
   """
-  market: Market!
+  market: Market! @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 }
 
 """
@@ -3799,187 +3996,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -4009,16 +4206,24 @@ type Location implements HasMetafields {
   localPickup: LocalPickup!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4146,7 +4351,7 @@ type MailingAddress {
   """
   The market of the address.
   """
-  market: Market
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 
   """
   The full name of the customer, based on firstName and lastName.
@@ -4189,16 +4394,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4235,52 +4448,71 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields) enable you to attach additional information.
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 input MetafieldOutput {
   """
-  The key for the metafield.
+  The unique identifier for the metafield within its namespace. A metafield is composed of a
+  namespace and a key, in the format `namespace.key`.
   """
   key: String!
 
   """
-  The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+  A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+  between different apps or different parts of the same app. If omitted, then the
+  [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+  is used.
   """
   namespace: String
 
   """
-  The type of data that is stored in the metafield. Refer to the list of supported types.
+  The [type of data](https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types)
+  that's stored in the metafield.
   """
   type: String!
 
@@ -4291,16 +4523,19 @@ input MetafieldOutput {
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4354,7 +4589,11 @@ input PickupLocation {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasGates & HasMetafields {
   """
@@ -4365,54 +4604,73 @@ type Product implements HasGates & HasMetafields {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4423,27 +4681,39 @@ type Product implements HasGates & HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4454,62 +4724,81 @@ type Product implements HasGates & HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4543,16 +4832,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4612,25 +4909,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/order-routing/javascript/location-rules/default/schema.graphql
+++ b/order-routing/javascript/location-rules/default/schema.graphql
@@ -9,11 +9,17 @@ Scale the Functions resource limits based on the field's length.
 directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -24,76 +30,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -104,113 +131,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -220,59 +274,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -297,16 +363,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -380,16 +454,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -407,7 +489,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1650,9 +1734,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2462,7 +2545,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2471,43 +2557,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2517,27 +2611,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2547,22 +2646,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2600,13 +2707,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2617,12 +2728,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2713,21 +2824,29 @@ input FulfillmentGroupRankedLocations {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations that rank locations for each fulfillment
+group. In API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The ranked locations for each fulfillment group.
+  The ordered list of operations that rank locations for each fulfillment group,
+  which includes one or more items to be shipped together.
+  The locations with the highest ranking are selected to fulfill the order.
   """
   operations: [Operation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations that rank locations for each fulfillment group.
 """
 input FunctionRunResult {
   """
-  The ranked locations for each fulfillment group.
+  The ordered list of operations that rank locations for each fulfillment group,
+  which includes one or more items to be shipped together.
+  The locations with the highest ranking are selected to fulfill the order.
   """
   operations: [Operation!]!
 }
@@ -2744,32 +2863,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2787,37 +2916,53 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  List of fulfillment groups in the context of this cart.
+  A list of
+  [fulfillment locations](https://shopify.dev/manual/fulfillment/setup/shipping-profiles/managing-fulfillment-locations)
+  that contain one or more items to be shipped together. Each item in the cart is assigned to one
+  fulfillment group.
   """
   fulfillmentGroups: [FulfillmentGroup!]!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The order routing location rule containing the function.
+  The backend logic that the Function uses to
+  [route orders](https://shopify.dev/manual/fulfillment/setup/order-routing/understanding-order-routing).
+  It includes the [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   locationRule: OrderRoutingLocationRule!
 
   """
-  The locations where the inventory items on this cart are stocked.
+  A list of all geographical locations where the inventory is stored,
+  including warehouses, retail locations, and distribution centers.
+  The list captures the locations that can fulfill items in the cart.
   """
   locations: [Location!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2840,7 +2985,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3560,7 +3706,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3640,16 +3787,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3687,187 +3840,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3892,16 +4045,24 @@ type Location implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4072,16 +4233,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4118,47 +4287,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4193,7 +4375,8 @@ An operation to apply to the fulfillment group inventory locations.
 """
 input Operation {
   """
-  Request to rank a fulfillment group's inventory locations.
+  A request to rank the locations associated with a fulfillment group.
+  The ranking determines the priority in which the locations are selected to fulfill the order.
   """
   rank: FulfillmentGroupRankedLocations!
 }
@@ -4203,71 +4386,102 @@ A customization which ranks inventory locations for fulfillment purposes.
 """
 type OrderRoutingLocationRule implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4278,27 +4492,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4309,62 +4535,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4413,16 +4658,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4482,25 +4735,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/schema.graphql
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/schema.graphql
@@ -24,11 +24,17 @@ type Allocation {
 }
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -39,7 +45,7 @@ type Attribute {
 }
 
 """
-The business hours for a pickup point.
+The pickup point's hours of operation for a specific day of the week.
 """
 input BusinessHours {
   """
@@ -48,97 +54,124 @@ input BusinessHours {
   day: Weekday!
 
   """
-  The business hours periods.
+  The operating time periods for a specific day. To represent split schedules
+  (for example, 9:00-12:00 and 13:00-17:00 for locations that close during
+  lunch), you can specify multiple periods.
+
+  Each period consists of `opening_time` and `closing_time`. To indicate the
+  location is closed on a specific day, such as Sunday, then omit it entirely
+  from the `business_hours` array.
   """
   periods: [BusinessHoursPeriod!]!
 }
 
 """
-The business hours period.
+The pickup point's hours of operation for a specific day of the week.
 """
 input BusinessHoursPeriod {
   """
-  The closing time.
+  The time that the pickup point location closes.
   """
   closingTime: TimeWithoutTimezone!
 
   """
-  The opening time.
+  The time that the pickup point location opens.
   """
   openingTime: TimeWithoutTimezone!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
-type Cart {
+type Cart implements HasMetafields {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -146,116 +179,171 @@ type Cart {
     """
     keys: [LocalizedFieldKey!]! = []
   ): [LocalizedField!]!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The physical location where a retail order is created or completed.
+  """
+  retailLocation: Location
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -265,59 +353,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -342,16 +442,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -425,16 +533,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -452,7 +568,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1695,9 +1813,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2507,7 +2624,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2516,43 +2636,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2562,27 +2690,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2592,22 +2725,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2645,13 +2786,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2662,12 +2807,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2708,21 +2853,22 @@ enum DeliveryMethod {
 }
 
 """
-The fetch target result. Refer to network access for Shopify Functions.
+The fetch target result. Your Function must return this data structure when generating the request.
 """
 input FunctionFetchResult {
   """
-  HTTP Request.
+  The attributes associated with an HTTP request.
   """
   request: HttpRequest
 }
 
 """
-The run target result.
+The output of the Function run target. The object contains the operations to
+generate pickup point delivery options at checkout.
 """
 input FunctionRunResult {
   """
-  An ordered list of operations to apply for pickup point delivery option generation.
+  An ordered list of operations to apply to generate pickup point delivery options.
   """
   operations: [Operation!]!
 }
@@ -2747,16 +2893,24 @@ type GateConfiguration implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2801,7 +2955,7 @@ interface HasGates {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 }
 
 """
@@ -2809,32 +2963,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2989,37 +3153,45 @@ scalar ID
 
 type Input {
   """
-  A list of allocations.
+  A list of one or more line items that are to be delivered to a specific address.
   """
   allocations: [Allocation!]! @deprecated(reason: "Use `deliveryAddress` instead.")
 
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The delivery address for pickup point delivery option.
+  The delivery address for the pickup point delivery option.
   """
   deliveryAddress: MailingAddress!
 
   """
-  The result of the fetch target. Refer to network access for Shopify Functions.
+  The fetch target result. Your Function must return this data structure when generating the request.
   """
   fetchResult: HttpResponse @restrictTarget(only: ["purchase.pickup-point-delivery-option-generator.run"])
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -3042,7 +3214,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3762,7 +3935,18 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+Local pickup settings associated with a location.
+"""
+type LocalPickup {
+  """
+  Whether local pickup is enabled for the location.
+  """
+  enabled: Boolean!
+}
+
+"""
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3842,23 +4026,29 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
   """
   The market of the active localized experience.
   """
-  market: Market!
+  market: Market! @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 }
 
 """
@@ -3889,189 +4079,307 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
+}
+
+"""
+Represents the location where the inventory resides.
+"""
+type Location implements HasMetafields {
+  """
+  The address of this location.
+  """
+  address: LocationAddress!
+
+  """
+  The location handle.
+  """
+  handle: Handle!
+
+  """
+  The location id.
+  """
+  id: ID!
+
+  """
+  Local pickup settings associated with a location.
+  """
+  localPickup: LocalPickup!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The name of the location.
+  """
+  name: String!
+}
+
+"""
+Represents the address of a location.
+"""
+type LocationAddress {
+  """
+  The first line of the address for the location.
+  """
+  address1: String
+
+  """
+  The second line of the address for the location.
+  """
+  address2: String
+
+  """
+  The city of the location.
+  """
+  city: String
+
+  """
+  The country of the location.
+  """
+  country: String
+
+  """
+  The country code of the location.
+  """
+  countryCode: String
+
+  """
+  A formatted version of the address for the location.
+  """
+  formatted: [String!]!
+
+  """
+  The approximate latitude coordinates of the location.
+  """
+  latitude: Float
+
+  """
+  The approximate longitude coordinates of the location.
+  """
+  longitude: Float
+
+  """
+  The phone number of the location.
+  """
+  phone: String
+
+  """
+  The province of the location.
+  """
+  province: String
+
+  """
+  The code for the province, state, or district of the address of the location.
+  """
+  provinceCode: String
+
+  """
+  The ZIP code of the location.
+  """
+  zip: String
 }
 
 """
@@ -4126,7 +4434,7 @@ type MailingAddress {
   """
   The market of the address.
   """
-  market: Market
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 
   """
   The full name of the customer, based on firstName and lastName.
@@ -4169,16 +4477,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4215,52 +4531,71 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields) enable you to attach additional information.
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 input MetafieldOutput {
   """
-  The key for the metafield.
+  The unique identifier for the metafield within its namespace. A metafield is composed of a
+  namespace and a key, in the format `namespace.key`.
   """
   key: String!
 
   """
-  The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+  A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+  between different apps or different parts of the same app. If omitted, then the
+  [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+  is used.
   """
   namespace: String
 
   """
-  The type of data that is stored in the metafield. Refer to the list of supported types.
+  The [type of data](https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types)
+  that's stored in the metafield.
   """
   type: String!
 
@@ -4271,16 +4606,19 @@ input MetafieldOutput {
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4311,7 +4649,7 @@ type MutationRoot {
 }
 
 """
-An operation to generate pickup point delivery options.
+An ordered list of operations to generate pickup point delivery options.
 """
 input Operation {
   """
@@ -4321,7 +4659,15 @@ input Operation {
 }
 
 """
-The pickup point delivery option address.
+Comprehensive geographic location information for a physical pickup point. [A pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points)
+is a location where customers can collect their online orders rather than having
+them delivered to their home or a to a [local pickup point](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store).
+Examples of pickup points include local post offices, convenience stores, and
+self-service lockers.
+
+This object stores both standard address fields and precise geolocation
+coordinates for generating pickup points and associated data, such as a
+location's distance from the customer.
 """
 input PickupAddress {
   """
@@ -4381,58 +4727,67 @@ input PickupAddress {
 }
 
 """
-A pickup point.
+A third-party location where customers can collect their orders, such as a local
+post office, convenience store, or self-service locker.
 """
 input PickupPoint {
   """
-  The pickup point address.
+  The address of the pickup point's location.
   """
   address: PickupAddress!
 
   """
-  The business hours of the pickup point location. Any day that is either not
-  mentioned or does not have any defined periods will be considered as closed.
+  A list of operating hours for the pickup point. A day that's omitted or
+  doesn't have defined time periods is considered to be closed.
   """
   businessHours: [BusinessHours!]
 
   """
-  The external id assigned by the provider for the pickup point delivery option.
+  The unique ID that the third-party service has assigned to the pickup point.
   """
   externalId: String!
 
   """
-  The name assigned by the provider for pickup point delivery option.
+  The name that the third-party service has assigned to the pickup point.
   """
   name: String!
 
   """
-  The pickup point delivery option provider.
+  The third-party service that manages pickup point delivery options.
   """
   provider: Provider!
 }
 
 """
-A pickup point delivery option.
+A pickup point delivery option, such as a local post office, convenience store, or self-service locker.
 """
 input PickupPointDeliveryOption {
   """
-  The cost of the delivery option in the currency of the cart. Defaults to the location pickup points settings price.
+  The delivery option's cost in the cart's currency. If not provided, then the
+  system uses the default price from the location's pickup points settings.
   """
   cost: Decimal
 
   """
-  The metafields associated with the delivery option.
+  The metafields associated with the pickup point delivery option.
   """
   metafields: [MetafieldOutput!] = []
 
   """
-  The pickup point.
+  The [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points) where customers can collect their online orders rather than having them
+  delivered to their home or to a [local pickup point](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store).
+  Examples of pickup points include local post offices, convenience stores, and
+  self-service lockers.
   """
   pickupPoint: PickupPoint!
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasGates & HasMetafields {
   """
@@ -4443,54 +4798,73 @@ type Product implements HasGates & HasMetafields {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4501,27 +4875,39 @@ type Product implements HasGates & HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4532,77 +4918,97 @@ type Product implements HasGates & HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-The provider for a pickup point.
+The third-party service that manages the pickup point delivery options.
 """
 input Provider {
   """
-  The provider logo url. The base URL must be `https://cdn.shopify.com`.
+  The URL logo for the third-party service that manages the pickup point
+  delivery options. The base URL must be `https://cdn.shopify.com`.
   """
   logoUrl: URL!
 
   """
-  The provider name.
+  The name of the third-party service that manages the pickup point delivery options.
   """
   name: String!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4636,16 +5042,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4705,25 +5119,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4751,7 +5175,7 @@ A void type that can be used to return a null value from a mutation.
 scalar Void
 
 """
-The weekday.
+The day of the week.
 """
 enum Weekday {
   """

--- a/order-routing/rust/fulfillment-constraints/default/schema.graphql
+++ b/order-routing/rust/fulfillment-constraints/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1739,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2550,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2562,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2616,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2651,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2712,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,12 +2733,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2672,37 +2783,55 @@ A customization which applies constraint rules to order routing and fulfillments
 """
 type FulfillmentConstraintRule implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
+In API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The fulfillment constraints determined by the function.
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
   """
   operations: [Operation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
 """
 input FunctionRunResult {
   """
-  The fulfillment constraints determined by the function.
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
   """
   operations: [Operation!]!
 }
@@ -2719,32 +2848,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2762,42 +2901,55 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The fulfillment constraint rule containing the function.
+  The backend logic that the Function uses to determine how to
+  [fulfill orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders). It includes the
+  [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   fulfillmentConstraintRule: FulfillmentConstraintRule!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  A list of all locations for the current shop.
+  A list of all geographical locations where the inventory is stored,
+  including warehouses, retail locations, and distribution centers.
   """
   locations(
     """
-    The list of location GIDs to search for.
+    A list of [globally-unique identifiers](https://shopify.dev/docs/api/usage/gids)
+    for the locations where inventory resides.
     """
     identifiers: [String!]
 
     """
-    The list of location names to search for.
+    A list of location names where the inventory resides.
     """
     names: [String!]
   ): [Location!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2820,7 +2972,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3540,7 +3693,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3620,16 +3774,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3667,187 +3827,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3872,16 +4032,24 @@ type Location implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4052,16 +4220,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4098,47 +4274,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4217,55 +4406,78 @@ input Operation @oneOf {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4276,27 +4488,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4307,62 +4531,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4396,16 +4639,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4465,25 +4716,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/order-routing/rust/local-pickup-delivery-option-generators/default/schema.graphql
+++ b/order-routing/rust/local-pickup-delivery-option-generators/default/schema.graphql
@@ -14,11 +14,17 @@ Scale the Functions resource limits based on the field's length.
 directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
-type Cart {
+type Cart implements HasMetafields {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -106,116 +133,171 @@ type Cart {
     """
     keys: [LocalizedFieldKey!]! = []
   ): [LocalizedField!]!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The physical location where a retail order is created or completed.
+  """
+  retailLocation: Location
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +307,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +396,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +487,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +522,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1767,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2578,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2590,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2644,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2679,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2740,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,12 +2761,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2672,16 +2811,24 @@ A customization representing how delivery options are generated.
 """
 type DeliveryOptionGenerator implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2723,21 +2870,29 @@ type FulfillmentGroup {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to generate local pickup options in checkout.
+In API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The ordered list of operations to apply for local pickup delivery option generation.
+  The ordered list of operations to apply when generating
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store)
+  options.
   """
   operations: [Operation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to generate local pickup options in checkout.
 """
 input FunctionRunResult {
   """
-  The ordered list of operations to apply for local pickup delivery option generation.
+  The ordered list of operations to apply when generating
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store)
+  options.
   """
   operations: [Operation!]!
 }
@@ -2762,16 +2917,24 @@ type GateConfiguration implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2816,7 +2979,7 @@ interface HasGates {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 }
 
 """
@@ -2824,32 +2987,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2864,37 +3037,53 @@ scalar ID
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The delivery option generator that owns the current function.
+  The backend logic that the Function uses to generate
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store)
+  options. It includes the [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   deliveryOptionGenerator: DeliveryOptionGenerator!
 
   """
-  A list of fulfillment groups.
+  A list of
+  [fulfillment locations](https://shopify.dev/manual/fulfillment/setup/shipping-profiles/managing-fulfillment-locations)
+  that contain one or more items to be shipped together. Each item in the cart is assigned to one
+  fulfillment group.
   """
   fulfillmentGroups: [FulfillmentGroup!]!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The locations that can fulfill the items in the cart or that offer local pickup.
+  A list of all geographical locations where the inventory is stored,
+  including warehouses, retail locations, and distribution centers.
+  The list captures the locations that can fulfill items in the cart or that offer local pickup.
   """
   locations: [Location!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2917,7 +3106,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3672,7 +3862,8 @@ input LocalPickupDeliveryOption {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3752,23 +3943,29 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
   """
   The market of the active localized experience.
   """
-  market: Market!
+  market: Market! @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 }
 
 """
@@ -3799,187 +3996,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -4009,16 +4206,24 @@ type Location implements HasMetafields {
   localPickup: LocalPickup!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4146,7 +4351,7 @@ type MailingAddress {
   """
   The market of the address.
   """
-  market: Market
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 
   """
   The full name of the customer, based on firstName and lastName.
@@ -4189,16 +4394,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4235,52 +4448,71 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields) enable you to attach additional information.
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 input MetafieldOutput {
   """
-  The key for the metafield.
+  The unique identifier for the metafield within its namespace. A metafield is composed of a
+  namespace and a key, in the format `namespace.key`.
   """
   key: String!
 
   """
-  The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+  A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+  between different apps or different parts of the same app. If omitted, then the
+  [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+  is used.
   """
   namespace: String
 
   """
-  The type of data that is stored in the metafield. Refer to the list of supported types.
+  The [type of data](https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types)
+  that's stored in the metafield.
   """
   type: String!
 
@@ -4291,16 +4523,19 @@ input MetafieldOutput {
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4354,7 +4589,11 @@ input PickupLocation {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasGates & HasMetafields {
   """
@@ -4365,54 +4604,73 @@ type Product implements HasGates & HasMetafields {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4423,27 +4681,39 @@ type Product implements HasGates & HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4454,62 +4724,81 @@ type Product implements HasGates & HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4543,16 +4832,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4612,25 +4909,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/order-routing/rust/location-rules/default/schema.graphql
+++ b/order-routing/rust/location-rules/default/schema.graphql
@@ -9,11 +9,17 @@ Scale the Functions resource limits based on the field's length.
 directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -24,76 +30,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -104,113 +131,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -220,59 +274,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -297,16 +363,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -380,16 +454,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -407,7 +489,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1650,9 +1734,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2462,7 +2545,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2471,43 +2557,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2517,27 +2611,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2547,22 +2646,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2600,13 +2707,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2617,12 +2728,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2713,21 +2824,29 @@ input FulfillmentGroupRankedLocations {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations that rank locations for each fulfillment
+group. In API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The ranked locations for each fulfillment group.
+  The ordered list of operations that rank locations for each fulfillment group,
+  which includes one or more items to be shipped together.
+  The locations with the highest ranking are selected to fulfill the order.
   """
   operations: [Operation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations that rank locations for each fulfillment group.
 """
 input FunctionRunResult {
   """
-  The ranked locations for each fulfillment group.
+  The ordered list of operations that rank locations for each fulfillment group,
+  which includes one or more items to be shipped together.
+  The locations with the highest ranking are selected to fulfill the order.
   """
   operations: [Operation!]!
 }
@@ -2744,32 +2863,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2787,37 +2916,53 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  List of fulfillment groups in the context of this cart.
+  A list of
+  [fulfillment locations](https://shopify.dev/manual/fulfillment/setup/shipping-profiles/managing-fulfillment-locations)
+  that contain one or more items to be shipped together. Each item in the cart is assigned to one
+  fulfillment group.
   """
   fulfillmentGroups: [FulfillmentGroup!]!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The order routing location rule containing the function.
+  The backend logic that the Function uses to
+  [route orders](https://shopify.dev/manual/fulfillment/setup/order-routing/understanding-order-routing).
+  It includes the [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   locationRule: OrderRoutingLocationRule!
 
   """
-  The locations where the inventory items on this cart are stocked.
+  A list of all geographical locations where the inventory is stored,
+  including warehouses, retail locations, and distribution centers.
+  The list captures the locations that can fulfill items in the cart.
   """
   locations: [Location!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2840,7 +2985,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3560,7 +3706,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3640,16 +3787,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3687,187 +3840,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3892,16 +4045,24 @@ type Location implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4072,16 +4233,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4118,47 +4287,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4193,7 +4375,8 @@ An operation to apply to the fulfillment group inventory locations.
 """
 input Operation {
   """
-  Request to rank a fulfillment group's inventory locations.
+  A request to rank the locations associated with a fulfillment group.
+  The ranking determines the priority in which the locations are selected to fulfill the order.
   """
   rank: FulfillmentGroupRankedLocations!
 }
@@ -4203,71 +4386,102 @@ A customization which ranks inventory locations for fulfillment purposes.
 """
 type OrderRoutingLocationRule implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4278,27 +4492,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4309,62 +4535,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4413,16 +4658,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4482,25 +4735,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/schema.graphql
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/schema.graphql
@@ -24,11 +24,17 @@ type Allocation {
 }
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -39,7 +45,7 @@ type Attribute {
 }
 
 """
-The business hours for a pickup point.
+The pickup point's hours of operation for a specific day of the week.
 """
 input BusinessHours {
   """
@@ -48,97 +54,124 @@ input BusinessHours {
   day: Weekday!
 
   """
-  The business hours periods.
+  The operating time periods for a specific day. To represent split schedules
+  (for example, 9:00-12:00 and 13:00-17:00 for locations that close during
+  lunch), you can specify multiple periods.
+
+  Each period consists of `opening_time` and `closing_time`. To indicate the
+  location is closed on a specific day, such as Sunday, then omit it entirely
+  from the `business_hours` array.
   """
   periods: [BusinessHoursPeriod!]!
 }
 
 """
-The business hours period.
+The pickup point's hours of operation for a specific day of the week.
 """
 input BusinessHoursPeriod {
   """
-  The closing time.
+  The time that the pickup point location closes.
   """
   closingTime: TimeWithoutTimezone!
 
   """
-  The opening time.
+  The time that the pickup point location opens.
   """
   openingTime: TimeWithoutTimezone!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
-type Cart {
+type Cart implements HasMetafields {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -146,116 +179,171 @@ type Cart {
     """
     keys: [LocalizedFieldKey!]! = []
   ): [LocalizedField!]!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The physical location where a retail order is created or completed.
+  """
+  retailLocation: Location
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -265,59 +353,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -342,16 +442,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -425,16 +533,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -452,7 +568,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1695,9 +1813,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2507,7 +2624,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2516,43 +2636,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2562,27 +2690,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2592,22 +2725,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2645,13 +2786,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2662,12 +2807,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2708,21 +2853,22 @@ enum DeliveryMethod {
 }
 
 """
-The fetch target result. Refer to network access for Shopify Functions.
+The fetch target result. Your Function must return this data structure when generating the request.
 """
 input FunctionFetchResult {
   """
-  HTTP Request.
+  The attributes associated with an HTTP request.
   """
   request: HttpRequest
 }
 
 """
-The run target result.
+The output of the Function run target. The object contains the operations to
+generate pickup point delivery options at checkout.
 """
 input FunctionRunResult {
   """
-  An ordered list of operations to apply for pickup point delivery option generation.
+  An ordered list of operations to apply to generate pickup point delivery options.
   """
   operations: [Operation!]!
 }
@@ -2747,16 +2893,24 @@ type GateConfiguration implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2801,7 +2955,7 @@ interface HasGates {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 }
 
 """
@@ -2809,32 +2963,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2989,37 +3153,45 @@ scalar ID
 
 type Input {
   """
-  A list of allocations.
+  A list of one or more line items that are to be delivered to a specific address.
   """
   allocations: [Allocation!]! @deprecated(reason: "Use `deliveryAddress` instead.")
 
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The delivery address for pickup point delivery option.
+  The delivery address for the pickup point delivery option.
   """
   deliveryAddress: MailingAddress!
 
   """
-  The result of the fetch target. Refer to network access for Shopify Functions.
+  The fetch target result. Your Function must return this data structure when generating the request.
   """
   fetchResult: HttpResponse @restrictTarget(only: ["purchase.pickup-point-delivery-option-generator.run"])
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -3042,7 +3214,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3762,7 +3935,18 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+Local pickup settings associated with a location.
+"""
+type LocalPickup {
+  """
+  Whether local pickup is enabled for the location.
+  """
+  enabled: Boolean!
+}
+
+"""
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3842,23 +4026,29 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
   """
   The market of the active localized experience.
   """
-  market: Market!
+  market: Market! @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 }
 
 """
@@ -3889,189 +4079,307 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
+}
+
+"""
+Represents the location where the inventory resides.
+"""
+type Location implements HasMetafields {
+  """
+  The address of this location.
+  """
+  address: LocationAddress!
+
+  """
+  The location handle.
+  """
+  handle: Handle!
+
+  """
+  The location id.
+  """
+  id: ID!
+
+  """
+  Local pickup settings associated with a location.
+  """
+  localPickup: LocalPickup!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The name of the location.
+  """
+  name: String!
+}
+
+"""
+Represents the address of a location.
+"""
+type LocationAddress {
+  """
+  The first line of the address for the location.
+  """
+  address1: String
+
+  """
+  The second line of the address for the location.
+  """
+  address2: String
+
+  """
+  The city of the location.
+  """
+  city: String
+
+  """
+  The country of the location.
+  """
+  country: String
+
+  """
+  The country code of the location.
+  """
+  countryCode: String
+
+  """
+  A formatted version of the address for the location.
+  """
+  formatted: [String!]!
+
+  """
+  The approximate latitude coordinates of the location.
+  """
+  latitude: Float
+
+  """
+  The approximate longitude coordinates of the location.
+  """
+  longitude: Float
+
+  """
+  The phone number of the location.
+  """
+  phone: String
+
+  """
+  The province of the location.
+  """
+  province: String
+
+  """
+  The code for the province, state, or district of the address of the location.
+  """
+  provinceCode: String
+
+  """
+  The ZIP code of the location.
+  """
+  zip: String
 }
 
 """
@@ -4126,7 +4434,7 @@ type MailingAddress {
   """
   The market of the address.
   """
-  market: Market
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 
   """
   The full name of the customer, based on firstName and lastName.
@@ -4169,16 +4477,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4215,52 +4531,71 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields) enable you to attach additional information.
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 input MetafieldOutput {
   """
-  The key for the metafield.
+  The unique identifier for the metafield within its namespace. A metafield is composed of a
+  namespace and a key, in the format `namespace.key`.
   """
   key: String!
 
   """
-  The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+  A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+  between different apps or different parts of the same app. If omitted, then the
+  [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+  is used.
   """
   namespace: String
 
   """
-  The type of data that is stored in the metafield. Refer to the list of supported types.
+  The [type of data](https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types)
+  that's stored in the metafield.
   """
   type: String!
 
@@ -4271,16 +4606,19 @@ input MetafieldOutput {
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4311,7 +4649,7 @@ type MutationRoot {
 }
 
 """
-An operation to generate pickup point delivery options.
+An ordered list of operations to generate pickup point delivery options.
 """
 input Operation {
   """
@@ -4321,7 +4659,15 @@ input Operation {
 }
 
 """
-The pickup point delivery option address.
+Comprehensive geographic location information for a physical pickup point. [A pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points)
+is a location where customers can collect their online orders rather than having
+them delivered to their home or a to a [local pickup point](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store).
+Examples of pickup points include local post offices, convenience stores, and
+self-service lockers.
+
+This object stores both standard address fields and precise geolocation
+coordinates for generating pickup points and associated data, such as a
+location's distance from the customer.
 """
 input PickupAddress {
   """
@@ -4381,58 +4727,67 @@ input PickupAddress {
 }
 
 """
-A pickup point.
+A third-party location where customers can collect their orders, such as a local
+post office, convenience store, or self-service locker.
 """
 input PickupPoint {
   """
-  The pickup point address.
+  The address of the pickup point's location.
   """
   address: PickupAddress!
 
   """
-  The business hours of the pickup point location. Any day that is either not
-  mentioned or does not have any defined periods will be considered as closed.
+  A list of operating hours for the pickup point. A day that's omitted or
+  doesn't have defined time periods is considered to be closed.
   """
   businessHours: [BusinessHours!]
 
   """
-  The external id assigned by the provider for the pickup point delivery option.
+  The unique ID that the third-party service has assigned to the pickup point.
   """
   externalId: String!
 
   """
-  The name assigned by the provider for pickup point delivery option.
+  The name that the third-party service has assigned to the pickup point.
   """
   name: String!
 
   """
-  The pickup point delivery option provider.
+  The third-party service that manages pickup point delivery options.
   """
   provider: Provider!
 }
 
 """
-A pickup point delivery option.
+A pickup point delivery option, such as a local post office, convenience store, or self-service locker.
 """
 input PickupPointDeliveryOption {
   """
-  The cost of the delivery option in the currency of the cart. Defaults to the location pickup points settings price.
+  The delivery option's cost in the cart's currency. If not provided, then the
+  system uses the default price from the location's pickup points settings.
   """
   cost: Decimal
 
   """
-  The metafields associated with the delivery option.
+  The metafields associated with the pickup point delivery option.
   """
   metafields: [MetafieldOutput!] = []
 
   """
-  The pickup point.
+  The [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points) where customers can collect their online orders rather than having them
+  delivered to their home or to a [local pickup point](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store).
+  Examples of pickup points include local post offices, convenience stores, and
+  self-service lockers.
   """
   pickupPoint: PickupPoint!
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasGates & HasMetafields {
   """
@@ -4443,54 +4798,73 @@ type Product implements HasGates & HasMetafields {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4501,27 +4875,39 @@ type Product implements HasGates & HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4532,77 +4918,97 @@ type Product implements HasGates & HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-The provider for a pickup point.
+The third-party service that manages the pickup point delivery options.
 """
 input Provider {
   """
-  The provider logo url. The base URL must be `https://cdn.shopify.com`.
+  The URL logo for the third-party service that manages the pickup point
+  delivery options. The base URL must be `https://cdn.shopify.com`.
   """
   logoUrl: URL!
 
   """
-  The provider name.
+  The name of the third-party service that manages the pickup point delivery options.
   """
   name: String!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4636,16 +5042,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4705,25 +5119,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4751,7 +5175,7 @@ A void type that can be used to return a null value from a mutation.
 scalar Void
 
 """
-The weekday.
+The day of the week.
 """
 enum Weekday {
   """

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/schema.graphql
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/schema.graphql
@@ -24,11 +24,17 @@ type Allocation {
 }
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -39,7 +45,7 @@ type Attribute {
 }
 
 """
-The business hours for a pickup point.
+The pickup point's hours of operation for a specific day of the week.
 """
 input BusinessHours {
   """
@@ -48,97 +54,124 @@ input BusinessHours {
   day: Weekday!
 
   """
-  The business hours periods.
+  The operating time periods for a specific day. To represent split schedules
+  (for example, 9:00-12:00 and 13:00-17:00 for locations that close during
+  lunch), you can specify multiple periods.
+
+  Each period consists of `opening_time` and `closing_time`. To indicate the
+  location is closed on a specific day, such as Sunday, then omit it entirely
+  from the `business_hours` array.
   """
   periods: [BusinessHoursPeriod!]!
 }
 
 """
-The business hours period.
+The pickup point's hours of operation for a specific day of the week.
 """
 input BusinessHoursPeriod {
   """
-  The closing time.
+  The time that the pickup point location closes.
   """
   closingTime: TimeWithoutTimezone!
 
   """
-  The opening time.
+  The time that the pickup point location opens.
   """
   openingTime: TimeWithoutTimezone!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
-type Cart {
+type Cart implements HasMetafields {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -146,116 +179,171 @@ type Cart {
     """
     keys: [LocalizedFieldKey!]! = []
   ): [LocalizedField!]!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The physical location where a retail order is created or completed.
+  """
+  retailLocation: Location
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -265,59 +353,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -342,16 +442,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -425,16 +533,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -452,7 +568,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1695,9 +1813,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2507,7 +2624,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2516,43 +2636,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2562,27 +2690,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2592,22 +2725,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2645,13 +2786,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2662,12 +2807,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2708,21 +2853,22 @@ enum DeliveryMethod {
 }
 
 """
-The fetch target result. Refer to network access for Shopify Functions.
+The fetch target result. Your Function must return this data structure when generating the request.
 """
 input FunctionFetchResult {
   """
-  HTTP Request.
+  The attributes associated with an HTTP request.
   """
   request: HttpRequest
 }
 
 """
-The run target result.
+The output of the Function run target. The object contains the operations to
+generate pickup point delivery options at checkout.
 """
 input FunctionRunResult {
   """
-  An ordered list of operations to apply for pickup point delivery option generation.
+  An ordered list of operations to apply to generate pickup point delivery options.
   """
   operations: [Operation!]!
 }
@@ -2747,16 +2893,24 @@ type GateConfiguration implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2801,7 +2955,7 @@ interface HasGates {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 }
 
 """
@@ -2809,32 +2963,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2989,37 +3153,45 @@ scalar ID
 
 type Input {
   """
-  A list of allocations.
+  A list of one or more line items that are to be delivered to a specific address.
   """
   allocations: [Allocation!]! @deprecated(reason: "Use `deliveryAddress` instead.")
 
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The delivery address for pickup point delivery option.
+  The delivery address for the pickup point delivery option.
   """
   deliveryAddress: MailingAddress!
 
   """
-  The result of the fetch target. Refer to network access for Shopify Functions.
+  The fetch target result. Your Function must return this data structure when generating the request.
   """
   fetchResult: HttpResponse @restrictTarget(only: ["purchase.pickup-point-delivery-option-generator.run"])
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -3042,7 +3214,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3762,7 +3935,18 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+Local pickup settings associated with a location.
+"""
+type LocalPickup {
+  """
+  Whether local pickup is enabled for the location.
+  """
+  enabled: Boolean!
+}
+
+"""
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3842,23 +4026,29 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
   """
   The market of the active localized experience.
   """
-  market: Market!
+  market: Market! @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 }
 
 """
@@ -3889,189 +4079,307 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
+}
+
+"""
+Represents the location where the inventory resides.
+"""
+type Location implements HasMetafields {
+  """
+  The address of this location.
+  """
+  address: LocationAddress!
+
+  """
+  The location handle.
+  """
+  handle: Handle!
+
+  """
+  The location id.
+  """
+  id: ID!
+
+  """
+  Local pickup settings associated with a location.
+  """
+  localPickup: LocalPickup!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The name of the location.
+  """
+  name: String!
+}
+
+"""
+Represents the address of a location.
+"""
+type LocationAddress {
+  """
+  The first line of the address for the location.
+  """
+  address1: String
+
+  """
+  The second line of the address for the location.
+  """
+  address2: String
+
+  """
+  The city of the location.
+  """
+  city: String
+
+  """
+  The country of the location.
+  """
+  country: String
+
+  """
+  The country code of the location.
+  """
+  countryCode: String
+
+  """
+  A formatted version of the address for the location.
+  """
+  formatted: [String!]!
+
+  """
+  The approximate latitude coordinates of the location.
+  """
+  latitude: Float
+
+  """
+  The approximate longitude coordinates of the location.
+  """
+  longitude: Float
+
+  """
+  The phone number of the location.
+  """
+  phone: String
+
+  """
+  The province of the location.
+  """
+  province: String
+
+  """
+  The code for the province, state, or district of the address of the location.
+  """
+  provinceCode: String
+
+  """
+  The ZIP code of the location.
+  """
+  zip: String
 }
 
 """
@@ -4126,7 +4434,7 @@ type MailingAddress {
   """
   The market of the address.
   """
-  market: Market
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 
   """
   The full name of the customer, based on firstName and lastName.
@@ -4169,16 +4477,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4215,52 +4531,71 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields) enable you to attach additional information.
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 input MetafieldOutput {
   """
-  The key for the metafield.
+  The unique identifier for the metafield within its namespace. A metafield is composed of a
+  namespace and a key, in the format `namespace.key`.
   """
   key: String!
 
   """
-  The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+  A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+  between different apps or different parts of the same app. If omitted, then the
+  [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+  is used.
   """
   namespace: String
 
   """
-  The type of data that is stored in the metafield. Refer to the list of supported types.
+  The [type of data](https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types)
+  that's stored in the metafield.
   """
   type: String!
 
@@ -4271,16 +4606,19 @@ input MetafieldOutput {
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4311,7 +4649,7 @@ type MutationRoot {
 }
 
 """
-An operation to generate pickup point delivery options.
+An ordered list of operations to generate pickup point delivery options.
 """
 input Operation {
   """
@@ -4321,7 +4659,15 @@ input Operation {
 }
 
 """
-The pickup point delivery option address.
+Comprehensive geographic location information for a physical pickup point. [A pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points)
+is a location where customers can collect their online orders rather than having
+them delivered to their home or a to a [local pickup point](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store).
+Examples of pickup points include local post offices, convenience stores, and
+self-service lockers.
+
+This object stores both standard address fields and precise geolocation
+coordinates for generating pickup points and associated data, such as a
+location's distance from the customer.
 """
 input PickupAddress {
   """
@@ -4381,58 +4727,67 @@ input PickupAddress {
 }
 
 """
-A pickup point.
+A third-party location where customers can collect their orders, such as a local
+post office, convenience store, or self-service locker.
 """
 input PickupPoint {
   """
-  The pickup point address.
+  The address of the pickup point's location.
   """
   address: PickupAddress!
 
   """
-  The business hours of the pickup point location. Any day that is either not
-  mentioned or does not have any defined periods will be considered as closed.
+  A list of operating hours for the pickup point. A day that's omitted or
+  doesn't have defined time periods is considered to be closed.
   """
   businessHours: [BusinessHours!]
 
   """
-  The external id assigned by the provider for the pickup point delivery option.
+  The unique ID that the third-party service has assigned to the pickup point.
   """
   externalId: String!
 
   """
-  The name assigned by the provider for pickup point delivery option.
+  The name that the third-party service has assigned to the pickup point.
   """
   name: String!
 
   """
-  The pickup point delivery option provider.
+  The third-party service that manages pickup point delivery options.
   """
   provider: Provider!
 }
 
 """
-A pickup point delivery option.
+A pickup point delivery option, such as a local post office, convenience store, or self-service locker.
 """
 input PickupPointDeliveryOption {
   """
-  The cost of the delivery option in the currency of the cart. Defaults to the location pickup points settings price.
+  The delivery option's cost in the cart's currency. If not provided, then the
+  system uses the default price from the location's pickup points settings.
   """
   cost: Decimal
 
   """
-  The metafields associated with the delivery option.
+  The metafields associated with the pickup point delivery option.
   """
   metafields: [MetafieldOutput!] = []
 
   """
-  The pickup point.
+  The [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points) where customers can collect their online orders rather than having them
+  delivered to their home or to a [local pickup point](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store).
+  Examples of pickup points include local post offices, convenience stores, and
+  self-service lockers.
   """
   pickupPoint: PickupPoint!
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasGates & HasMetafields {
   """
@@ -4443,54 +4798,73 @@ type Product implements HasGates & HasMetafields {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4501,27 +4875,39 @@ type Product implements HasGates & HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4532,77 +4918,97 @@ type Product implements HasGates & HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-The provider for a pickup point.
+The third-party service that manages the pickup point delivery options.
 """
 input Provider {
   """
-  The provider logo url. The base URL must be `https://cdn.shopify.com`.
+  The URL logo for the third-party service that manages the pickup point
+  delivery options. The base URL must be `https://cdn.shopify.com`.
   """
   logoUrl: URL!
 
   """
-  The provider name.
+  The name of the third-party service that manages the pickup point delivery options.
   """
   name: String!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4636,16 +5042,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4705,25 +5119,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4751,7 +5175,7 @@ A void type that can be used to return a null value from a mutation.
 scalar Void
 
 """
-The weekday.
+The day of the week.
 """
 enum Weekday {
   """

--- a/order-routing/wasm/fulfillment-constraints/default/schema.graphql
+++ b/order-routing/wasm/fulfillment-constraints/default/schema.graphql
@@ -14,11 +14,17 @@ Requires that exactly one field must be supplied and that field must not be `nul
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -109,113 +136,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +279,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +368,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +459,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +494,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1739,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2550,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2562,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2616,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2651,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2712,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,12 +2733,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2672,37 +2783,55 @@ A customization which applies constraint rules to order routing and fulfillments
 """
 type FulfillmentConstraintRule implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
+In API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The fulfillment constraints determined by the function.
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
   """
   operations: [Operation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to apply constraints for fulfilling orders.
 """
 input FunctionRunResult {
   """
-  The fulfillment constraints determined by the function.
+  The ordered list of operations to apply when
+  [fulfilling orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders).
+  You can either specify a list of locations where cart items can be fulfilled from,
+  or specify that cart items must be fulfilled from the same location.
   """
   operations: [Operation!]!
 }
@@ -2719,32 +2848,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2762,42 +2901,55 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The fulfillment constraint rule containing the function.
+  The backend logic that the Function uses to determine how to
+  [fulfill orders](https://help.shopify.com/manual/fulfillment/fulfilling-orders). It includes the
+  [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   fulfillmentConstraintRule: FulfillmentConstraintRule!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  A list of all locations for the current shop.
+  A list of all geographical locations where the inventory is stored,
+  including warehouses, retail locations, and distribution centers.
   """
   locations(
     """
-    The list of location GIDs to search for.
+    A list of [globally-unique identifiers](https://shopify.dev/docs/api/usage/gids)
+    for the locations where inventory resides.
     """
     identifiers: [String!]
 
     """
-    The list of location names to search for.
+    A list of location names where the inventory resides.
     """
     names: [String!]
   ): [Location!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2820,7 +2972,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3540,7 +3693,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3620,16 +3774,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3667,187 +3827,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3872,16 +4032,24 @@ type Location implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4052,16 +4220,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4098,47 +4274,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4217,55 +4406,78 @@ input Operation @oneOf {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4276,27 +4488,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4307,62 +4531,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4396,16 +4639,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4465,25 +4716,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/order-routing/wasm/local-pickup-delivery-option-generators/default/schema.graphql
+++ b/order-routing/wasm/local-pickup-delivery-option-generators/default/schema.graphql
@@ -14,11 +14,17 @@ Scale the Functions resource limits based on the field's length.
 directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -29,76 +35,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
-type Cart {
+type Cart implements HasMetafields {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -106,116 +133,171 @@ type Cart {
     """
     keys: [LocalizedFieldKey!]! = []
   ): [LocalizedField!]!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The physical location where a retail order is created or completed.
+  """
+  retailLocation: Location
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -225,59 +307,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -302,16 +396,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -385,16 +487,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -412,7 +522,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1655,9 +1767,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2467,7 +2578,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2476,43 +2590,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2522,27 +2644,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2552,22 +2679,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2605,13 +2740,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2622,12 +2761,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2672,16 +2811,24 @@ A customization representing how delivery options are generated.
 """
 type DeliveryOptionGenerator implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2723,21 +2870,29 @@ type FulfillmentGroup {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to generate local pickup options in checkout.
+In API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The ordered list of operations to apply for local pickup delivery option generation.
+  The ordered list of operations to apply when generating
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store)
+  options.
   """
   operations: [Operation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to generate local pickup options in checkout.
 """
 input FunctionRunResult {
   """
-  The ordered list of operations to apply for local pickup delivery option generation.
+  The ordered list of operations to apply when generating
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store)
+  options.
   """
   operations: [Operation!]!
 }
@@ -2762,16 +2917,24 @@ type GateConfiguration implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2816,7 +2979,7 @@ interface HasGates {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 }
 
 """
@@ -2824,32 +2987,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2864,37 +3037,53 @@ scalar ID
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The delivery option generator that owns the current function.
+  The backend logic that the Function uses to generate
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store)
+  options. It includes the [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   deliveryOptionGenerator: DeliveryOptionGenerator!
 
   """
-  A list of fulfillment groups.
+  A list of
+  [fulfillment locations](https://shopify.dev/manual/fulfillment/setup/shipping-profiles/managing-fulfillment-locations)
+  that contain one or more items to be shipped together. Each item in the cart is assigned to one
+  fulfillment group.
   """
   fulfillmentGroups: [FulfillmentGroup!]!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The locations that can fulfill the items in the cart or that offer local pickup.
+  A list of all geographical locations where the inventory is stored,
+  including warehouses, retail locations, and distribution centers.
+  The list captures the locations that can fulfill items in the cart or that offer local pickup.
   """
   locations: [Location!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2917,7 +3106,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3672,7 +3862,8 @@ input LocalPickupDeliveryOption {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3752,23 +3943,29 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
   """
   The market of the active localized experience.
   """
-  market: Market!
+  market: Market! @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 }
 
 """
@@ -3799,187 +3996,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -4009,16 +4206,24 @@ type Location implements HasMetafields {
   localPickup: LocalPickup!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4146,7 +4351,7 @@ type MailingAddress {
   """
   The market of the address.
   """
-  market: Market
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 
   """
   The full name of the customer, based on firstName and lastName.
@@ -4189,16 +4394,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4235,52 +4448,71 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields) enable you to attach additional information.
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 input MetafieldOutput {
   """
-  The key for the metafield.
+  The unique identifier for the metafield within its namespace. A metafield is composed of a
+  namespace and a key, in the format `namespace.key`.
   """
   key: String!
 
   """
-  The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+  A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+  between different apps or different parts of the same app. If omitted, then the
+  [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+  is used.
   """
   namespace: String
 
   """
-  The type of data that is stored in the metafield. Refer to the list of supported types.
+  The [type of data](https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types)
+  that's stored in the metafield.
   """
   type: String!
 
@@ -4291,16 +4523,19 @@ input MetafieldOutput {
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4354,7 +4589,11 @@ input PickupLocation {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasGates & HasMetafields {
   """
@@ -4365,54 +4604,73 @@ type Product implements HasGates & HasMetafields {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4423,27 +4681,39 @@ type Product implements HasGates & HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4454,62 +4724,81 @@ type Product implements HasGates & HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4543,16 +4832,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4612,25 +4909,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/order-routing/wasm/location-rules/default/schema.graphql
+++ b/order-routing/wasm/location-rules/default/schema.graphql
@@ -9,11 +9,17 @@ Scale the Functions resource limits based on the field's length.
 directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -24,76 +30,97 @@ type Attribute {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -104,113 +131,140 @@ type Cart {
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -220,59 +274,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -297,16 +363,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -380,16 +454,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -407,7 +489,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1650,9 +1734,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2462,7 +2545,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2471,43 +2557,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2517,27 +2611,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2547,22 +2646,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2600,13 +2707,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2617,12 +2728,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2713,21 +2824,29 @@ input FulfillmentGroupRankedLocations {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations that rank locations for each fulfillment
+group. In API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The ranked locations for each fulfillment group.
+  The ordered list of operations that rank locations for each fulfillment group,
+  which includes one or more items to be shipped together.
+  The locations with the highest ranking are selected to fulfill the order.
   """
   operations: [Operation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations that rank locations for each fulfillment group.
 """
 input FunctionRunResult {
   """
-  The ranked locations for each fulfillment group.
+  The ordered list of operations that rank locations for each fulfillment group,
+  which includes one or more items to be shipped together.
+  The locations with the highest ranking are selected to fulfill the order.
   """
   operations: [Operation!]!
 }
@@ -2744,32 +2863,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2787,37 +2916,53 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  List of fulfillment groups in the context of this cart.
+  A list of
+  [fulfillment locations](https://shopify.dev/manual/fulfillment/setup/shipping-profiles/managing-fulfillment-locations)
+  that contain one or more items to be shipped together. Each item in the cart is assigned to one
+  fulfillment group.
   """
   fulfillmentGroups: [FulfillmentGroup!]!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The order routing location rule containing the function.
+  The backend logic that the Function uses to
+  [route orders](https://shopify.dev/manual/fulfillment/setup/order-routing/understanding-order-routing).
+  It includes the [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   locationRule: OrderRoutingLocationRule!
 
   """
-  The locations where the inventory items on this cart are stocked.
+  A list of all geographical locations where the inventory is stored,
+  including warehouses, retail locations, and distribution centers.
+  The list captures the locations that can fulfill items in the cart.
   """
   locations: [Location!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -2840,7 +2985,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3560,7 +3706,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3640,16 +3787,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3687,187 +3840,187 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
 }
@@ -3892,16 +4045,24 @@ type Location implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4072,16 +4233,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4118,47 +4287,60 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4193,7 +4375,8 @@ An operation to apply to the fulfillment group inventory locations.
 """
 input Operation {
   """
-  Request to rank a fulfillment group's inventory locations.
+  A request to rank the locations associated with a fulfillment group.
+  The ranking determines the priority in which the locations are selected to fulfill the order.
   """
   rank: FulfillmentGroupRankedLocations!
 }
@@ -4203,71 +4386,102 @@ A customization which ranks inventory locations for fulfillment purposes.
 """
 type OrderRoutingLocationRule implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4278,27 +4492,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4309,62 +4535,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4413,16 +4658,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4482,25 +4735,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/order-routing/wasm/pickup-point-delivery-option-generators/default/schema.graphql
+++ b/order-routing/wasm/pickup-point-delivery-option-generators/default/schema.graphql
@@ -24,11 +24,17 @@ type Allocation {
 }
 
 """
-Represents a generic custom attribute, such as whether an order is a customer's first.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  The key or name of the attribute. For example, `"customersFirstOrder"`.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
@@ -39,7 +45,7 @@ type Attribute {
 }
 
 """
-The business hours for a pickup point.
+The pickup point's hours of operation for a specific day of the week.
 """
 input BusinessHours {
   """
@@ -48,97 +54,124 @@ input BusinessHours {
   day: Weekday!
 
   """
-  The business hours periods.
+  The operating time periods for a specific day. To represent split schedules
+  (for example, 9:00-12:00 and 13:00-17:00 for locations that close during
+  lunch), you can specify multiple periods.
+
+  Each period consists of `opening_time` and `closing_time`. To indicate the
+  location is closed on a specific day, such as Sunday, then omit it entirely
+  from the `business_hours` array.
   """
   periods: [BusinessHoursPeriod!]!
 }
 
 """
-The business hours period.
+The pickup point's hours of operation for a specific day of the week.
 """
 input BusinessHoursPeriod {
   """
-  The closing time.
+  The time that the pickup point location closes.
   """
   closingTime: TimeWithoutTimezone!
 
   """
-  The opening time.
+  The time that the pickup point location opens.
   """
   openingTime: TimeWithoutTimezone!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
-type Cart {
+type Cart implements HasMetafields {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The localized fields available for the cart.
+  The additional fields on the **Cart** page that are required for international orders in specific countries,
+  such as customs information or tax identification numbers.
   """
   localizedFields(
     """
@@ -146,116 +179,171 @@ type Cart {
     """
     keys: [LocalizedFieldKey!]! = []
   ): [LocalizedField!]!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The physical location where a retail order is created or completed.
+  """
+  retailLocation: Location
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -265,59 +353,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line. This value varies depending on
-  the buyer's identity, and is null when the value is hidden to buyers.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -342,16 +442,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -425,16 +533,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -452,7 +568,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1695,9 +1813,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2507,7 +2624,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2516,43 +2636,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2562,27 +2690,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2592,22 +2725,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2645,13 +2786,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2662,12 +2807,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2708,21 +2853,22 @@ enum DeliveryMethod {
 }
 
 """
-The fetch target result. Refer to network access for Shopify Functions.
+The fetch target result. Your Function must return this data structure when generating the request.
 """
 input FunctionFetchResult {
   """
-  HTTP Request.
+  The attributes associated with an HTTP request.
   """
   request: HttpRequest
 }
 
 """
-The run target result.
+The output of the Function run target. The object contains the operations to
+generate pickup point delivery options at checkout.
 """
 input FunctionRunResult {
   """
-  An ordered list of operations to apply for pickup point delivery option generation.
+  An ordered list of operations to apply to generate pickup point delivery options.
   """
   operations: [Operation!]!
 }
@@ -2747,16 +2893,24 @@ type GateConfiguration implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2801,7 +2955,7 @@ interface HasGates {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 }
 
 """
@@ -2809,32 +2963,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2989,37 +3153,45 @@ scalar ID
 
 type Input {
   """
-  A list of allocations.
+  A list of one or more line items that are to be delivered to a specific address.
   """
   allocations: [Allocation!]! @deprecated(reason: "Use `deliveryAddress` instead.")
 
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The delivery address for pickup point delivery option.
+  The delivery address for the pickup point delivery option.
   """
   deliveryAddress: MailingAddress!
 
   """
-  The result of the fetch target. Refer to network access for Shopify Functions.
+  The fetch target result. Your Function must return this data structure when generating the request.
   """
   fetchResult: HttpResponse @restrictTarget(only: ["purchase.pickup-point-delivery-option-generator.run"])
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
@@ -3042,7 +3214,8 @@ Example value:
 scalar JSON
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -3762,7 +3935,18 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+Local pickup settings associated with a location.
+"""
+type LocalPickup {
+  """
+  Whether local pickup is enabled for the location.
+  """
+  enabled: Boolean!
+}
+
+"""
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3842,23 +4026,29 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
   """
   The market of the active localized experience.
   """
-  market: Market!
+  market: Market! @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 }
 
 """
@@ -3889,189 +4079,307 @@ Unique key identifying localized fields.
 """
 enum LocalizedFieldKey {
   """
-  Localized field key 'shipping_credential_br' for country BR.
+  Localized field key 'shipping_credential_br' for country Brazil.
   """
   SHIPPING_CREDENTIAL_BR
 
   """
-  Localized field key 'shipping_credential_cl' for country CL.
+  Localized field key 'shipping_credential_cl' for country Chile.
   """
   SHIPPING_CREDENTIAL_CL
 
   """
-  Localized field key 'shipping_credential_cn' for country CN.
+  Localized field key 'shipping_credential_cn' for country China.
   """
   SHIPPING_CREDENTIAL_CN
 
   """
-  Localized field key 'shipping_credential_co' for country CO.
+  Localized field key 'shipping_credential_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_CO
 
   """
-  Localized field key 'shipping_credential_cr' for country CR.
+  Localized field key 'shipping_credential_cr' for country Costa Rica.
   """
   SHIPPING_CREDENTIAL_CR
 
   """
-  Localized field key 'shipping_credential_ec' for country EC.
+  Localized field key 'shipping_credential_ec' for country Ecuador.
   """
   SHIPPING_CREDENTIAL_EC
 
   """
-  Localized field key 'shipping_credential_es' for country ES.
+  Localized field key 'shipping_credential_es' for country Spain.
   """
   SHIPPING_CREDENTIAL_ES
 
   """
-  Localized field key 'shipping_credential_gt' for country GT.
+  Localized field key 'shipping_credential_gt' for country Guatemala.
   """
   SHIPPING_CREDENTIAL_GT
 
   """
-  Localized field key 'shipping_credential_id' for country ID.
+  Localized field key 'shipping_credential_id' for country Indonesia.
   """
   SHIPPING_CREDENTIAL_ID
 
   """
-  Localized field key 'shipping_credential_kr' for country KR.
+  Localized field key 'shipping_credential_kr' for country South Korea.
   """
   SHIPPING_CREDENTIAL_KR
 
   """
-  Localized field key 'shipping_credential_mx' for country MX.
+  Localized field key 'shipping_credential_mx' for country Mexico.
   """
   SHIPPING_CREDENTIAL_MX
 
   """
-  Localized field key 'shipping_credential_my' for country MY.
+  Localized field key 'shipping_credential_my' for country Malaysia.
   """
   SHIPPING_CREDENTIAL_MY
 
   """
-  Localized field key 'shipping_credential_pe' for country PE.
+  Localized field key 'shipping_credential_pe' for country Peru.
   """
   SHIPPING_CREDENTIAL_PE
 
   """
-  Localized field key 'shipping_credential_pt' for country PT.
+  Localized field key 'shipping_credential_pt' for country Portugal.
   """
   SHIPPING_CREDENTIAL_PT
 
   """
-  Localized field key 'shipping_credential_py' for country PY.
+  Localized field key 'shipping_credential_py' for country Paraguay.
   """
   SHIPPING_CREDENTIAL_PY
 
   """
-  Localized field key 'shipping_credential_tr' for country TR.
+  Localized field key 'shipping_credential_tr' for country Turkey.
   """
   SHIPPING_CREDENTIAL_TR
 
   """
-  Localized field key 'shipping_credential_tw' for country TW.
+  Localized field key 'shipping_credential_tw' for country Taiwan.
   """
   SHIPPING_CREDENTIAL_TW
 
   """
-  Localized field key 'shipping_credential_type_co' for country CO.
+  Localized field key 'shipping_credential_type_co' for country Colombia.
   """
   SHIPPING_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_br' for country BR.
+  Localized field key 'tax_credential_br' for country Brazil.
   """
   TAX_CREDENTIAL_BR
 
   """
-  Localized field key 'tax_credential_cl' for country CL.
+  Localized field key 'tax_credential_cl' for country Chile.
   """
   TAX_CREDENTIAL_CL
 
   """
-  Localized field key 'tax_credential_co' for country CO.
+  Localized field key 'tax_credential_co' for country Colombia.
   """
   TAX_CREDENTIAL_CO
 
   """
-  Localized field key 'tax_credential_cr' for country CR.
+  Localized field key 'tax_credential_cr' for country Costa Rica.
   """
   TAX_CREDENTIAL_CR
 
   """
-  Localized field key 'tax_credential_ec' for country EC.
+  Localized field key 'tax_credential_ec' for country Ecuador.
   """
   TAX_CREDENTIAL_EC
 
   """
-  Localized field key 'tax_credential_es' for country ES.
+  Localized field key 'tax_credential_es' for country Spain.
   """
   TAX_CREDENTIAL_ES
 
   """
-  Localized field key 'tax_credential_gt' for country GT.
+  Localized field key 'tax_credential_gt' for country Guatemala.
   """
   TAX_CREDENTIAL_GT
 
   """
-  Localized field key 'tax_credential_id' for country ID.
+  Localized field key 'tax_credential_id' for country Indonesia.
   """
   TAX_CREDENTIAL_ID
 
   """
-  Localized field key 'tax_credential_it' for country IT.
+  Localized field key 'tax_credential_it' for country Italy.
   """
   TAX_CREDENTIAL_IT
 
   """
-  Localized field key 'tax_credential_mx' for country MX.
+  Localized field key 'tax_credential_mx' for country Mexico.
   """
   TAX_CREDENTIAL_MX
 
   """
-  Localized field key 'tax_credential_my' for country MY.
+  Localized field key 'tax_credential_my' for country Malaysia.
   """
   TAX_CREDENTIAL_MY
 
   """
-  Localized field key 'tax_credential_pe' for country PE.
+  Localized field key 'tax_credential_pe' for country Peru.
   """
   TAX_CREDENTIAL_PE
 
   """
-  Localized field key 'tax_credential_pt' for country PT.
+  Localized field key 'tax_credential_pt' for country Portugal.
   """
   TAX_CREDENTIAL_PT
 
   """
-  Localized field key 'tax_credential_py' for country PY.
+  Localized field key 'tax_credential_py' for country Paraguay.
   """
   TAX_CREDENTIAL_PY
 
   """
-  Localized field key 'tax_credential_tr' for country TR.
+  Localized field key 'tax_credential_tr' for country Turkey.
   """
   TAX_CREDENTIAL_TR
 
   """
-  Localized field key 'tax_credential_type_co' for country CO.
+  Localized field key 'tax_credential_type_co' for country Colombia.
   """
   TAX_CREDENTIAL_TYPE_CO
 
   """
-  Localized field key 'tax_credential_type_mx' for country MX.
+  Localized field key 'tax_credential_type_mx' for country Mexico.
   """
   TAX_CREDENTIAL_TYPE_MX
 
   """
-  Localized field key 'tax_credential_use_mx' for country MX.
+  Localized field key 'tax_credential_use_mx' for country Mexico.
   """
   TAX_CREDENTIAL_USE_MX
 
   """
-  Localized field key 'tax_email_it' for country IT.
+  Localized field key 'tax_email_it' for country Italy.
   """
   TAX_EMAIL_IT
+}
+
+"""
+Represents the location where the inventory resides.
+"""
+type Location implements HasMetafields {
+  """
+  The address of this location.
+  """
+  address: LocationAddress!
+
+  """
+  The location handle.
+  """
+  handle: Handle!
+
+  """
+  The location id.
+  """
+  id: ID!
+
+  """
+  Local pickup settings associated with a location.
+  """
+  localPickup: LocalPickup!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The name of the location.
+  """
+  name: String!
+}
+
+"""
+Represents the address of a location.
+"""
+type LocationAddress {
+  """
+  The first line of the address for the location.
+  """
+  address1: String
+
+  """
+  The second line of the address for the location.
+  """
+  address2: String
+
+  """
+  The city of the location.
+  """
+  city: String
+
+  """
+  The country of the location.
+  """
+  country: String
+
+  """
+  The country code of the location.
+  """
+  countryCode: String
+
+  """
+  A formatted version of the address for the location.
+  """
+  formatted: [String!]!
+
+  """
+  The approximate latitude coordinates of the location.
+  """
+  latitude: Float
+
+  """
+  The approximate longitude coordinates of the location.
+  """
+  longitude: Float
+
+  """
+  The phone number of the location.
+  """
+  phone: String
+
+  """
+  The province of the location.
+  """
+  province: String
+
+  """
+  The code for the province, state, or district of the address of the location.
+  """
+  provinceCode: String
+
+  """
+  The ZIP code of the location.
+  """
+  zip: String
 }
 
 """
@@ -4126,7 +4434,7 @@ type MailingAddress {
   """
   The market of the address.
   """
-  market: Market
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
 
   """
   The full name of the customer, based on firstName and lastName.
@@ -4169,16 +4477,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4215,52 +4531,71 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The data stored in the metafield in JSON format.
+  The data that's stored in the metafield, using JSON format.
   """
   jsonValue: JSON!
 
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields) enable you to attach additional information.
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 input MetafieldOutput {
   """
-  The key for the metafield.
+  The unique identifier for the metafield within its namespace. A metafield is composed of a
+  namespace and a key, in the format `namespace.key`.
   """
   key: String!
 
   """
-  The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+  A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+  between different apps or different parts of the same app. If omitted, then the
+  [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+  is used.
   """
   namespace: String
 
   """
-  The type of data that is stored in the metafield. Refer to the list of supported types.
+  The [type of data](https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types)
+  that's stored in the metafield.
   """
   type: String!
 
@@ -4271,16 +4606,19 @@ input MetafieldOutput {
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -4311,7 +4649,7 @@ type MutationRoot {
 }
 
 """
-An operation to generate pickup point delivery options.
+An ordered list of operations to generate pickup point delivery options.
 """
 input Operation {
   """
@@ -4321,7 +4659,15 @@ input Operation {
 }
 
 """
-The pickup point delivery option address.
+Comprehensive geographic location information for a physical pickup point. [A pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points)
+is a location where customers can collect their online orders rather than having
+them delivered to their home or a to a [local pickup point](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store).
+Examples of pickup points include local post offices, convenience stores, and
+self-service lockers.
+
+This object stores both standard address fields and precise geolocation
+coordinates for generating pickup points and associated data, such as a
+location's distance from the customer.
 """
 input PickupAddress {
   """
@@ -4381,58 +4727,67 @@ input PickupAddress {
 }
 
 """
-A pickup point.
+A third-party location where customers can collect their orders, such as a local
+post office, convenience store, or self-service locker.
 """
 input PickupPoint {
   """
-  The pickup point address.
+  The address of the pickup point's location.
   """
   address: PickupAddress!
 
   """
-  The business hours of the pickup point location. Any day that is either not
-  mentioned or does not have any defined periods will be considered as closed.
+  A list of operating hours for the pickup point. A day that's omitted or
+  doesn't have defined time periods is considered to be closed.
   """
   businessHours: [BusinessHours!]
 
   """
-  The external id assigned by the provider for the pickup point delivery option.
+  The unique ID that the third-party service has assigned to the pickup point.
   """
   externalId: String!
 
   """
-  The name assigned by the provider for pickup point delivery option.
+  The name that the third-party service has assigned to the pickup point.
   """
   name: String!
 
   """
-  The pickup point delivery option provider.
+  The third-party service that manages pickup point delivery options.
   """
   provider: Provider!
 }
 
 """
-A pickup point delivery option.
+A pickup point delivery option, such as a local post office, convenience store, or self-service locker.
 """
 input PickupPointDeliveryOption {
   """
-  The cost of the delivery option in the currency of the cart. Defaults to the location pickup points settings price.
+  The delivery option's cost in the cart's currency. If not provided, then the
+  system uses the default price from the location's pickup points settings.
   """
   cost: Decimal
 
   """
-  The metafields associated with the delivery option.
+  The metafields associated with the pickup point delivery option.
   """
   metafields: [MetafieldOutput!] = []
 
   """
-  The pickup point.
+  The [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points) where customers can collect their online orders rather than having them
+  delivered to their home or to a [local pickup point](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store).
+  Examples of pickup points include local post offices, convenience stores, and
+  self-service lockers.
   """
   pickupPoint: PickupPoint!
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasGates & HasMetafields {
   """
@@ -4443,54 +4798,73 @@ type Product implements HasGates & HasMetafields {
     The handle of the gate configurations to search for.
     """
     handle: Handle
-  ): [GateSubject!]!
+  ): [GateSubject!]! @deprecated(reason: "Gates API is being sunset and will be removed in a future version. Use `metafields` instead for gate configuration.")
 
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -4501,27 +4875,39 @@ type Product implements HasGates & HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -4532,77 +4918,97 @@ type Product implements HasGates & HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-The provider for a pickup point.
+The third-party service that manages the pickup point delivery options.
 """
 input Provider {
   """
-  The provider logo url. The base URL must be `https://cdn.shopify.com`.
+  The URL logo for the third-party service that manages the pickup point
+  delivery options. The base URL must be `https://cdn.shopify.com`.
   """
   logoUrl: URL!
 
   """
-  The provider name.
+  The name of the third-party service that manages the pickup point delivery options.
   """
   name: String!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4636,16 +5042,24 @@ type SellingPlan implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4705,25 +5119,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -4751,7 +5175,7 @@ A void type that can be used to return a null value from a mutation.
 scalar Void
 
 """
-The weekday.
+The day of the week.
 """
 enum Weekday {
   """

--- a/sample-apps/bundles-cart-transform/extensions/cart-expand-js/schema.graphql
+++ b/sample-apps/bundles-cart-transform/extensions/cart-expand-js/schema.graphql
@@ -4,113 +4,150 @@ schema {
 }
 
 """
+Scale the Functions resource limits based on the field's length.
+"""
+directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
+
+"""
 Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  Key or name of the attribute.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the attribute. For example, `"true"`.
   """
   value: String
 }
 
 """
-Key-value pairs that contains additional information.
+The custom attributes associated with a cart line to store additional information. Cart attributes
+allow you to collect specific information from customers on the **Cart** page, such as order notes,
+gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 """
 input AttributeOutput {
   """
-  Key or name of the attribute.
+  The key of the cart line attribute to retrieve. For example, `"gift_wrapping"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the cart line attribute to retrieve. For example, `"true"`.
   """
   value: String!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  lines: [CartLine!]!
+  lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -120,50 +157,60 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 input CartLineInput {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
@@ -174,56 +221,84 @@ input CartLineInput {
 }
 
 """
-An operation to apply to the Cart.
+An operation to apply to the cart. For example, you can expand a cart line item to display
+its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+multiple cart lines into a single line representing a bundle, and update the presentation of line items
+in the cart to override their price, title, or image.
 """
 input CartOperation @oneOf {
   """
-  A cart line expand operation.
+  An operation that expands a single cart line item to form a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   expand: ExpandOperation
 
   """
-  A cart line merge operation.
+  An operation that merges multiple cart line items into a
+  single line, representing a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   merge: MergeOperation
 
   """
-  A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+  An operation that allows you to override the price, title,
+  and image of a cart line item. Only stores on a
+  [Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+  can use apps with `update` operations.
   """
   update: UpdateOperation
 }
 
 """
-A customization which applies cart transformations to the merchandise lines.
+A customization that changes the pricing and
+presentation of items in a cart. For example,
+you can modify the appearance of cart items,
+such as updating titles and images,
+or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
 """
 type CartTransform implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -248,16 +323,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -331,16 +414,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -358,7 +449,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1601,9 +1694,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2413,7 +2505,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2422,43 +2517,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2468,27 +2571,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2498,22 +2606,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2547,53 +2663,74 @@ Example values: `"29.99"`, `"29.999"`.
 scalar Decimal
 
 """
-A cart line expand operation.
+An operation that expands a single cart line item to form a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input ExpandOperation {
   """
-  The cart line id to expand.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The cart items to expand.
+  The cart items to expand. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+  bundle is a group of products that are sold together as a single unit.
   """
   expandedCartItems: [ExpandedItem!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  Title override. If title is not provided, variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
 
+"""
+The cart item to expand. Each item is a component of the
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+bundle is a group of products that are sold together as a single unit.
+"""
 input ExpandedItem {
   """
-  The CartLine attributes to be added to component line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The merchandise id of the expanded item.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant that represents the expanded item.
   """
   merchandiseId: ID!
 
   """
-  The price adjustment for the expanded item.
+  A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: ExpandedItemPriceAdjustment
 
   """
-  The quantity of the expanded item.The max quantity is 2000.
+  The quantity of the expanded item. The maximum quantity is
+  2000.
   """
   quantity: Int!
 }
@@ -2609,11 +2746,13 @@ input ExpandedItemFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to the expanded item.
+A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
 """
 input ExpandedItemPriceAdjustment {
   """
-  The price adjustment for the expanded item.
+  The value of the price adjustment to apply to the expanded item.
   """
   adjustment: ExpandedItemPriceAdjustmentValue!
 }
@@ -2629,21 +2768,31 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart.
 """
 input FunctionRunResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
@@ -2660,32 +2809,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2699,7 +2858,8 @@ Example value: `"gid://shopify/Product/10079785100"`
 scalar ID
 
 """
-The image of an object.
+An image that replaces the existing image for a single cart line item or group of cart line items.
+The image must have a publicly accessible URL.
 """
 input ImageInput {
   """
@@ -2710,33 +2870,46 @@ input ImageInput {
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The CartTransform containing the function.
+  A customization that changes the pricing and
+  presentation of items in a cart. For example,
+  you can modify the appearance of cart items,
+  such as updating titles and images,
+  or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartTransform: CartTransform!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -2746,7 +2919,7 @@ type Language {
 }
 
 """
-ISO 639-1 language codes supported by Shopify.
+Language codes supported by Shopify.
 """
 enum LanguageCode {
   """
@@ -2823,6 +2996,11 @@ enum LanguageCode {
   Chechen.
   """
   CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
 
   """
   Czech.
@@ -2903,6 +3081,11 @@ enum LanguageCode {
   Finnish.
   """
   FI
+
+  """
+  Filipino.
+  """
+  FIL
 
   """
   Faroese.
@@ -3255,6 +3438,16 @@ enum LanguageCode {
   RW
 
   """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
   Sindhi.
   """
   SD
@@ -3436,7 +3629,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3516,16 +3710,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3555,16 +3755,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3601,77 +3809,101 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-A cart line merge operation.
+An operation that merges multiple cart line items into a
+single line, representing a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input MergeOperation {
   """
-  The CartLine attributes to be added to the parent line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The list of cart lines to merge.
+  The cart items to merge. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartLines: [CartLineInput!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The product variant that models the group of lines.
+  The [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  of the product variant that represents the collection of cart line items.
   """
   parentVariantId: ID!
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  The name of the group of lines to merge. If it isn't specified, it will use the parent_variant' name.
+  The title that replaces the existing title for a group of cart line items.
+  If you don't provide a title, then the title of the parent variant is used.
   """
   title: String
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -3701,6 +3933,11 @@ type MutationRoot {
   ): Void!
 }
 
+"""
+A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
+"""
 input PriceAdjustment {
   """
   The percentage price decrease of the price adjustment.
@@ -3716,55 +3953,78 @@ input PriceAdjustmentValue {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3775,27 +4035,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3806,62 +4078,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3949,25 +4240,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3984,32 +4285,41 @@ scalar TimeWithoutTimezone
 Represents an [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and
 [RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987)-compliant URI string.
 
-For example, `"https://johns-apparel.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
-(`johns-apparel.myshopify.com`).
+For example, `"https://example.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
+(`example.myshopify.com`).
 """
 scalar URL
 
 """
-A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+An operation that allows you to override the price, title,
+and image of a cart line item. Only stores on a
+[Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+can use apps with `update` operations.
 """
 input UpdateOperation {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The image override for the cart line item.
+  The image that replaces the existing image for the cart line item.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment for the cart line item.
+  A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+  price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+  for which the customer qualifies.
   """
   price: UpdateOperationPriceAdjustment
 
   """
-  The title override for the cart line item. If not provided, the variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
@@ -4025,7 +4335,9 @@ input UpdateOperationFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+for which the customer qualifies.
 """
 input UpdateOperationPriceAdjustment {
   """
@@ -4035,7 +4347,7 @@ input UpdateOperationPriceAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+The value of the price adjustment to apply to the updated item.
 """
 input UpdateOperationPriceAdjustmentValue @oneOf {
   """

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/schema.graphql
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/schema.graphql
@@ -4,113 +4,150 @@ schema {
 }
 
 """
+Scale the Functions resource limits based on the field's length.
+"""
+directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
+
+"""
 Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  Key or name of the attribute.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the attribute. For example, `"true"`.
   """
   value: String
 }
 
 """
-Key-value pairs that contains additional information.
+The custom attributes associated with a cart line to store additional information. Cart attributes
+allow you to collect specific information from customers on the **Cart** page, such as order notes,
+gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 """
 input AttributeOutput {
   """
-  Key or name of the attribute.
+  The key of the cart line attribute to retrieve. For example, `"gift_wrapping"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the cart line attribute to retrieve. For example, `"true"`.
   """
   value: String!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  lines: [CartLine!]!
+  lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -120,50 +157,60 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 input CartLineInput {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
@@ -174,56 +221,84 @@ input CartLineInput {
 }
 
 """
-An operation to apply to the Cart.
+An operation to apply to the cart. For example, you can expand a cart line item to display
+its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+multiple cart lines into a single line representing a bundle, and update the presentation of line items
+in the cart to override their price, title, or image.
 """
 input CartOperation @oneOf {
   """
-  A cart line expand operation.
+  An operation that expands a single cart line item to form a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   expand: ExpandOperation
 
   """
-  A cart line merge operation.
+  An operation that merges multiple cart line items into a
+  single line, representing a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   merge: MergeOperation
 
   """
-  A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+  An operation that allows you to override the price, title,
+  and image of a cart line item. Only stores on a
+  [Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+  can use apps with `update` operations.
   """
   update: UpdateOperation
 }
 
 """
-A customization which applies cart transformations to the merchandise lines.
+A customization that changes the pricing and
+presentation of items in a cart. For example,
+you can modify the appearance of cart items,
+such as updating titles and images,
+or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
 """
 type CartTransform implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -248,16 +323,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -331,16 +414,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -358,7 +449,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1601,9 +1694,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2413,7 +2505,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2422,43 +2517,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2468,27 +2571,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2498,22 +2606,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2547,53 +2663,74 @@ Example values: `"29.99"`, `"29.999"`.
 scalar Decimal
 
 """
-A cart line expand operation.
+An operation that expands a single cart line item to form a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input ExpandOperation {
   """
-  The cart line id to expand.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The cart items to expand.
+  The cart items to expand. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+  bundle is a group of products that are sold together as a single unit.
   """
   expandedCartItems: [ExpandedItem!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  Title override. If title is not provided, variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
 
+"""
+The cart item to expand. Each item is a component of the
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+bundle is a group of products that are sold together as a single unit.
+"""
 input ExpandedItem {
   """
-  The CartLine attributes to be added to component line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The merchandise id of the expanded item.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant that represents the expanded item.
   """
   merchandiseId: ID!
 
   """
-  The price adjustment for the expanded item.
+  A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: ExpandedItemPriceAdjustment
 
   """
-  The quantity of the expanded item.The max quantity is 2000.
+  The quantity of the expanded item. The maximum quantity is
+  2000.
   """
   quantity: Int!
 }
@@ -2609,11 +2746,13 @@ input ExpandedItemFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to the expanded item.
+A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
 """
 input ExpandedItemPriceAdjustment {
   """
-  The price adjustment for the expanded item.
+  The value of the price adjustment to apply to the expanded item.
   """
   adjustment: ExpandedItemPriceAdjustmentValue!
 }
@@ -2629,21 +2768,31 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart.
 """
 input FunctionRunResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
@@ -2660,32 +2809,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2699,7 +2858,8 @@ Example value: `"gid://shopify/Product/10079785100"`
 scalar ID
 
 """
-The image of an object.
+An image that replaces the existing image for a single cart line item or group of cart line items.
+The image must have a publicly accessible URL.
 """
 input ImageInput {
   """
@@ -2710,33 +2870,46 @@ input ImageInput {
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The CartTransform containing the function.
+  A customization that changes the pricing and
+  presentation of items in a cart. For example,
+  you can modify the appearance of cart items,
+  such as updating titles and images,
+  or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartTransform: CartTransform!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -2746,7 +2919,7 @@ type Language {
 }
 
 """
-ISO 639-1 language codes supported by Shopify.
+Language codes supported by Shopify.
 """
 enum LanguageCode {
   """
@@ -2823,6 +2996,11 @@ enum LanguageCode {
   Chechen.
   """
   CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
 
   """
   Czech.
@@ -2903,6 +3081,11 @@ enum LanguageCode {
   Finnish.
   """
   FI
+
+  """
+  Filipino.
+  """
+  FIL
 
   """
   Faroese.
@@ -3255,6 +3438,16 @@ enum LanguageCode {
   RW
 
   """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
   Sindhi.
   """
   SD
@@ -3436,7 +3629,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3516,16 +3710,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3555,16 +3755,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3601,77 +3809,101 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-A cart line merge operation.
+An operation that merges multiple cart line items into a
+single line, representing a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input MergeOperation {
   """
-  The CartLine attributes to be added to the parent line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The list of cart lines to merge.
+  The cart items to merge. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartLines: [CartLineInput!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The product variant that models the group of lines.
+  The [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  of the product variant that represents the collection of cart line items.
   """
   parentVariantId: ID!
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  The name of the group of lines to merge. If it isn't specified, it will use the parent_variant' name.
+  The title that replaces the existing title for a group of cart line items.
+  If you don't provide a title, then the title of the parent variant is used.
   """
   title: String
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -3701,6 +3933,11 @@ type MutationRoot {
   ): Void!
 }
 
+"""
+A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
+"""
 input PriceAdjustment {
   """
   The percentage price decrease of the price adjustment.
@@ -3716,55 +3953,78 @@ input PriceAdjustmentValue {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3775,27 +4035,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3806,62 +4078,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3949,25 +4240,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3984,32 +4285,41 @@ scalar TimeWithoutTimezone
 Represents an [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and
 [RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987)-compliant URI string.
 
-For example, `"https://johns-apparel.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
-(`johns-apparel.myshopify.com`).
+For example, `"https://example.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
+(`example.myshopify.com`).
 """
 scalar URL
 
 """
-A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+An operation that allows you to override the price, title,
+and image of a cart line item. Only stores on a
+[Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+can use apps with `update` operations.
 """
 input UpdateOperation {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The image override for the cart line item.
+  The image that replaces the existing image for the cart line item.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment for the cart line item.
+  A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+  price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+  for which the customer qualifies.
   """
   price: UpdateOperationPriceAdjustment
 
   """
-  The title override for the cart line item. If not provided, the variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
@@ -4025,7 +4335,9 @@ input UpdateOperationFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+for which the customer qualifies.
 """
 input UpdateOperationPriceAdjustment {
   """
@@ -4035,7 +4347,7 @@ input UpdateOperationPriceAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+The value of the price adjustment to apply to the updated item.
 """
 input UpdateOperationPriceAdjustmentValue @oneOf {
   """

--- a/sample-apps/bundles-price-per-component/extensions/price-per-component-js/schema.graphql
+++ b/sample-apps/bundles-price-per-component/extensions/price-per-component-js/schema.graphql
@@ -4,113 +4,150 @@ schema {
 }
 
 """
+Scale the Functions resource limits based on the field's length.
+"""
+directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
+
+"""
 Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  Key or name of the attribute.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the attribute. For example, `"true"`.
   """
   value: String
 }
 
 """
-Key-value pairs that contains additional information.
+The custom attributes associated with a cart line to store additional information. Cart attributes
+allow you to collect specific information from customers on the **Cart** page, such as order notes,
+gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 """
 input AttributeOutput {
   """
-  Key or name of the attribute.
+  The key of the cart line attribute to retrieve. For example, `"gift_wrapping"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the cart line attribute to retrieve. For example, `"true"`.
   """
   value: String!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  lines: [CartLine!]!
+  lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -120,50 +157,60 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 input CartLineInput {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
@@ -174,56 +221,84 @@ input CartLineInput {
 }
 
 """
-An operation to apply to the Cart.
+An operation to apply to the cart. For example, you can expand a cart line item to display
+its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+multiple cart lines into a single line representing a bundle, and update the presentation of line items
+in the cart to override their price, title, or image.
 """
 input CartOperation @oneOf {
   """
-  A cart line expand operation.
+  An operation that expands a single cart line item to form a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   expand: ExpandOperation
 
   """
-  A cart line merge operation.
+  An operation that merges multiple cart line items into a
+  single line, representing a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   merge: MergeOperation
 
   """
-  A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+  An operation that allows you to override the price, title,
+  and image of a cart line item. Only stores on a
+  [Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+  can use apps with `update` operations.
   """
   update: UpdateOperation
 }
 
 """
-A customization which applies cart transformations to the merchandise lines.
+A customization that changes the pricing and
+presentation of items in a cart. For example,
+you can modify the appearance of cart items,
+such as updating titles and images,
+or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
 """
 type CartTransform implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -248,16 +323,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -331,16 +414,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -358,7 +449,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1601,9 +1694,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2413,7 +2505,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2422,43 +2517,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2468,27 +2571,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2498,22 +2606,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2547,53 +2663,74 @@ Example values: `"29.99"`, `"29.999"`.
 scalar Decimal
 
 """
-A cart line expand operation.
+An operation that expands a single cart line item to form a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input ExpandOperation {
   """
-  The cart line id to expand.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The cart items to expand.
+  The cart items to expand. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+  bundle is a group of products that are sold together as a single unit.
   """
   expandedCartItems: [ExpandedItem!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  Title override. If title is not provided, variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
 
+"""
+The cart item to expand. Each item is a component of the
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+bundle is a group of products that are sold together as a single unit.
+"""
 input ExpandedItem {
   """
-  The CartLine attributes to be added to component line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The merchandise id of the expanded item.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant that represents the expanded item.
   """
   merchandiseId: ID!
 
   """
-  The price adjustment for the expanded item.
+  A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: ExpandedItemPriceAdjustment
 
   """
-  The quantity of the expanded item.The max quantity is 2000.
+  The quantity of the expanded item. The maximum quantity is
+  2000.
   """
   quantity: Int!
 }
@@ -2609,11 +2746,13 @@ input ExpandedItemFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to the expanded item.
+A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
 """
 input ExpandedItemPriceAdjustment {
   """
-  The price adjustment for the expanded item.
+  The value of the price adjustment to apply to the expanded item.
   """
   adjustment: ExpandedItemPriceAdjustmentValue!
 }
@@ -2629,21 +2768,31 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart.
 """
 input FunctionRunResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
@@ -2660,32 +2809,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2699,7 +2858,8 @@ Example value: `"gid://shopify/Product/10079785100"`
 scalar ID
 
 """
-The image of an object.
+An image that replaces the existing image for a single cart line item or group of cart line items.
+The image must have a publicly accessible URL.
 """
 input ImageInput {
   """
@@ -2710,33 +2870,46 @@ input ImageInput {
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The CartTransform containing the function.
+  A customization that changes the pricing and
+  presentation of items in a cart. For example,
+  you can modify the appearance of cart items,
+  such as updating titles and images,
+  or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartTransform: CartTransform!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -2746,7 +2919,7 @@ type Language {
 }
 
 """
-ISO 639-1 language codes supported by Shopify.
+Language codes supported by Shopify.
 """
 enum LanguageCode {
   """
@@ -2823,6 +2996,11 @@ enum LanguageCode {
   Chechen.
   """
   CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
 
   """
   Czech.
@@ -2903,6 +3081,11 @@ enum LanguageCode {
   Finnish.
   """
   FI
+
+  """
+  Filipino.
+  """
+  FIL
 
   """
   Faroese.
@@ -3255,6 +3438,16 @@ enum LanguageCode {
   RW
 
   """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
   Sindhi.
   """
   SD
@@ -3436,7 +3629,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3516,16 +3710,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3555,16 +3755,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3601,77 +3809,101 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-A cart line merge operation.
+An operation that merges multiple cart line items into a
+single line, representing a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input MergeOperation {
   """
-  The CartLine attributes to be added to the parent line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The list of cart lines to merge.
+  The cart items to merge. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartLines: [CartLineInput!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The product variant that models the group of lines.
+  The [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  of the product variant that represents the collection of cart line items.
   """
   parentVariantId: ID!
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  The name of the group of lines to merge. If it isn't specified, it will use the parent_variant' name.
+  The title that replaces the existing title for a group of cart line items.
+  If you don't provide a title, then the title of the parent variant is used.
   """
   title: String
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -3701,6 +3933,11 @@ type MutationRoot {
   ): Void!
 }
 
+"""
+A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
+"""
 input PriceAdjustment {
   """
   The percentage price decrease of the price adjustment.
@@ -3716,55 +3953,78 @@ input PriceAdjustmentValue {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3775,27 +4035,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3806,62 +4078,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3949,25 +4240,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3984,32 +4285,41 @@ scalar TimeWithoutTimezone
 Represents an [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and
 [RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987)-compliant URI string.
 
-For example, `"https://johns-apparel.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
-(`johns-apparel.myshopify.com`).
+For example, `"https://example.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
+(`example.myshopify.com`).
 """
 scalar URL
 
 """
-A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+An operation that allows you to override the price, title,
+and image of a cart line item. Only stores on a
+[Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+can use apps with `update` operations.
 """
 input UpdateOperation {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The image override for the cart line item.
+  The image that replaces the existing image for the cart line item.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment for the cart line item.
+  A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+  price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+  for which the customer qualifies.
   """
   price: UpdateOperationPriceAdjustment
 
   """
-  The title override for the cart line item. If not provided, the variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
@@ -4025,7 +4335,9 @@ input UpdateOperationFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+for which the customer qualifies.
 """
 input UpdateOperationPriceAdjustment {
   """
@@ -4035,7 +4347,7 @@ input UpdateOperationPriceAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+The value of the price adjustment to apply to the updated item.
 """
 input UpdateOperationPriceAdjustmentValue @oneOf {
   """

--- a/sample-apps/delivery-customizations/extensions/delivery-customization-js/schema.graphql
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization-js/schema.graphql
@@ -4,203 +4,261 @@ schema {
 }
 
 """
+Scale the Functions resource limits based on the field's length.
+"""
+directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
+
+"""
 Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  Key or name of the attribute.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the attribute. For example, `"true"`.
   """
   value: String
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  lines: [CartLine!]!
+  lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  cartLines: [CartLine!]!
+  cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -210,58 +268,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -286,16 +357,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -369,16 +448,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -396,7 +483,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1639,9 +1728,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2451,7 +2539,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2460,43 +2551,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2506,27 +2605,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2536,22 +2640,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2589,13 +2701,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2606,12 +2722,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2621,16 +2737,24 @@ A customization representing how delivery options will be ordered, hidden, or re
 """
 type DeliveryCustomization implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2672,22 +2796,27 @@ enum DeliveryMethod {
 }
 
 """
-The result of a delivery customization function. In API versions 2023-10 and
-beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to apply to delivery options in checkout. In
+API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The ordered list of operations to apply to the list of delivery options.
+  The ordered list of operations to apply to the list of
+  [delivery options](https://shopify.dev/docs/apps/build/checkout/delivery-shipping/delivery-options/build-function).
   """
   operations: [Operation!]!
 }
 
 """
-The result of a delivery customization function.
+The output of the Function run target.
+The object contains the operations to apply to delivery options in checkout.
 """
 input FunctionRunResult {
   """
-  The ordered list of operations to apply to the list of delivery options.
+  The ordered list of operations to apply to the list of
+  [delivery options](https://shopify.dev/docs/apps/build/checkout/delivery-shipping/delivery-options/build-function).
   """
   operations: [Operation!]!
 }
@@ -2704,38 +2833,48 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
 
 """
-Request to hide a delivery option.
+An operation that hides a delivery option from a list that's offered to customers at checkout.
 """
 input HideOperation {
   """
@@ -2754,33 +2893,46 @@ scalar ID
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The delivery customization that owns the current function.
+  The backend logic that the Function is running to define how
+  [delivery options](https://shopify.dev/apps/build/checkout/delivery-shipping/delivery-options/build-function)
+  are sorted, hidden, or renamed. It includes the
+  [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   deliveryCustomization: DeliveryCustomization!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -2790,7 +2942,7 @@ type Language {
 }
 
 """
-ISO 639-1 language codes supported by Shopify.
+Language codes supported by Shopify.
 """
 enum LanguageCode {
   """
@@ -2867,6 +3019,11 @@ enum LanguageCode {
   Chechen.
   """
   CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
 
   """
   Czech.
@@ -2947,6 +3104,11 @@ enum LanguageCode {
   Finnish.
   """
   FI
+
+  """
+  Filipino.
+  """
+  FIL
 
   """
   Faroese.
@@ -3299,6 +3461,16 @@ enum LanguageCode {
   RW
 
   """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
   Sindhi.
   """
   SD
@@ -3480,7 +3652,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3560,16 +3733,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3644,7 +3823,7 @@ type MailingAddress {
   phone: String
 
   """
-  The two-letter code for the region. For example, ON.
+  The alphanumeric code for the region. For example, ON.
   """
   provinceCode: String
 
@@ -3674,16 +3853,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3720,48 +3907,66 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
 
 """
-Request to move a delivery option to a new index.
+An operation that sorts a list of delivery options that are offered to customers at checkout.
+
+If you reorder shipping delivery options, then you are
+[prohibited](https://shopify.dev/docs/apps/launch/app-requirements-checklist#prohibited-app-types).
+from automatically selecting higher-priced delivery alternatives by default. The cheapest shipping delivery option
+must always be the first option selected.
 """
 input MoveOperation {
   """
@@ -3770,7 +3975,7 @@ input MoveOperation {
   deliveryOptionHandle: Handle!
 
   """
-  The index to move the delivery option to.
+  The target index within the delivery group to move the delivery option to.
   """
   index: Int!
 }
@@ -3805,71 +4010,104 @@ An operation to apply to the list of delivery options.
 """
 input Operation @oneOf {
   """
-  Request to hide a delivery option.
+  An operation that hides a delivery option from a list that's offered to customers at checkout.
   """
   hide: HideOperation
 
   """
-  Request to move a delivery option to a new index.
+  An operation that sorts a list of delivery options that are offered to customers at checkout.
+
+  If you reorder shipping delivery options, then you are
+  [prohibited](https://shopify.dev/docs/apps/launch/app-requirements-checklist#prohibited-app-types).
+  from automatically selecting higher-priced delivery alternatives by default. The cheapest shipping delivery option
+  must always be the first option selected.
   """
   move: MoveOperation
 
   """
-  Request to rename a delivery option.
+  An operation that renames a delivery option that's offered to customers at checkout.
+
+  The carrier name is automatically prepended to the delivery option title at checkout when using the
+  `RenameOperation` object, and can't be altered or omitted through the API. For example, if the carrier name
+  is **UPS** and the option is **Standard**, then you could change **UPS Standard** to **UPS Standard Shipping**,
+  but you couldn't change **UPS Standard** to **Standard Shipping**.
   """
   rename: RenameOperation
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3880,27 +4118,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3911,62 +4161,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3986,7 +4255,12 @@ type PurchasingCompany {
 }
 
 """
-Request to rename a delivery option.
+An operation that renames a delivery option that's offered to customers at checkout.
+
+The carrier name is automatically prepended to the delivery option title at checkout when using the
+`RenameOperation` object, and can't be altered or omitted through the API. For example, if the carrier name
+is **UPS** and the option is **Standard**, then you could change **UPS Standard** to **UPS Standard Shipping**,
+but you couldn't change **UPS Standard** to **Standard Shipping**.
 """
 input RenameOperation {
   """
@@ -4069,25 +4343,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/sample-apps/delivery-customizations/extensions/delivery-customization-js/shopify.extension.toml
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization-js/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "delivery-customization-js"

--- a/sample-apps/delivery-customizations/extensions/delivery-customization-rust/schema.graphql
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization-rust/schema.graphql
@@ -4,203 +4,261 @@ schema {
 }
 
 """
+Scale the Functions resource limits based on the field's length.
+"""
+directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
+
+"""
 Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  Key or name of the attribute.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the attribute. For example, `"true"`.
   """
   value: String
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  lines: [CartLine!]!
+  lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  cartLines: [CartLine!]!
+  cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -210,58 +268,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -286,16 +357,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -369,16 +448,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -396,7 +483,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1639,9 +1728,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2451,7 +2539,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2460,43 +2551,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2506,27 +2605,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2536,22 +2640,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2589,13 +2701,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2606,12 +2722,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2621,16 +2737,24 @@ A customization representing how delivery options will be ordered, hidden, or re
 """
 type DeliveryCustomization implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2672,22 +2796,27 @@ enum DeliveryMethod {
 }
 
 """
-The result of a delivery customization function. In API versions 2023-10 and
-beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to apply to delivery options in checkout. In
+API versions 2023-10 and beyond, this type is deprecated in favor of
+`FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The ordered list of operations to apply to the list of delivery options.
+  The ordered list of operations to apply to the list of
+  [delivery options](https://shopify.dev/docs/apps/build/checkout/delivery-shipping/delivery-options/build-function).
   """
   operations: [Operation!]!
 }
 
 """
-The result of a delivery customization function.
+The output of the Function run target.
+The object contains the operations to apply to delivery options in checkout.
 """
 input FunctionRunResult {
   """
-  The ordered list of operations to apply to the list of delivery options.
+  The ordered list of operations to apply to the list of
+  [delivery options](https://shopify.dev/docs/apps/build/checkout/delivery-shipping/delivery-options/build-function).
   """
   operations: [Operation!]!
 }
@@ -2704,38 +2833,48 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
 
 """
-Request to hide a delivery option.
+An operation that hides a delivery option from a list that's offered to customers at checkout.
 """
 input HideOperation {
   """
@@ -2754,33 +2893,46 @@ scalar ID
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The delivery customization that owns the current function.
+  The backend logic that the Function is running to define how
+  [delivery options](https://shopify.dev/apps/build/checkout/delivery-shipping/delivery-options/build-function)
+  are sorted, hidden, or renamed. It includes the
+  [metafields](https://shopify.dev/docs/apps/build/custom-data)
+  that are associated with the customization.
   """
   deliveryCustomization: DeliveryCustomization!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -2790,7 +2942,7 @@ type Language {
 }
 
 """
-ISO 639-1 language codes supported by Shopify.
+Language codes supported by Shopify.
 """
 enum LanguageCode {
   """
@@ -2867,6 +3019,11 @@ enum LanguageCode {
   Chechen.
   """
   CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
 
   """
   Czech.
@@ -2947,6 +3104,11 @@ enum LanguageCode {
   Finnish.
   """
   FI
+
+  """
+  Filipino.
+  """
+  FIL
 
   """
   Faroese.
@@ -3299,6 +3461,16 @@ enum LanguageCode {
   RW
 
   """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
   Sindhi.
   """
   SD
@@ -3480,7 +3652,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3560,16 +3733,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3644,7 +3823,7 @@ type MailingAddress {
   phone: String
 
   """
-  The two-letter code for the region. For example, ON.
+  The alphanumeric code for the region. For example, ON.
   """
   provinceCode: String
 
@@ -3674,16 +3853,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3720,48 +3907,66 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
 
 """
-Request to move a delivery option to a new index.
+An operation that sorts a list of delivery options that are offered to customers at checkout.
+
+If you reorder shipping delivery options, then you are
+[prohibited](https://shopify.dev/docs/apps/launch/app-requirements-checklist#prohibited-app-types).
+from automatically selecting higher-priced delivery alternatives by default. The cheapest shipping delivery option
+must always be the first option selected.
 """
 input MoveOperation {
   """
@@ -3770,7 +3975,7 @@ input MoveOperation {
   deliveryOptionHandle: Handle!
 
   """
-  The index to move the delivery option to.
+  The target index within the delivery group to move the delivery option to.
   """
   index: Int!
 }
@@ -3805,71 +4010,104 @@ An operation to apply to the list of delivery options.
 """
 input Operation @oneOf {
   """
-  Request to hide a delivery option.
+  An operation that hides a delivery option from a list that's offered to customers at checkout.
   """
   hide: HideOperation
 
   """
-  Request to move a delivery option to a new index.
+  An operation that sorts a list of delivery options that are offered to customers at checkout.
+
+  If you reorder shipping delivery options, then you are
+  [prohibited](https://shopify.dev/docs/apps/launch/app-requirements-checklist#prohibited-app-types).
+  from automatically selecting higher-priced delivery alternatives by default. The cheapest shipping delivery option
+  must always be the first option selected.
   """
   move: MoveOperation
 
   """
-  Request to rename a delivery option.
+  An operation that renames a delivery option that's offered to customers at checkout.
+
+  The carrier name is automatically prepended to the delivery option title at checkout when using the
+  `RenameOperation` object, and can't be altered or omitted through the API. For example, if the carrier name
+  is **UPS** and the option is **Standard**, then you could change **UPS Standard** to **UPS Standard Shipping**,
+  but you couldn't change **UPS Standard** to **Standard Shipping**.
   """
   rename: RenameOperation
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3880,27 +4118,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3911,62 +4161,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3986,7 +4255,12 @@ type PurchasingCompany {
 }
 
 """
-Request to rename a delivery option.
+An operation that renames a delivery option that's offered to customers at checkout.
+
+The carrier name is automatically prepended to the delivery option title at checkout when using the
+`RenameOperation` object, and can't be altered or omitted through the API. For example, if the carrier name
+is **UPS** and the option is **Standard**, then you could change **UPS Standard** to **UPS Standard Shipping**,
+but you couldn't change **UPS Standard** to **Standard Shipping**.
 """
 input RenameOperation {
   """
@@ -4069,25 +4343,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/sample-apps/delivery-customizations/extensions/delivery-customization-rust/shopify.extension.toml
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization-rust/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "delivery-customization-rust"

--- a/sample-apps/discounts/extensions/product-discount-js/schema.graphql
+++ b/sample-apps/discounts/extensions/product-discount-js/schema.graphql
@@ -4,203 +4,261 @@ schema {
 }
 
 """
+Scale the Functions resource limits based on the field's length.
+"""
+directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
+
+"""
 Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  Key or name of the attribute.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the attribute. For example, `"true"`.
   """
   value: String
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  lines: [CartLine!]!
+  lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  cartLines: [CartLine!]!
+  cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -210,58 +268,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -286,16 +357,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -369,16 +448,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -396,7 +483,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1508,7 +1597,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -1639,9 +1728,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2451,7 +2539,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2460,43 +2551,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2506,27 +2605,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2536,22 +2640,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2589,13 +2701,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2606,12 +2722,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2652,41 +2768,69 @@ enum DeliveryMethod {
 }
 
 """
-The discount to be applied.
+A price reduction applied to a product.
+
+Discounts can be offered in various forms, such as a percentage off, a fixed amount off, or free shipping.
+They can be applied automatically at checkout if certain conditions are met, or through a discount code that
+customers enter during checkout. Discounts are often used during promotional events or to attract first-time
+customers.
 """
 input Discount {
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the discount.
+  The method for applying the discount to products. This argument accepts a collection of either
+  `ProductVariantTarget` or `CartLineTarget`, but not both.
+
+  The `ProductVariantTarget` is used to target a specific product variant. A product variant is a specific
+  version of a product that comes in more than one option, such as size or color. For example, if a merchant
+  sells t-shirts with options for size and color, then a small, blue t-shirt would be one product variant
+  and a large, blue t-shirt would be another.
+
+  The `CartLineTarget` is used to target a specific line item in the cart. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   targets: [Target!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
 
 """
-The strategy that's applied to the list of discounts.
+The approach that determines how multiple discounts are evaluated and
+applied to a cart. You can apply all discounts with conditions that are met,
+apply a discount only to the first line item in a cart that meets conditions,
+or apply only the discount that offers a maximum price reduction.
 """
 enum DiscountApplicationStrategy {
   """
-  Apply all discounts with conditions that are satisfied.
+  Apply all discounts with conditions that are met. For example, you can use the `ALL` strategy to apply a
+  20% discount on a t-shirt, a $5 discount on a pair of shoes, and a 10% discount on a hat. The total
+  discount would be the sum of all three discounts, which would be applied to the order total. This strategy
+  doesn't override [discount combination](https://help.shopify.com/manual/discounts/discount-combinations)
+  rules.
   """
   ALL
 
   """
-  Only apply the first discount with conditions that are satisfied.
+  Only apply the discount to the first line item in a cart that meets conditions.
+  For example, you can use the `FIRST` strategy to apply a 20% discount to the first line item in a cart
+  and ensure no other discounts are applied.
   """
   FIRST
 
   """
-  Only apply the discount that offers the maximum reduction.
+  Only apply the discount that provides the greatest savings. For example, you can use the `MAXIMUM` strategy
+  to apply the higher of two discounts. If you have a 20% discount on a $30 t-shirt and a $5 discount on $40
+  shoes, then the 20% discount saves you $6 (20% of $30), while the $5 discount stays the same.
+  Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
 }
@@ -2696,16 +2840,24 @@ A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2732,31 +2884,43 @@ input FixedAmount {
 }
 
 """
-The result of the function. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply all discounts with conditions that are met,
+  apply a discount only to the first line item in a cart that meets conditions,
+  or apply only the discount that offers a maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
 
 """
-The result of the function.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart.
 """
 input FunctionRunResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply all discounts with conditions that are met,
+  apply a discount only to the first line item in a cart that meets conditions,
+  or apply only the discount that offers a maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
@@ -2773,32 +2937,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2816,33 +2990,44 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The discount node executing the function.
+  A wrapper around the discount that executes the Function. The `discountNode` field
+  enables you to manage [discounts](https://help.shopify.com/manual/discounts),
+  which are applied at checkout or on a cart.
   """
   discountNode: DiscountNode!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -2852,7 +3037,7 @@ type Language {
 }
 
 """
-ISO 639-1 language codes supported by Shopify.
+Language codes supported by Shopify.
 """
 enum LanguageCode {
   """
@@ -2929,6 +3114,11 @@ enum LanguageCode {
   Chechen.
   """
   CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
 
   """
   Czech.
@@ -3009,6 +3199,11 @@ enum LanguageCode {
   Finnish.
   """
   FI
+
+  """
+  Filipino.
+  """
+  FIL
 
   """
   Faroese.
@@ -3361,6 +3556,16 @@ enum LanguageCode {
   RW
 
   """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
   Sindhi.
   """
   SD
@@ -3542,7 +3747,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3622,16 +3828,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3706,7 +3918,7 @@ type MailingAddress {
   phone: String
 
   """
-  The two-letter code for the region. For example, ON.
+  The alphanumeric code for the region. For example, ON.
   """
   provinceCode: String
 
@@ -3736,16 +3948,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3782,42 +4002,55 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -3854,61 +4087,84 @@ input Percentage {
   """
   The percentage value.
 
-  The value is validated against: >= 0.
+  The value is validated against: >= 0 and <= 100.
   """
   value: Decimal!
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3919,27 +4175,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3950,72 +4218,94 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-The target product variant.
+A method for applying a discount to a
+[product variant](https://help.shopify.com/manual/products/variants). Product variants
+are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+product variants in the order, or to specific product variants that meet certain criteria.
 """
 input ProductVariantTarget {
   """
-  The ID of the target product variant.
+  The ID of the targeted product variant.
   """
   id: ID!
 
   """
-  The number of line items that are being discounted.
-  The default value is `null`, which represents the quantity of the matching line items.
+  The maximum number of line item units to be discounted.
+  The default value is `null`, which represents the total quantity of the matching line items.
 
   The value is validated against: > 0.
   """
@@ -4023,7 +4313,8 @@ input ProductVariantTarget {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4111,36 +4402,53 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-The target of the discount.
+The target for a discount. A discount's collection of targets determines which
+cart line(s) will have the discount value applied.
+
+A discount can have one or more `ProductVariantTarget`s.
 """
 input Target @oneOf {
   """
-  The target product variant.
+  A method for applying a discount to a
+  [product variant](https://help.shopify.com/manual/products/variants). Product variants
+  are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+  in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+  product variants in the order, or to specific product variants that meet certain criteria.
   """
   productVariant: ProductVariantTarget
 }
@@ -4153,7 +4461,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The value of the discount.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 input Value @oneOf {
   """

--- a/sample-apps/discounts/extensions/product-discount-js/shopify.extension.toml
+++ b/sample-apps/discounts/extensions/product-discount-js/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "product-discount-js"

--- a/sample-apps/discounts/extensions/product-discount-rust/schema.graphql
+++ b/sample-apps/discounts/extensions/product-discount-rust/schema.graphql
@@ -4,203 +4,261 @@ schema {
 }
 
 """
+Scale the Functions resource limits based on the field's length.
+"""
+directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
+
+"""
 Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  Key or name of the attribute.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the attribute. For example, `"true"`.
   """
   value: String
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  lines: [CartLine!]!
+  lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  cartLines: [CartLine!]!
+  cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -210,58 +268,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -286,16 +357,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -369,16 +448,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -396,7 +483,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1508,7 +1597,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -1639,9 +1728,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2451,7 +2539,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2460,43 +2551,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2506,27 +2605,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2536,22 +2640,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2589,13 +2701,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2606,12 +2722,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2652,41 +2768,69 @@ enum DeliveryMethod {
 }
 
 """
-The discount to be applied.
+A price reduction applied to a product.
+
+Discounts can be offered in various forms, such as a percentage off, a fixed amount off, or free shipping.
+They can be applied automatically at checkout if certain conditions are met, or through a discount code that
+customers enter during checkout. Discounts are often used during promotional events or to attract first-time
+customers.
 """
 input Discount {
   """
-  The discount message.
+  A notification that informs customers about available discounts.
+  The message is displayed on the **Cart** page. For example, "Save 20% on all t-shirts."
   """
   message: String
 
   """
-  The targets of the discount.
+  The method for applying the discount to products. This argument accepts a collection of either
+  `ProductVariantTarget` or `CartLineTarget`, but not both.
+
+  The `ProductVariantTarget` is used to target a specific product variant. A product variant is a specific
+  version of a product that comes in more than one option, such as size or color. For example, if a merchant
+  sells t-shirts with options for size and color, then a small, blue t-shirt would be one product variant
+  and a large, blue t-shirt would be another.
+
+  The `CartLineTarget` is used to target a specific line item in the cart. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   targets: [Target!]!
 
   """
-  The value of the discount.
+  The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
   """
   value: Value!
 }
 
 """
-The strategy that's applied to the list of discounts.
+The approach that determines how multiple discounts are evaluated and
+applied to a cart. You can apply all discounts with conditions that are met,
+apply a discount only to the first line item in a cart that meets conditions,
+or apply only the discount that offers a maximum price reduction.
 """
 enum DiscountApplicationStrategy {
   """
-  Apply all discounts with conditions that are satisfied.
+  Apply all discounts with conditions that are met. For example, you can use the `ALL` strategy to apply a
+  20% discount on a t-shirt, a $5 discount on a pair of shoes, and a 10% discount on a hat. The total
+  discount would be the sum of all three discounts, which would be applied to the order total. This strategy
+  doesn't override [discount combination](https://help.shopify.com/manual/discounts/discount-combinations)
+  rules.
   """
   ALL
 
   """
-  Only apply the first discount with conditions that are satisfied.
+  Only apply the discount to the first line item in a cart that meets conditions.
+  For example, you can use the `FIRST` strategy to apply a 20% discount to the first line item in a cart
+  and ensure no other discounts are applied.
   """
   FIRST
 
   """
-  Only apply the discount that offers the maximum reduction.
+  Only apply the discount that provides the greatest savings. For example, you can use the `MAXIMUM` strategy
+  to apply the higher of two discounts. If you have a 20% discount on a $30 t-shirt and a $5 discount on $40
+  shoes, then the 20% discount saves you $6 (20% of $30), while the $5 discount stays the same.
+  Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
 }
@@ -2696,16 +2840,24 @@ A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -2732,31 +2884,43 @@ input FixedAmount {
 }
 
 """
-The result of the function. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply all discounts with conditions that are met,
+  apply a discount only to the first line item in a cart that meets conditions,
+  or apply only the discount that offers a maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
 
 """
-The result of the function.
+The output of the Function run target.
+The object contains the list of discounts and strategies to apply to each item
+in a cart.
 """
 input FunctionRunResult {
   """
-  The strategy to apply the list of discounts.
+  The approach that determines how multiple discounts are evaluated and
+  applied to a cart. You can apply all discounts with conditions that are met,
+  apply a discount only to the first line item in a cart that meets conditions,
+  or apply only the discount that offers a maximum price reduction.
   """
   discountApplicationStrategy: DiscountApplicationStrategy!
 
   """
-  The list of discounts to be applied.
+  The list of discounts that are applied to product variants or line items in a cart.
+  It includes data such as the discount value and the message associated with the discount.
   """
   discounts: [Discount!]!
 }
@@ -2773,32 +2937,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2816,33 +2990,44 @@ The input object for the function.
 """
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The discount node executing the function.
+  A wrapper around the discount that executes the Function. The `discountNode` field
+  enables you to manage [discounts](https://help.shopify.com/manual/discounts),
+  which are applied at checkout or on a cart.
   """
   discountNode: DiscountNode!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -2852,7 +3037,7 @@ type Language {
 }
 
 """
-ISO 639-1 language codes supported by Shopify.
+Language codes supported by Shopify.
 """
 enum LanguageCode {
   """
@@ -2929,6 +3114,11 @@ enum LanguageCode {
   Chechen.
   """
   CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
 
   """
   Czech.
@@ -3009,6 +3199,11 @@ enum LanguageCode {
   Finnish.
   """
   FI
+
+  """
+  Filipino.
+  """
+  FIL
 
   """
   Faroese.
@@ -3361,6 +3556,16 @@ enum LanguageCode {
   RW
 
   """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
   Sindhi.
   """
   SD
@@ -3542,7 +3747,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3622,16 +3828,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3706,7 +3918,7 @@ type MailingAddress {
   phone: String
 
   """
-  The two-letter code for the region. For example, ON.
+  The alphanumeric code for the region. For example, ON.
   """
   provinceCode: String
 
@@ -3736,16 +3948,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3782,42 +4002,55 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -3854,61 +4087,84 @@ input Percentage {
   """
   The percentage value.
 
-  The value is validated against: >= 0.
+  The value is validated against: >= 0 and <= 100.
   """
   value: Decimal!
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3919,27 +4175,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3950,72 +4218,94 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-The target product variant.
+A method for applying a discount to a
+[product variant](https://help.shopify.com/manual/products/variants). Product variants
+are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+product variants in the order, or to specific product variants that meet certain criteria.
 """
 input ProductVariantTarget {
   """
-  The ID of the target product variant.
+  The ID of the targeted product variant.
   """
   id: ID!
 
   """
-  The number of line items that are being discounted.
-  The default value is `null`, which represents the quantity of the matching line items.
+  The maximum number of line item units to be discounted.
+  The default value is `null`, which represents the total quantity of the matching line items.
 
   The value is validated against: > 0.
   """
@@ -4023,7 +4313,8 @@ input ProductVariantTarget {
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -4111,36 +4402,53 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-The target of the discount.
+The target for a discount. A discount's collection of targets determines which
+cart line(s) will have the discount value applied.
+
+A discount can have one or more `ProductVariantTarget`s.
 """
 input Target @oneOf {
   """
-  The target product variant.
+  A method for applying a discount to a
+  [product variant](https://help.shopify.com/manual/products/variants). Product variants
+  are the different versions of a product that can be purchased. For example, if a customer orders a t-shirt
+  in a specific size and color, the t-shirt is a product variant. The discount can be applied to all
+  product variants in the order, or to specific product variants that meet certain criteria.
   """
   productVariant: ProductVariantTarget
 }
@@ -4153,7 +4461,7 @@ For example, "05:43:21".
 scalar TimeWithoutTimezone
 
 """
-The value of the discount.
+The value of the discount. The value can be a fixed amount, like $5 (5.0), or a percentage, such as 10% (0.1).
 """
 input Value @oneOf {
   """

--- a/sample-apps/discounts/extensions/product-discount-rust/shopify.extension.toml
+++ b/sample-apps/discounts/extensions/product-discount-rust/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "product-discount-rust"

--- a/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-js/schema.graphql
+++ b/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-js/schema.graphql
@@ -4,98 +4,150 @@ schema {
 }
 
 """
+Scale the Functions resource limits based on the field's length.
+"""
+directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
+
+"""
 Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  Key or name of the attribute.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the attribute. For example, `"true"`.
   """
   value: String
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The custom attributes associated with a cart line to store additional information. Cart attributes
+allow you to collect specific information from customers on the **Cart** page, such as order notes,
+gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
+"""
+input AttributeOutput {
+  """
+  The key of the cart line attribute to retrieve. For example, `"gift_wrapping"`.
+  """
+  key: String!
+
+  """
+  The value of the cart line attribute to retrieve. For example, `"true"`.
+  """
+  value: String!
+}
+
+"""
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  lines: [CartLine!]!
+  lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -105,50 +157,60 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 input CartLineInput {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
@@ -159,49 +221,84 @@ input CartLineInput {
 }
 
 """
-An operation to apply to the Cart.
+An operation to apply to the cart. For example, you can expand a cart line item to display
+its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+multiple cart lines into a single line representing a bundle, and update the presentation of line items
+in the cart to override their price, title, or image.
 """
 input CartOperation @oneOf {
+  """
+  An operation that expands a single cart line item to form a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
+  """
   expand: ExpandOperation
+
+  """
+  An operation that merges multiple cart line items into a
+  single line, representing a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
+  """
   merge: MergeOperation
 
   """
-  A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+  An operation that allows you to override the price, title,
+  and image of a cart line item. Only stores on a
+  [Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+  can use apps with `update` operations.
   """
   update: UpdateOperation
 }
 
 """
-A customization which applies cart transformations to the merchandise lines.
+A customization that changes the pricing and
+presentation of items in a cart. For example,
+you can modify the appearance of cart items,
+such as updating titles and images,
+or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
 """
 type CartTransform implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -226,16 +323,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -309,16 +414,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -336,7 +449,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1448,7 +1563,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -1579,9 +1694,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2391,7 +2505,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2400,43 +2517,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2446,27 +2571,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2476,22 +2606,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2524,46 +2662,75 @@ Example values: `"29.99"`, `"29.999"`.
 """
 scalar Decimal
 
+"""
+An operation that expands a single cart line item to form a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
+"""
 input ExpandOperation {
   """
-  The cart line id to expand.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The cart items to expand.
+  The cart items to expand. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+  bundle is a group of products that are sold together as a single unit.
   """
   expandedCartItems: [ExpandedItem!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  Title override. If title is not provided, variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
 
+"""
+The cart item to expand. Each item is a component of the
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+bundle is a group of products that are sold together as a single unit.
+"""
 input ExpandedItem {
   """
-  The merchandise id of the expanded item.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
+  """
+  attributes: [AttributeOutput!] = []
+
+  """
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant that represents the expanded item.
   """
   merchandiseId: ID!
 
   """
-  The price adjustment for the expanded item.
+  A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: ExpandedItemPriceAdjustment
 
   """
-  The quantity of the expanded item.The max quantity is 2000.
+  The quantity of the expanded item. The maximum quantity is
+  2000.
   """
   quantity: Int!
 }
@@ -2579,11 +2746,13 @@ input ExpandedItemFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to the expanded item.
+A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
 """
 input ExpandedItemPriceAdjustment {
   """
-  The price adjustment for the expanded item.
+  The value of the price adjustment to apply to the expanded item.
   """
   adjustment: ExpandedItemPriceAdjustmentValue!
 }
@@ -2599,22 +2768,31 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-Transformations to apply to the Cart. In API versions 2023-10 and beyond, this
-type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
 
 """
-Transformations to apply to the Cart.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart.
 """
 input FunctionRunResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
@@ -2631,32 +2809,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2670,7 +2858,8 @@ Example value: `"gid://shopify/Product/10079785100"`
 scalar ID
 
 """
-The image of an object.
+An image that replaces the existing image for a single cart line item or group of cart line items.
+The image must have a publicly accessible URL.
 """
 input ImageInput {
   """
@@ -2681,33 +2870,46 @@ input ImageInput {
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The CartTransform containing the function.
+  A customization that changes the pricing and
+  presentation of items in a cart. For example,
+  you can modify the appearance of cart items,
+  such as updating titles and images,
+  or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartTransform: CartTransform!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -2717,7 +2919,7 @@ type Language {
 }
 
 """
-ISO 639-1 language codes supported by Shopify.
+Language codes supported by Shopify.
 """
 enum LanguageCode {
   """
@@ -2794,6 +2996,11 @@ enum LanguageCode {
   Chechen.
   """
   CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
 
   """
   Czech.
@@ -2874,6 +3081,11 @@ enum LanguageCode {
   Finnish.
   """
   FI
+
+  """
+  Filipino.
+  """
+  FIL
 
   """
   Faroese.
@@ -3226,6 +3438,16 @@ enum LanguageCode {
   RW
 
   """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
   Sindhi.
   """
   SD
@@ -3407,7 +3629,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3487,16 +3710,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3526,16 +3755,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3572,69 +3809,101 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
+"""
+An operation that merges multiple cart line items into a
+single line, representing a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
+"""
 input MergeOperation {
   """
-  The list of cart lines to merge.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
+  """
+  attributes: [AttributeOutput!] = []
+
+  """
+  The cart items to merge. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartLines: [CartLineInput!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The product variant that models the group of lines.
+  The [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  of the product variant that represents the collection of cart line items.
   """
   parentVariantId: ID!
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  The name of the group of lines to merge. If it isn't specified, it will use the parent_variant' name.
+  The title that replaces the existing title for a group of cart line items.
+  If you don't provide a title, then the title of the parent variant is used.
   """
   title: String
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -3664,6 +3933,11 @@ type MutationRoot {
   ): Void!
 }
 
+"""
+A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
+"""
 input PriceAdjustment {
   """
   The percentage price decrease of the price adjustment.
@@ -3679,55 +3953,78 @@ input PriceAdjustmentValue {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3738,27 +4035,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3769,62 +4078,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3912,25 +4240,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3947,32 +4285,41 @@ scalar TimeWithoutTimezone
 Represents an [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and
 [RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987)-compliant URI string.
 
-For example, `"https://johns-apparel.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
-(`johns-apparel.myshopify.com`).
+For example, `"https://example.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
+(`example.myshopify.com`).
 """
 scalar URL
 
 """
-A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+An operation that allows you to override the price, title,
+and image of a cart line item. Only stores on a
+[Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+can use apps with `update` operations.
 """
 input UpdateOperation {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The image override for the cart line item.
+  The image that replaces the existing image for the cart line item.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment for the cart line item.
+  A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+  price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+  for which the customer qualifies.
   """
   price: UpdateOperationPriceAdjustment
 
   """
-  The title override for the cart line item. If not provided, the variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
@@ -3988,7 +4335,9 @@ input UpdateOperationFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+for which the customer qualifies.
 """
 input UpdateOperationPriceAdjustment {
   """
@@ -3998,7 +4347,7 @@ input UpdateOperationPriceAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+The value of the price adjustment to apply to the updated item.
 """
 input UpdateOperationPriceAdjustmentValue @oneOf {
   """

--- a/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-js/shopify.extension.toml
+++ b/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-js/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "add-ons-demo"

--- a/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/schema.graphql
+++ b/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/schema.graphql
@@ -4,98 +4,150 @@ schema {
 }
 
 """
+Scale the Functions resource limits based on the field's length.
+"""
+directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
+
+"""
 Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  Key or name of the attribute.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the attribute. For example, `"true"`.
   """
   value: String
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The custom attributes associated with a cart line to store additional information. Cart attributes
+allow you to collect specific information from customers on the **Cart** page, such as order notes,
+gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
+"""
+input AttributeOutput {
+  """
+  The key of the cart line attribute to retrieve. For example, `"gift_wrapping"`.
+  """
+  key: String!
+
+  """
+  The value of the cart line attribute to retrieve. For example, `"true"`.
+  """
+  value: String!
+}
+
+"""
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  lines: [CartLine!]!
+  lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -105,50 +157,60 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 input CartLineInput {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
@@ -159,49 +221,84 @@ input CartLineInput {
 }
 
 """
-An operation to apply to the Cart.
+An operation to apply to the cart. For example, you can expand a cart line item to display
+its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+multiple cart lines into a single line representing a bundle, and update the presentation of line items
+in the cart to override their price, title, or image.
 """
 input CartOperation @oneOf {
+  """
+  An operation that expands a single cart line item to form a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
+  """
   expand: ExpandOperation
+
+  """
+  An operation that merges multiple cart line items into a
+  single line, representing a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
+  """
   merge: MergeOperation
 
   """
-  A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+  An operation that allows you to override the price, title,
+  and image of a cart line item. Only stores on a
+  [Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+  can use apps with `update` operations.
   """
   update: UpdateOperation
 }
 
 """
-A customization which applies cart transformations to the merchandise lines.
+A customization that changes the pricing and
+presentation of items in a cart. For example,
+you can modify the appearance of cart items,
+such as updating titles and images,
+or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
 """
 type CartTransform implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -226,16 +323,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -309,16 +414,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -336,7 +449,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1448,7 +1563,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -1579,9 +1694,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2391,7 +2505,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2400,43 +2517,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2446,27 +2571,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2476,22 +2606,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2524,46 +2662,75 @@ Example values: `"29.99"`, `"29.999"`.
 """
 scalar Decimal
 
+"""
+An operation that expands a single cart line item to form a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
+"""
 input ExpandOperation {
   """
-  The cart line id to expand.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The cart items to expand.
+  The cart items to expand. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+  bundle is a group of products that are sold together as a single unit.
   """
   expandedCartItems: [ExpandedItem!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  Title override. If title is not provided, variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
 
+"""
+The cart item to expand. Each item is a component of the
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+bundle is a group of products that are sold together as a single unit.
+"""
 input ExpandedItem {
   """
-  The merchandise id of the expanded item.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
+  """
+  attributes: [AttributeOutput!] = []
+
+  """
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant that represents the expanded item.
   """
   merchandiseId: ID!
 
   """
-  The price adjustment for the expanded item.
+  A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: ExpandedItemPriceAdjustment
 
   """
-  The quantity of the expanded item.The max quantity is 2000.
+  The quantity of the expanded item. The maximum quantity is
+  2000.
   """
   quantity: Int!
 }
@@ -2579,11 +2746,13 @@ input ExpandedItemFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to the expanded item.
+A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
 """
 input ExpandedItemPriceAdjustment {
   """
-  The price adjustment for the expanded item.
+  The value of the price adjustment to apply to the expanded item.
   """
   adjustment: ExpandedItemPriceAdjustmentValue!
 }
@@ -2599,22 +2768,31 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-Transformations to apply to the Cart. In API versions 2023-10 and beyond, this
-type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
 
 """
-Transformations to apply to the Cart.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart.
 """
 input FunctionRunResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
@@ -2631,32 +2809,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2670,7 +2858,8 @@ Example value: `"gid://shopify/Product/10079785100"`
 scalar ID
 
 """
-The image of an object.
+An image that replaces the existing image for a single cart line item or group of cart line items.
+The image must have a publicly accessible URL.
 """
 input ImageInput {
   """
@@ -2681,33 +2870,46 @@ input ImageInput {
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The CartTransform containing the function.
+  A customization that changes the pricing and
+  presentation of items in a cart. For example,
+  you can modify the appearance of cart items,
+  such as updating titles and images,
+  or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartTransform: CartTransform!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -2717,7 +2919,7 @@ type Language {
 }
 
 """
-ISO 639-1 language codes supported by Shopify.
+Language codes supported by Shopify.
 """
 enum LanguageCode {
   """
@@ -2794,6 +2996,11 @@ enum LanguageCode {
   Chechen.
   """
   CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
 
   """
   Czech.
@@ -2874,6 +3081,11 @@ enum LanguageCode {
   Finnish.
   """
   FI
+
+  """
+  Filipino.
+  """
+  FIL
 
   """
   Faroese.
@@ -3226,6 +3438,16 @@ enum LanguageCode {
   RW
 
   """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
   Sindhi.
   """
   SD
@@ -3407,7 +3629,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3487,16 +3710,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3526,16 +3755,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3572,69 +3809,101 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
+"""
+An operation that merges multiple cart line items into a
+single line, representing a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
+"""
 input MergeOperation {
   """
-  The list of cart lines to merge.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
+  """
+  attributes: [AttributeOutput!] = []
+
+  """
+  The cart items to merge. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartLines: [CartLineInput!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The product variant that models the group of lines.
+  The [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  of the product variant that represents the collection of cart line items.
   """
   parentVariantId: ID!
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  The name of the group of lines to merge. If it isn't specified, it will use the parent_variant' name.
+  The title that replaces the existing title for a group of cart line items.
+  If you don't provide a title, then the title of the parent variant is used.
   """
   title: String
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -3664,6 +3933,11 @@ type MutationRoot {
   ): Void!
 }
 
+"""
+A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
+"""
 input PriceAdjustment {
   """
   The percentage price decrease of the price adjustment.
@@ -3679,55 +3953,78 @@ input PriceAdjustmentValue {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3738,27 +4035,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3769,62 +4078,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3912,25 +4240,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3947,32 +4285,41 @@ scalar TimeWithoutTimezone
 Represents an [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and
 [RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987)-compliant URI string.
 
-For example, `"https://johns-apparel.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
-(`johns-apparel.myshopify.com`).
+For example, `"https://example.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
+(`example.myshopify.com`).
 """
 scalar URL
 
 """
-A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+An operation that allows you to override the price, title,
+and image of a cart line item. Only stores on a
+[Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+can use apps with `update` operations.
 """
 input UpdateOperation {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The image override for the cart line item.
+  The image that replaces the existing image for the cart line item.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment for the cart line item.
+  A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+  price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+  for which the customer qualifies.
   """
   price: UpdateOperationPriceAdjustment
 
   """
-  The title override for the cart line item. If not provided, the variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
@@ -3988,7 +4335,9 @@ input UpdateOperationFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+for which the customer qualifies.
 """
 input UpdateOperationPriceAdjustment {
   """
@@ -3998,7 +4347,7 @@ input UpdateOperationPriceAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+The value of the price adjustment to apply to the updated item.
 """
 input UpdateOperationPriceAdjustmentValue @oneOf {
   """

--- a/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/shopify.extension.toml
+++ b/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "optional-add-ons-rust"

--- a/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/src/run.rs
+++ b/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/src/run.rs
@@ -52,6 +52,7 @@ fn get_update_cart_operations(
                                 },
                             ),
                         }),
+                        attributes: None,
                     };
                     let expanded_cart_item = ExpandedItem {
                         merchandise_id: _warranty_variant_id.value.clone(),
@@ -67,6 +68,7 @@ fn get_update_cart_operations(
                                 },
                             ),
                         }),
+                        attributes: None,
                     };
                     let expand_operation = ExpandOperation {
                         cart_line_id: line.id.clone(),

--- a/sample-apps/payment-customizations/extensions/payment-customization-js/schema.graphql
+++ b/sample-apps/payment-customizations/extensions/payment-customization-js/schema.graphql
@@ -4,203 +4,261 @@ schema {
 }
 
 """
+Scale the Functions resource limits based on the field's length.
+"""
+directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
+
+"""
 Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  Key or name of the attribute.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the attribute. For example, `"true"`.
   """
   value: String
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  lines: [CartLine!]!
+  lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  cartLines: [CartLine!]!
+  cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -210,58 +268,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -286,16 +357,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -369,16 +448,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -396,7 +483,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1508,7 +1597,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -1639,9 +1728,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2451,7 +2539,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2460,43 +2551,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2506,27 +2605,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2536,22 +2640,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2589,13 +2701,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2606,12 +2722,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2652,8 +2768,9 @@ enum DeliveryMethod {
 }
 
 """
-The result of a payment method function. In API versions 2023-10 and beyond,
-this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target. The object contains the operations to
+apply to payment methods in checkout. In API versions 2023-10 and beyond, this
+type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
@@ -2663,7 +2780,7 @@ input FunctionResult {
 }
 
 """
-The result of a payment method function.
+The output of the Function run target. The object contains the operations to apply to payment methods in checkout.
 """
 input FunctionRunResult {
   """
@@ -2684,38 +2801,54 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
 
 """
-Request to hide a payment method.
+A request to hide a payment method during checkout.
+
+When your Function returns this operation, it removes the specified payment method
+from the available options shown to customers during checkout.
+
+Use this operation when you want to conditionally hide payment methods based on
+checkout attributes, customer data, or other business logic implemented in your Function.
 """
 input HideOperation {
   """
@@ -2732,40 +2865,58 @@ Example value: `"gid://shopify/Product/10079785100"`
 """
 scalar ID
 
+"""
+The `Input` object is the complete GraphQL schema that your Function can query
+as an input to customize the payment methods that are available to customers
+during checkout. Your Function receives only the fields that you request in the
+input query. To optimize performance, we highly recommend that you request only
+the fields that your function requires.
+"""
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The payment customization that owns the current function.
+  The configuration of the app that owns the Function. This configuration
+  controls how merchants can modify [payment methods](https://help.shopify.com/manual/checkout-settings/checkout-customization),
+  such as renaming, reordering, or hiding them.
   """
   paymentCustomization: PaymentCustomization!
 
   """
-  The list of payment methods.
+  The list of payment methods that are available to customers during checkout that your Function can customize.
   """
   paymentMethods: [PaymentCustomizationPaymentMethod!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -2775,7 +2926,7 @@ type Language {
 }
 
 """
-ISO 639-1 language codes supported by Shopify.
+Language codes supported by Shopify.
 """
 enum LanguageCode {
   """
@@ -2852,6 +3003,11 @@ enum LanguageCode {
   Chechen.
   """
   CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
 
   """
   Czech.
@@ -2932,6 +3088,11 @@ enum LanguageCode {
   Finnish.
   """
   FI
+
+  """
+  Filipino.
+  """
+  FIL
 
   """
   Faroese.
@@ -3284,6 +3445,16 @@ enum LanguageCode {
   RW
 
   """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
   Sindhi.
   """
   SD
@@ -3465,7 +3636,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3545,16 +3717,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3629,7 +3807,7 @@ type MailingAddress {
   phone: String
 
   """
-  The two-letter code for the region. For example, ON.
+  The alphanumeric code for the region. For example, ON.
   """
   provinceCode: String
 
@@ -3659,16 +3837,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3705,48 +3891,67 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
 
 """
-Request to move a payment method to a new index.
+A request to move a payment method to a new position in the checkout display order.
+
+When your Function returns this operation, it changes the display order of payment methods
+by placing the specified payment method at the requested index position.
+
+Use this operation when you want to prioritize certain payment methods based on
+checkout context, customer preferences, or other business logic implemented in your Function.
 """
 input MoveOperation {
   """
@@ -3790,17 +3995,36 @@ An operation to apply to the list of payment methods.
 """
 input Operation @oneOf {
   """
-  Request to hide a payment method.
+  A request to hide a payment method during checkout.
+
+  When your Function returns this operation, it removes the specified payment method
+  from the available options shown to customers during checkout.
+
+  Use this operation when you want to conditionally hide payment methods based on
+  checkout attributes, customer data, or other business logic implemented in your Function.
   """
   hide: HideOperation
 
   """
-  Request to move a payment method to a new index.
+  A request to move a payment method to a new position in the checkout display order.
+
+  When your Function returns this operation, it changes the display order of payment methods
+  by placing the specified payment method at the requested index position.
+
+  Use this operation when you want to prioritize certain payment methods based on
+  checkout context, customer preferences, or other business logic implemented in your Function.
   """
   move: MoveOperation
 
   """
-  Request to rename a payment method.
+  A request to change the displayed name of a payment method during checkout.
+
+  When your Function returns this operation, it replaces the default name of the
+  specified payment method with the custom name that's provided in the request.
+
+  Use this operation when you want to provide more context or clarity about
+  payment methods based on checkout details, locale, or other business logic
+  implemented in your Function.
   """
   rename: RenameOperation
 }
@@ -3810,16 +4034,24 @@ A customization representing how payment methods will be ordered, hidden, or ren
 """
 type PaymentCustomization implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3830,59 +4062,86 @@ type PaymentCustomizationPaymentMethod {
   Unique identifier for the payment method.
   """
   id: ID!
+
+  """
+  Name for the payment method.
+  """
   name: String!
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3893,27 +4152,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3924,62 +4195,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3999,7 +4289,14 @@ type PurchasingCompany {
 }
 
 """
-Request to rename a payment method.
+A request to change the displayed name of a payment method during checkout.
+
+When your Function returns this operation, it replaces the default name of the
+specified payment method with the custom name that's provided in the request.
+
+Use this operation when you want to provide more context or clarity about
+payment methods based on checkout details, locale, or other business logic
+implemented in your Function.
 """
 input RenameOperation {
   """
@@ -4082,25 +4379,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/sample-apps/payment-customizations/extensions/payment-customization-js/shopify.extension.toml
+++ b/sample-apps/payment-customizations/extensions/payment-customization-js/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "payment-customization-js"

--- a/sample-apps/payment-customizations/extensions/payment-customization-rust/schema.graphql
+++ b/sample-apps/payment-customizations/extensions/payment-customization-rust/schema.graphql
@@ -4,203 +4,261 @@ schema {
 }
 
 """
+Scale the Functions resource limits based on the field's length.
+"""
+directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
+
+"""
 Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  Key or name of the attribute.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the attribute. For example, `"true"`.
   """
   value: String
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  The costs that the buyer will pay at checkout.
+  A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+  the subtotal before taxes and duties, the tax amount, and duty charges.
   """
   cost: CartCost!
 
   """
-  A list of lines containing information about the items that can be delivered.
+  The items in a cart that are eligible for fulfillment and can be delivered to the customer.
   """
   deliverableLines: [DeliverableCartLine!]!
 
   """
-  The delivery groups available for the cart based on the buyer's shipping address.
+  A collection of items that are grouped by shared delivery characteristics. Delivery groups streamline
+  fulfillment by organizing items that can be shipped together, based on the customer's
+  shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+  together, then the items are included in the same delivery group.
   """
   deliveryGroups: [CartDeliveryGroup!]!
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  lines: [CartLine!]!
+  lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-The cost that the buyer will pay at checkout.
+A breakdown of the costs that the customer will pay at checkout. It includes the total amount,
+the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount, before taxes and discounts, for the customer to pay.
+  The amount for the customer to pay at checkout, excluding taxes and discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total amount for the customer to pay.
+  The total amount for the customer to pay at checkout.
   """
   totalAmount: MoneyV2!
 
   """
-  The duty amount for the customer to pay at checkout.
+  The duty charges for a customer to pay at checkout.
   """
   totalDutyAmount: MoneyV2
 
   """
-  The tax amount for the customer to pay at checkout.
+  The total tax amount for the customer to pay at checkout.
   """
   totalTaxAmount: MoneyV2
 }
 
 """
-Information about the options available for one or more line items to be delivered to a specific address.
+Information about items in a cart that are grouped by shared delivery characteristics.
+Delivery groups streamline fulfillment by organizing items that can be shipped together, based on the customer's
+shipping address. For example, if a customer orders a t-shirt and a pair of shoes that can be shipped
+together, then the items are included in the same delivery group.
 """
 type CartDeliveryGroup {
   """
-  A list of cart lines for the delivery group.
+  Information about items in a cart that a customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  cartLines: [CartLine!]!
+  cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
-  The destination address for the delivery group.
+  The shipping or destination address associated with the delivery group.
   """
   deliveryAddress: MailingAddress
 
   """
-  The delivery options available for the delivery group.
+  The delivery options available for the delivery group. Delivery options are the different ways that customers
+  can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
 
   """
-  Unique identifier for the delivery group.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the delivery group.
   """
   id: ID!
 
   """
-  Information about the delivery option the buyer has selected.
+  Information about the delivery option that the customer has selected.
   """
   selectedDeliveryOption: CartDeliveryOption
 }
 
 """
-Information about a delivery option.
+Information about a delivery option that's available for an item in a cart. Delivery options are the different
+ways that customers can choose to have their orders shipped. Examples include express shipping or standard
+shipping.
 """
 type CartDeliveryOption {
   """
-  The code of the delivery option.
+  A unique identifier that represents the delivery option offered to customers.
+  For example, `Canada Post Expedited`.
   """
   code: String
 
   """
-  The cost for the delivery option.
+  The amount that the customer pays if they select the delivery option.
   """
   cost: MoneyV2!
 
   """
-  The method for the delivery option.
+  The delivery method associated with the delivery option. A delivery method is a way that merchants can
+  fulfill orders from their online stores. Delivery methods include shipping to an address,
+  [local pickup](https://help.shopify.com/manual/fulfillment/setup/delivery-methods/pickup-in-store),
+  and shipping to a [pickup point](https://help.shopify.com/manual/fulfillment/shopify-shipping/pickup-points),
+  all of which are natively supported by Shopify checkout.
   """
   deliveryMethodType: DeliveryMethod!
 
   """
-  The description of the delivery option.
+  A single-line description of the delivery option, with HTML tags removed.
   """
   description: String
 
   """
-  The unique identifier of the delivery option.
+  A unique, human-readable identifier of the delivery option's title.
+  A handle can contain letters, hyphens (`-`), and numbers, but not spaces.
+  For example, `standard-shipping`.
   """
   handle: Handle!
 
   """
-  The title of the delivery option.
+  The name of the delivery option that displays to customers. The title is used to construct the delivery
+  option's handle. For example, if a delivery option is titled "Standard Shipping", then the handle is
+  `standard-shipping`.
   """
   title: String
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -210,58 +268,71 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -286,16 +357,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -369,16 +448,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -396,7 +483,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1508,7 +1597,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -1639,9 +1728,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2451,7 +2539,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2460,43 +2551,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2506,27 +2605,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2536,22 +2640,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2589,13 +2701,17 @@ Represents information about the merchandise in the cart.
 """
 type DeliverableCartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
@@ -2606,12 +2722,12 @@ type DeliverableCartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 }
@@ -2652,8 +2768,9 @@ enum DeliveryMethod {
 }
 
 """
-The result of a payment method function. In API versions 2023-10 and beyond,
-this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target. The object contains the operations to
+apply to payment methods in checkout. In API versions 2023-10 and beyond, this
+type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
@@ -2663,7 +2780,7 @@ input FunctionResult {
 }
 
 """
-The result of a payment method function.
+The output of the Function run target. The object contains the operations to apply to payment methods in checkout.
 """
 input FunctionRunResult {
   """
@@ -2684,38 +2801,54 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
 
 """
-Request to hide a payment method.
+A request to hide a payment method during checkout.
+
+When your Function returns this operation, it removes the specified payment method
+from the available options shown to customers during checkout.
+
+Use this operation when you want to conditionally hide payment methods based on
+checkout attributes, customer data, or other business logic implemented in your Function.
 """
 input HideOperation {
   """
@@ -2732,40 +2865,58 @@ Example value: `"gid://shopify/Product/10079785100"`
 """
 scalar ID
 
+"""
+The `Input` object is the complete GraphQL schema that your Function can query
+as an input to customize the payment methods that are available to customers
+during checkout. Your Function receives only the fields that you request in the
+input query. To optimize performance, we highly recommend that you request only
+the fields that your function requires.
+"""
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The payment customization that owns the current function.
+  The configuration of the app that owns the Function. This configuration
+  controls how merchants can modify [payment methods](https://help.shopify.com/manual/checkout-settings/checkout-customization),
+  such as renaming, reordering, or hiding them.
   """
   paymentCustomization: PaymentCustomization!
 
   """
-  The list of payment methods.
+  The list of payment methods that are available to customers during checkout that your Function can customize.
   """
   paymentMethods: [PaymentCustomizationPaymentMethod!]!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -2775,7 +2926,7 @@ type Language {
 }
 
 """
-ISO 639-1 language codes supported by Shopify.
+Language codes supported by Shopify.
 """
 enum LanguageCode {
   """
@@ -2852,6 +3003,11 @@ enum LanguageCode {
   Chechen.
   """
   CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
 
   """
   Czech.
@@ -2932,6 +3088,11 @@ enum LanguageCode {
   Finnish.
   """
   FI
+
+  """
+  Filipino.
+  """
+  FIL
 
   """
   Faroese.
@@ -3284,6 +3445,16 @@ enum LanguageCode {
   RW
 
   """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
   Sindhi.
   """
   SD
@@ -3465,7 +3636,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3545,16 +3717,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3629,7 +3807,7 @@ type MailingAddress {
   phone: String
 
   """
-  The two-letter code for the region. For example, ON.
+  The alphanumeric code for the region. For example, ON.
   """
   provinceCode: String
 
@@ -3659,16 +3837,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3705,48 +3891,67 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
 
 """
-Request to move a payment method to a new index.
+A request to move a payment method to a new position in the checkout display order.
+
+When your Function returns this operation, it changes the display order of payment methods
+by placing the specified payment method at the requested index position.
+
+Use this operation when you want to prioritize certain payment methods based on
+checkout context, customer preferences, or other business logic implemented in your Function.
 """
 input MoveOperation {
   """
@@ -3790,17 +3995,36 @@ An operation to apply to the list of payment methods.
 """
 input Operation @oneOf {
   """
-  Request to hide a payment method.
+  A request to hide a payment method during checkout.
+
+  When your Function returns this operation, it removes the specified payment method
+  from the available options shown to customers during checkout.
+
+  Use this operation when you want to conditionally hide payment methods based on
+  checkout attributes, customer data, or other business logic implemented in your Function.
   """
   hide: HideOperation
 
   """
-  Request to move a payment method to a new index.
+  A request to move a payment method to a new position in the checkout display order.
+
+  When your Function returns this operation, it changes the display order of payment methods
+  by placing the specified payment method at the requested index position.
+
+  Use this operation when you want to prioritize certain payment methods based on
+  checkout context, customer preferences, or other business logic implemented in your Function.
   """
   move: MoveOperation
 
   """
-  Request to rename a payment method.
+  A request to change the displayed name of a payment method during checkout.
+
+  When your Function returns this operation, it replaces the default name of the
+  specified payment method with the custom name that's provided in the request.
+
+  Use this operation when you want to provide more context or clarity about
+  payment methods based on checkout details, locale, or other business logic
+  implemented in your Function.
   """
   rename: RenameOperation
 }
@@ -3810,16 +4034,24 @@ A customization representing how payment methods will be ordered, hidden, or ren
 """
 type PaymentCustomization implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3830,59 +4062,86 @@ type PaymentCustomizationPaymentMethod {
   Unique identifier for the payment method.
   """
   id: ID!
+
+  """
+  Name for the payment method.
+  """
   name: String!
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3893,27 +4152,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3924,62 +4195,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3999,7 +4289,14 @@ type PurchasingCompany {
 }
 
 """
-Request to rename a payment method.
+A request to change the displayed name of a payment method during checkout.
+
+When your Function returns this operation, it replaces the default name of the
+specified payment method with the custom name that's provided in the request.
+
+Use this operation when you want to provide more context or clarity about
+payment methods based on checkout details, locale, or other business logic
+implemented in your Function.
 """
 input RenameOperation {
   """
@@ -4082,25 +4379,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield

--- a/sample-apps/payment-customizations/extensions/payment-customization-rust/shopify.extension.toml
+++ b/sample-apps/payment-customizations/extensions/payment-customization-rust/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "payment-customization-rust"

--- a/sample-apps/update-line-item/extensions/update-line-item-js/schema.graphql
+++ b/sample-apps/update-line-item/extensions/update-line-item-js/schema.graphql
@@ -4,113 +4,150 @@ schema {
 }
 
 """
+Scale the Functions resource limits based on the field's length.
+"""
+directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
+
+"""
 Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute.
+A custom property. Attributes are used to store additional information about a Shopify resource, such as
+products, customers, or orders. Attributes are stored as key-value pairs.
+
+For example, a list of attributes might include whether a customer is a first-time buyer (`"customer_first_order": "true"`),
+whether an order is gift-wrapped (`"gift_wrapped": "true"`), a preferred delivery date
+(`"preferred_delivery_date": "2025-10-01"`), the discount applied (`"loyalty_discount_applied": "10%"`), and any
+notes provided by the customer (`"customer_notes": "Please leave at the front door"`).
 """
 type Attribute {
   """
-  Key or name of the attribute.
+  The key or name of the attribute. For example, `"customer_first_order"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the attribute. For example, `"true"`.
   """
   value: String
 }
 
 """
-Key-value pairs that contains additional information.
+The custom attributes associated with a cart line to store additional information. Cart attributes
+allow you to collect specific information from customers on the **Cart** page, such as order notes,
+gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 """
 input AttributeOutput {
   """
-  Key or name of the attribute.
+  The key of the cart line attribute to retrieve. For example, `"gift_wrapping"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the cart line attribute to retrieve. For example, `"true"`.
   """
   value: String!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+Information about the customer that's interacting with the cart. It includes details such as the
+customer's email and phone number, and the total amount of money the customer has spent in the store.
+This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+are displayed to customers.
 """
 type BuyerIdentity {
   """
-  The customer associated with the cart.
+  The customer that's interacting with the cart. A customer is a buyer who has an
+  [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
   """
   customer: Customer
 
   """
-  The email address of the buyer that's interacting with the cart.
+  The email address of the customer that's interacting with the cart.
   """
   email: String
 
   """
-  Whether the buyer authenticated with a customer account.
+  Whether the customer is authenticated through their
+  [customer account](https://help.shopify.com/manual/customers/customer-accounts).
+  If the customer is authenticated, then the `customer` field returns the customer's information.
+  If the customer isn't authenticated, then the `customer` field returns `null`.
   """
   isAuthenticated: Boolean!
 
   """
-  The phone number of the buyer that's interacting with the cart.
+  The phone number of the customer that's interacting with the cart.
   """
   phone: String
 
   """
-  The purchasing company associated with the cart.
+  The company of a B2B customer that's interacting with the cart.
+  Used to manage and track purchases made by businesses rather than individual customers.
   """
   purchasingCompany: PurchasingCompany
 }
 
 """
-A cart represents the merchandise that a buyer intends to purchase, and the cost associated with the cart.
+The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+and information about the customer, such as the customer's email address and phone number.
 """
 type Cart {
   """
-  The attributes associated with the cart. Attributes are represented as key-value pairs.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  Information about the buyer that is interacting with the cart.
+  Information about the customer that's interacting with the cart. It includes details such as the
+  customer's email and phone number, and the total amount of money the customer has spent in the store.
+  This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
+  are displayed to customers.
   """
   buyerIdentity: BuyerIdentity
 
   """
-  A list of lines containing information about the items the customer intends to purchase.
+  The items in a cart that the customer intends to purchase. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
-  lines: [CartLine!]!
+  lines: [CartLine!]! @scaleLimits(rate: 0.005)
 }
 
 """
-Represents information about the merchandise in the cart.
+Information about an item in a cart that a customer intends to purchase. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLine {
   """
-  Retrieve a cart line attribute by key.
+  The custom attributes associated with a cart to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
-  Cart line attributes are also known as line item properties in Liquid.
+  Cart line attributes are equivalent to the
+  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  object in Liquid.
   """
   attribute(
     """
-    The key of the attribute to retrieve.
+    The key of the cart attribute to retrieve. For example, `"gift_wrapping"`.
     """
     key: String
   ): Attribute
 
   """
-  The cost of the merchandise line that the buyer will pay at checkout.
+  The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+  cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+  the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
 
@@ -120,50 +157,60 @@ type CartLine {
   id: ID!
 
   """
-  The merchandise that the buyer intends to purchase.
+  The item that the customer intends to purchase.
   """
   merchandise: Merchandise!
 
   """
-  The quantity of the merchandise that the customer intends to purchase.
+  The quantity of the item that the customer intends to purchase.
   """
   quantity: Int!
 
   """
-  The selling plan associated with the cart line and the effect that each
-  selling plan has on variants when they're purchased.
+  The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  associated with the cart line, including information about how a product variant can be sold and purchased.
   """
   sellingPlanAllocation: SellingPlanAllocation
 }
 
 """
-The cost of the merchandise line that the buyer will pay at checkout.
+The cost of an item in a cart that the customer intends to purchase. Cart lines are entries in the customer's
+cart that represent a single unit of a product variant. For example, if a customer adds two different sizes of
+the same t-shirt to their cart, then each size is represented as a separate cart line.
 """
 type CartLineCost {
   """
-  The amount of the merchandise line.
+  The cost of a single unit. For example, if a customer purchases three units of a product
+  that are priced at $10 each, then the `amountPerQuantity` is $10.
   """
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line.
+  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
+  is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
+  `null` when the value is hidden from buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
   """
-  The cost of the merchandise line before line-level discounts.
+  The cost of items in the cart before applying any discounts to certain items.
+  This amount serves as the starting point for calculating any potential savings customers
+  might receive through promotions or discounts.
   """
   subtotalAmount: MoneyV2!
 
   """
-  The total cost of the merchandise line.
+  The total cost of items in a cart.
   """
   totalAmount: MoneyV2!
 }
 
 input CartLineInput {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
@@ -174,56 +221,84 @@ input CartLineInput {
 }
 
 """
-An operation to apply to the Cart.
+An operation to apply to the cart. For example, you can expand a cart line item to display
+its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+multiple cart lines into a single line representing a bundle, and update the presentation of line items
+in the cart to override their price, title, or image.
 """
 input CartOperation @oneOf {
   """
-  A cart line expand operation.
+  An operation that expands a single cart line item to form a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   expand: ExpandOperation
 
   """
-  A cart line merge operation.
+  An operation that merges multiple cart line items into a
+  single line, representing a
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+  of components.
   """
   merge: MergeOperation
 
   """
-  A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+  An operation that allows you to override the price, title,
+  and image of a cart line item. Only stores on a
+  [Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+  can use apps with `update` operations.
   """
   update: UpdateOperation
 }
 
 """
-A customization which applies cart transformations to the merchandise lines.
+A customization that changes the pricing and
+presentation of items in a cart. For example,
+you can modify the appearance of cart items,
+such as updating titles and images,
+or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
 """
 type CartTransform implements HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the product is a member of the given collection.
+Whether the product is in the specified collection.
+
+A collection is a group of products that can be displayed in online stores and other sales channels in
+categories, which makes it easy for customers to find them. For example, an athletics store might create
+different collections for running attire and accessories.
 """
 type CollectionMembership {
   """
-  The ID of the collection.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the collection.
   """
   collectionId: ID!
 
   """
-  Whether the product is a member of the collection.
+  Whether the product is in the specified collection.
   """
   isMember: Boolean!
 }
@@ -248,16 +323,24 @@ type Company implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -331,16 +414,24 @@ type CompanyLocation implements HasMetafields {
   locale: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -358,7 +449,9 @@ type CompanyLocation implements HasMetafields {
 }
 
 """
-A country.
+The country for which the store is customized, reflecting local preferences and regulations.
+Localization might influence the language, currency, and product offerings available in a store to enhance
+the shopping experience for customers in that region.
 """
 type Country {
   """
@@ -1601,9 +1694,8 @@ enum CountryCode {
 }
 
 """
-The three-letter currency codes that represent the world currencies used in
-stores. These include standard ISO 4217 codes, legacy codes,
-and non-standard codes.
+The three-letter currency codes that represent the world currencies used in stores. Currency codes include
+[standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes, and non-standard codes.
 """
 enum CurrencyCode {
   """
@@ -2413,7 +2505,10 @@ enum CurrencyCode {
 }
 
 """
-A custom product.
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 type CustomProduct {
   """
@@ -2422,43 +2517,51 @@ type CustomProduct {
   isGiftCard: Boolean!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents a customer with the shop.
+Represents a [customer](https://help.shopify.com/manual/customers/manage-customers)
+who has an [account](https://help.shopify.com/manual/customers/customer-accounts) with the store.
+`Customer` returns data including the customer's contact information and order history.
 """
 type Customer implements HasMetafields {
   """
-  The total amount of money spent by the customer. Converted from the shop's
-  currency to the currency of the cart using a market rate.
+  The total amount that the customer has spent on orders.
+  The amount is converted from the shop's currency to the currency of the cart using a market rate.
   """
   amountSpent: MoneyV2!
 
   """
-  The customer’s name, email or phone number.
+  The full name of the customer, based on the values for `firstName` and `lastName`.
+  If `firstName` and `lastName` aren't specified, then the value is the customer's email address.
+  If the email address isn't specified, then the value is the customer's phone number.
   """
   displayName: String!
 
   """
-  The customer’s email address.
+  The customer's email address.
   """
   email: String
 
@@ -2468,27 +2571,32 @@ type Customer implements HasMetafields {
   firstName: String
 
   """
-  Whether the customer has any of the given tags.
+  Whether the customer is associated with any of the specified tags. The customer must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to search for.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with either the `VIP` or `Gold` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the customer has the given tags.
+  Whether the customer is associated with the specified tags. The customer must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the customer. For example,
+    `"VIP, Gold"` returns customers with both the `VIP` and `Gold` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A unique identifier for the customer.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the customer.
   """
   id: ID!
 
@@ -2498,22 +2606,30 @@ type Customer implements HasMetafields {
   lastName: String
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The number of orders made by the customer.
+  The total number of orders that the customer has made at the store.
   """
   numberOfOrders: Int!
 }
@@ -2547,53 +2663,74 @@ Example values: `"29.99"`, `"29.999"`.
 scalar Decimal
 
 """
-A cart line expand operation.
+An operation that expands a single cart line item to form a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input ExpandOperation {
   """
-  The cart line id to expand.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The cart items to expand.
+  The cart items to expand. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+  bundle is a group of products that are sold together as a single unit.
   """
   expandedCartItems: [ExpandedItem!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  Title override. If title is not provided, variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
 
+"""
+The cart item to expand. Each item is a component of the
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles). A
+bundle is a group of products that are sold together as a single unit.
+"""
 input ExpandedItem {
   """
-  The CartLine attributes to be added to component line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The merchandise id of the expanded item.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant that represents the expanded item.
   """
   merchandiseId: ID!
 
   """
-  The price adjustment for the expanded item.
+  A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: ExpandedItemPriceAdjustment
 
   """
-  The quantity of the expanded item.The max quantity is 2000.
+  The quantity of the expanded item. The maximum quantity is
+  2000.
   """
   quantity: Int!
 }
@@ -2609,11 +2746,13 @@ input ExpandedItemFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to the expanded item.
+A change to the original price of the expanded item. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
 """
 input ExpandedItemPriceAdjustment {
   """
-  The price adjustment for the expanded item.
+  The value of the price adjustment to apply to the expanded item.
   """
   adjustment: ExpandedItemPriceAdjustmentValue!
 }
@@ -2629,21 +2768,31 @@ input ExpandedItemPriceAdjustmentValue @oneOf {
 }
 
 """
-The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
 
 """
-The run target result.
+The output of the Function run target.
+The object contains the operations to change the pricing and presentation of items
+in a cart.
 """
 input FunctionRunResult {
   """
-  Cart operations to run on Cart.
+  The ordered list of operations to apply to the cart. For example, you can expand a cart line item to display
+  its [bundled items](https://shopify.dev/docs/apps/build/product-merchandising/bundles), merge
+  multiple cart lines into a single line representing a bundle, and update the presentation of line items
+  in the cart to override their price, title, or image.
   """
   operations: [CartOperation!]!
 }
@@ -2660,32 +2809,42 @@ Represents information about the metafields associated to the specified resource
 """
 interface HasMetafields {
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 }
 
 """
-Represents whether the current object has the given tag.
+Whether a Shopify resource, such as a product or customer, has a specified tag.
 """
 type HasTagResponse {
   """
-  Whether the current object has the tag.
+  Whether the Shopify resource has the tag.
   """
   hasTag: Boolean!
 
   """
-  The tag.
+  A searchable keyword that's associated with a Shopify resource, such as a product or customer. For example,
+  a merchant might apply the `sports` and `summer` tags to products that are associated with sportswear for
+  summer.
   """
   tag: String!
 }
@@ -2699,7 +2858,8 @@ Example value: `"gid://shopify/Product/10079785100"`
 scalar ID
 
 """
-The image of an object.
+An image that replaces the existing image for a single cart line item or group of cart line items.
+The image must have a publicly accessible URL.
 """
 input ImageInput {
   """
@@ -2710,33 +2870,46 @@ input ImageInput {
 
 type Input {
   """
-  The cart.
+  The cart where the Function is running. A cart contains the merchandise that a customer intends to purchase
+  and information about the customer, such as the customer's email address and phone number.
   """
   cart: Cart!
 
   """
-  The CartTransform containing the function.
+  A customization that changes the pricing and
+  presentation of items in a cart. For example,
+  you can modify the appearance of cart items,
+  such as updating titles and images,
+  or [bundling items](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartTransform: CartTransform!
 
   """
-  The localization of the Function execution context.
+  The regional and language settings that determine how the Function
+  handles currency, numbers, dates, and other locale-specific values
+  during discount calculations. These settings are based on the store's configured
+  [localization practices](https://shopify.dev/docs/apps/build/functions/localization-practices-shopify-functions).
   """
   localization: Localization!
 
   """
-  The conversion rate between the shop's currency and the currency of the cart.
+  The exchange rate used to convert discounts between the shop's default
+  currency and the currency that displays to the customer during checkout.
+  For example, if a store operates in USD but a customer is viewing discounts in EUR,
+  then the presentment currency rate handles this conversion for accurate pricing.
   """
   presentmentCurrencyRate: Decimal!
 
   """
-  Information about the shop.
+  Information about the shop where the Function is running, including the shop's timezone
+  setting and associated [metafields](https://shopify.dev/docs/apps/build/custom-data).
   """
   shop: Shop!
 }
 
 """
-A language.
+The language for which the store is customized, ensuring content is tailored to local customers.
+This includes product descriptions and customer communications that resonate with the target audience.
 """
 type Language {
   """
@@ -2746,7 +2919,7 @@ type Language {
 }
 
 """
-ISO 639-1 language codes supported by Shopify.
+Language codes supported by Shopify.
 """
 enum LanguageCode {
   """
@@ -2823,6 +2996,11 @@ enum LanguageCode {
   Chechen.
   """
   CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
 
   """
   Czech.
@@ -2903,6 +3081,11 @@ enum LanguageCode {
   Finnish.
   """
   FI
+
+  """
+  Filipino.
+  """
+  FIL
 
   """
   Faroese.
@@ -3255,6 +3438,16 @@ enum LanguageCode {
   RW
 
   """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
   Sindhi.
   """
   SD
@@ -3436,7 +3629,8 @@ enum LanguageCode {
 }
 
 """
-Represents limited information about the current time relative to the parent object.
+The current time based on the
+[store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
 """
 type LocalTime {
   """
@@ -3516,16 +3710,22 @@ type LocalTime {
 }
 
 """
-Information about the localized experiences configured for the shop.
+Details about the localized experience for the store in a specific region, including country and language
+settings. The localized experience is determined by the store's settings and the customer's location.
+Localization ensures that customers can access relevant content and options while browsing or purchasing
+products in a store.
 """
 type Localization {
   """
-  The country of the active localized experience.
+  The country for which the store is customized, reflecting local preferences and regulations.
+  Localization might influence the language, currency, and product offerings available in a store to enhance
+  the shopping experience for customers in that region.
   """
   country: Country!
 
   """
-  The language of the active localized experience.
+  The language for which the store is customized, ensuring content is tailored to local customers.
+  This includes product descriptions and customer communications that resonate with the target audience.
   """
   language: Language!
 
@@ -3555,16 +3755,24 @@ type Market implements HasMetafields {
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3601,77 +3809,101 @@ type MarketRegionCountry implements MarketRegion {
 }
 
 """
-The merchandise to be purchased at checkout.
+The item that a customer intends to purchase. Merchandise can be a product variant or a custom
+product.
+
+A product variant is a specific version of a product that comes in more than one option, such as size or color.
+For example, if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be
+one product variant and a large, blue t-shirt would be another.
+
+A custom product represents a product that doesn't map to Shopify's
+[standard product categories](https://help.shopify.com/manual/products/details/product-type).
+For example, you can use a custom product to manage gift cards, shipping requirements, localized product
+information, or weight measurements and conversions.
 """
 union Merchandise = CustomProduct | ProductVariant
 
 """
-A cart line merge operation.
+An operation that merges multiple cart line items into a
+single line, representing a
+[bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
+of components.
 """
 input MergeOperation {
   """
-  The CartLine attributes to be added to the parent line.
+  The custom attributes associated with a cart line to store additional information. Cart attributes
+  allow you to collect specific information from customers on the **Cart** page, such as order notes,
+  gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
   """
   attributes: [AttributeOutput!] = []
 
   """
-  The list of cart lines to merge.
+  The cart items to merge. Each item in the list is a component of the
+  [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles).
   """
   cartLines: [CartLineInput!]!
 
   """
-  The image of the group.
+  The image that replaces the existing image for the group of cart line items.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The product variant that models the group of lines.
+  The [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  of the product variant that represents the collection of cart line items.
   """
   parentVariantId: ID!
 
   """
-  The price adjustment to the group.
+  A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+  affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+  or any price changes that the customer qualifies for.
   """
   price: PriceAdjustment
 
   """
-  The name of the group of lines to merge. If it isn't specified, it will use the parent_variant' name.
+  The title that replaces the existing title for a group of cart line items.
+  If you don't provide a title, then the title of the parent variant is used.
   """
   title: String
 }
 
 """
-[Metafields](https://shopify.dev/apps/metafields)
-enable you to attach additional information to a
-Shopify resource, such as a [Product](https://shopify.dev/api/admin-graphql/latest/objects/product)
-or a [Collection](https://shopify.dev/api/admin-graphql/latest/objects/collection).
-For more information about the Shopify resources that you can attach metafields to, refer to
-[HasMetafields](https://shopify.dev/api/admin/graphql/reference/common-objects/HasMetafields).
+[Custom fields](https://shopify.dev/docs/apps/build/custom-data) that store additional information
+about a Shopify resource, such as products, orders, and
+[many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+enables you to customize the checkout experience.
 """
 type Metafield {
   """
-  The type of data that the metafield stores in the `value` field.
-  Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
+  The [type of data](https://shopify.dev/apps/metafields/types) that the metafield stores in
+  the `value` field.
   """
   type: String!
 
   """
-  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  The data that's stored in the metafield. The data is always stored as a string,
+  regardless of the [metafield's type](https://shopify.dev/apps/metafields/types).
   """
   value: String!
 }
 
 """
-A monetary value with currency.
+A precise monetary value and its associated currency. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
-  Decimal money amount.
+  A monetary value in decimal format, allowing for precise representation of cents or fractional
+  currency. For example, 12.99.
   """
   amount: Decimal!
 
   """
-  Currency of the money.
+  The three-letter currency code that represents a world currency used in a store. Currency codes
+  include standard [standard ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217), legacy codes,
+  and non-standard codes. For example, USD.
   """
   currencyCode: CurrencyCode!
 }
@@ -3701,6 +3933,11 @@ type MutationRoot {
   ): Void!
 }
 
+"""
+A change to the original price of a group of items. Price adjustments include discounts or additional charges that
+affect the final price the customer pays. Price adjustments are often used for promotions, special offers,
+or any price changes that the customer qualifies for.
+"""
 input PriceAdjustment {
   """
   The percentage price decrease of the price adjustment.
@@ -3716,55 +3953,78 @@ input PriceAdjustmentValue {
 }
 
 """
-Represents a product.
+The goods and services that merchants offer to customers. Products can include details such as
+title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
+Products can be organized by grouping them into a collection.
+
+Learn more about [managing products in a merchant's store](https://help.shopify.com/manual/products).
 """
 type Product implements HasMetafields {
   """
-  A unique human-friendly string of the product's title.
+  A unique, human-readable string of the product's title. A handle can contain letters, hyphens (`-`), and
+  numbers, but not spaces. The handle is used in the online store URL for the product. For example, if a product
+  is titled "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   handle: Handle!
 
   """
-  Whether the product has any of the given tags.
+  Whether the product is associated with any of the specified tags. The product must have at least one tag
+  from the list to return `true`.
   """
   hasAnyTag(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with either the `sports` or `summer` tag.
     """
     tags: [String!]! = []
   ): Boolean!
 
   """
-  Whether the product has the given tags.
+  Whether the product is associated with the specified tags. The product must have all of the tags in the list
+  to return `true`.
   """
   hasTags(
     """
-    The tags to check.
+    A comma-separated list of searchable keywords that are associated with the product. For example,
+    `"sports, summer"` returns products with both the `sports` and `summer` tags.
     """
     tags: [String!]! = []
   ): [HasTagResponse!]!
 
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product.
   """
   id: ID!
 
   """
-  Whether the product is in any of the given collections.
+  Whether the product is in any of the specified collections. The product must be in at least one collection
+  from the list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inAnyCollection(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): Boolean!
 
   """
-  Whether the product is in the given collections.
+  Whether the product is in the specified collections. The product must be in all of the collections in the
+  list to return `true`.
+
+  A collection is a group of products that can be displayed in online stores and other sales channels in
+  categories, which makes it easy for customers to find them. For example, an athletics store might create
+  different collections for running attire and accessories.
   """
   inCollections(
     """
-    The IDs of the collections to check.
+    A comma-separated list of [globally-unique collection IDs](https://shopify.dev/docs/api/usage/gids)
+    that are associated with the product. For example, `gid://shopify/Collection/123`, `gid://shopify/Collection/456`.
     """
     ids: [ID!]! = []
   ): [CollectionMembership!]!
@@ -3775,27 +4035,39 @@ type Product implements HasMetafields {
   isGiftCard: Boolean!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product type specified by the merchant.
+  A custom category for a product. Product types allow merchants to define categories other than the
+  ones available in Shopify's
+  [standard product categories](https://help.shopify.com/manual/products/details/product-type).
   """
   productType: String
 
   """
-  The localized title of the product in the customer’s locale.
+  The localized name for the product that displays to customers. The title is used to construct the product's
+  handle, which is a unique, human-readable string of the product's title. For example, if a product is titled
+  "Black Sunglasses", then the handle is `black-sunglasses`.
   """
   title: String!
 
@@ -3806,62 +4078,81 @@ type Product implements HasMetafields {
 }
 
 """
-Represents a product variant.
+A specific version of a product that comes in more than one option, such as size or color. For example,
+if a merchant sells t-shirts with options for size and color, then a small, blue t-shirt would be one
+product variant and a large, blue t-shirt would be another.
 """
 type ProductVariant implements HasMetafields {
   """
-  A globally-unique identifier.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for the product variant.
   """
   id: ID!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
 
   """
-  The product that this variant belongs to.
+  The product associated with the product variant. For example, if a
+  merchant sells t-shirts with options for size and color, then a small,
+  blue t-shirt would be one product variant and a large, blue t-shirt would be another.
+  The product associated with the product variant would be the t-shirt itself.
   """
   product: Product!
 
   """
-  Whether the merchandise requires shipping.
+  Whether the item needs to be shipped to the customer. For example, a
+  digital gift card doesn't need to be shipped, but a t-shirt does
+  need to be shipped.
   """
   requiresShipping: Boolean!
 
   """
-  An identifier for the product variant in the shop. Required in order to connect to a fulfillment service.
+  A case-sensitive identifier for the product variant in the merchant's store. For example, `"BBC-1"`.
+  A product variant must have a SKU to be connected to a
+  [fulfillment service](https://shopify.dev/docs/apps/build/orders-fulfillment/fulfillment-service-apps/build-for-fulfillment-services).
   """
   sku: String
 
   """
-  The localized title of the product variant in the customer’s locale.
+  The localized name for the product variant that displays to customers.
   """
   title: String
 
   """
-  The weight of the product variant in the unit system specified with `weight_unit`.
+  The product variant's weight, in the system of measurement set in the `weightUnit` field.
   """
   weight: Float
 
   """
-  Unit of measurement for weight.
+  The unit of measurement for weight.
   """
   weightUnit: WeightUnit!
 }
 
 """
-Represents information about the buyer that is interacting with the cart.
+The company of a B2B customer that's interacting with the cart.
+Used to manage and track purchases made by businesses rather than individual customers.
 """
 type PurchasingCompany {
   """
@@ -3949,25 +4240,35 @@ type SellingPlanAllocationPriceAdjustment {
 }
 
 """
-Information about the shop.
+Information about the store, including the store's timezone setting
+and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 """
 type Shop implements HasMetafields {
   """
-  Information about the current time relative to the shop's timezone setting.
+  The current time based on the
+  [store's timezone setting](https://help.shopify.com/manual/intro-to-shopify/initial-setup/setup-business-settings).
   """
   localTime: LocalTime!
 
   """
-  Returns a metafield by namespace and key that belongs to the resource.
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
   """
   metafield(
     """
-    The key for the metafield.
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
     """
     key: String!
 
     """
-    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
     """
     namespace: String
   ): Metafield
@@ -3984,32 +4285,41 @@ scalar TimeWithoutTimezone
 Represents an [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and
 [RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987)-compliant URI string.
 
-For example, `"https://johns-apparel.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
-(`johns-apparel.myshopify.com`).
+For example, `"https://example.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
+(`example.myshopify.com`).
 """
 scalar URL
 
 """
-A cart line update operation. Only stores on the Shopify Plus plan can use apps with update operations.
+An operation that allows you to override the price, title,
+and image of a cart line item. Only stores on a
+[Shopify Plus plan](https://help.shopify.com/manual/intro-to-shopify/pricing-plans/plans-features/shopify-plus-plan)
+can use apps with `update` operations.
 """
 input UpdateOperation {
   """
-  The ID of the cart line.
+  A [globally-unique ID](https://shopify.dev/docs/api/usage/gids)
+  for a line item in a cart. A cart line represents a single unit of a
+  product variant that a customer intends to purchase.
   """
   cartLineId: ID!
 
   """
-  The image override for the cart line item.
+  The image that replaces the existing image for the cart line item.
+  The image must have a publicly accessible URL.
   """
   image: ImageInput
 
   """
-  The price adjustment for the cart line item.
+  A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+  price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+  for which the customer qualifies.
   """
   price: UpdateOperationPriceAdjustment
 
   """
-  The title override for the cart line item. If not provided, the variant title is used.
+  The title that replaces the existing title for the cart line item.
+  If you don't provide a title, then the title of the product variant is used.
   """
   title: String
 }
@@ -4025,7 +4335,9 @@ input UpdateOperationFixedPricePerUnitAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+A change to an item's original price. Price adjustments include discounts or additional charges that affect the final
+price the customer pays. Price adjustments are often used for promotions, special offers, or any price changes
+for which the customer qualifies.
 """
 input UpdateOperationPriceAdjustment {
   """
@@ -4035,7 +4347,7 @@ input UpdateOperationPriceAdjustment {
 }
 
 """
-A price adjustment to apply to a cart line item.
+The value of the price adjustment to apply to the updated item.
 """
 input UpdateOperationPriceAdjustmentValue @oneOf {
   """


### PR DESCRIPTION
We have been polishing many of schema descriptions over the last few weeks. 

Content:
- Update some sample-apps from 2024-01 to 2024-04 (2024-01 is no longer available).
- Pull fresh schema for all extensions.
- Fix a missing required 'attributes' field for optional-add-ons-cart-transform

These updates have already made their way to shopify.dev. This process was automated. The automation should be moved into this repository for further use, not included as part of this PR. 

