### PR TITLE
Add missing toml description attributes

### DIFF
--- a/order-routing/javascript/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/javascript/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -4,6 +4,7 @@ api_version = "unstable"
 name = "t:name"
 handle = "{{handle}}"
 type = "function"
+description = "t:description"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
   [[extensions.targeting]]

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -4,6 +4,7 @@ api_version = "unstable"
 name = "t:name"
 handle = "{{handle}}"
 type = "function"
+description = "t:description"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
   [[extensions.targeting]]

--- a/order-routing/rust/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -4,6 +4,7 @@ api_version = "unstable"
 name = "t:name"
 handle = "{{handle}}"
 type = "function"
+description = "t:description"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
   [[extensions.targeting]]

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -4,6 +4,7 @@ api_version = "unstable"
 name = "t:name"
 handle = "{{handle}}"
 type = "function"
+description = "t:description"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
 [[extensions.targeting]]

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -4,6 +4,7 @@ api_version = "unstable"
 name = "t:name"
 handle = "{{handle}}"
 type = "function"
+description = "t:description"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
   [[extensions.targeting]]

--- a/order-routing/wasm/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/wasm/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -4,6 +4,7 @@ api_version = "unstable"
 name = "t:name"
 handle = "{{handle}}"
 type = "function"
+description = "t:description"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
   [[extensions.targeting]]

--- a/order-routing/wasm/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/wasm/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -4,6 +4,7 @@ api_version = "unstable"
 name = "t:name"
 handle = "{{handle}}"
 type = "function"
+description = "t:description"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
   [[extensions.targeting]]


### PR DESCRIPTION
These `t:description` do exist in the locale file, so I can only presume this was the original intent.