### PR TITLE
Regenerate schemas

### DIFF
--- a/discounts/javascript/discount/default/schema.graphql
+++ b/discounts/javascript/discount/default/schema.graphql
@@ -3372,7 +3372,7 @@ type Input {
 
   """
   The discount node that owns the [Shopify
-  Function](https://shopify.dev/docs/apps/build/functions)). Discounts are a way
+  Function](https://shopify.dev/docs/apps/build/functions). Discounts are a way
   for merchants to promote sales and special offers, or as customer loyalty
   rewards. A single discount can be automatic or code-based, and can be applied
   to a cart lines, orders, and delivery.

--- a/discounts/rust/discount/default/schema.graphql
+++ b/discounts/rust/discount/default/schema.graphql
@@ -3478,7 +3478,7 @@ type Input {
 
   """
   The discount node that owns the [Shopify
-  Function](https://shopify.dev/docs/apps/build/functions)). Discounts are a way
+  Function](https://shopify.dev/docs/apps/build/functions). Discounts are a way
   for merchants to promote sales and special offers, or as customer loyalty
   rewards. A single discount can be automatic or code-based, and can be applied
   to a cart lines, orders, and delivery.


### PR DESCRIPTION
Minor regeneration refresh. 

Description contained a typo in the discount schema.