### PR TITLE
Explicitly specify the @shopify/shopify_function NPM package as a dependency

### DIFF
--- a/checkout/javascript/cart-checkout-validation/default/package.json.liquid
+++ b/checkout/javascript/cart-checkout-validation/default/package.json.liquid
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
+  },
+  "dependencies": {
+    "@shopify/shopify_function": "~1.0.0"
   }
 }

--- a/checkout/javascript/cart-transform/default/package.json.liquid
+++ b/checkout/javascript/cart-transform/default/package.json.liquid
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
+  },
+  "dependencies": {
+    "@shopify/shopify_function": "~1.0.0"
   }
 }

--- a/checkout/javascript/delivery-customization/default/package.json.liquid
+++ b/checkout/javascript/delivery-customization/default/package.json.liquid
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
+  },
+  "dependencies": {
+    "@shopify/shopify_function": "~1.0.0"
   }
 }

--- a/checkout/javascript/payment-customization/default/package.json.liquid
+++ b/checkout/javascript/payment-customization/default/package.json.liquid
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
+  },
+  "dependencies": {
+    "@shopify/shopify_function": "~1.0.0"
   }
 }

--- a/discounts/javascript/discount/default/package.json.liquid
+++ b/discounts/javascript/discount/default/package.json.liquid
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
+  },
+  "dependencies": {
+    "@shopify/shopify_function": "~1.0.0"
   }
 }

--- a/discounts/javascript/discounts-allocator/default/package.json.liquid
+++ b/discounts/javascript/discounts-allocator/default/package.json.liquid
@@ -28,6 +28,7 @@
     "vitest": "^0.29.8"
   },
   "dependencies": {
-    "decimal.js": "^10.4.3"
+    "decimal.js": "^10.4.3",
+    "@shopify/shopify_function": "~1.0.0"
   }
 }

--- a/discounts/javascript/order-discounts/default/package.json.liquid
+++ b/discounts/javascript/order-discounts/default/package.json.liquid
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
+  },
+  "dependencies": {
+    "@shopify/shopify_function": "~1.0.0"
   }
 }

--- a/discounts/javascript/product-discounts/default/package.json.liquid
+++ b/discounts/javascript/product-discounts/default/package.json.liquid
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
+  },
+  "dependencies": {
+    "@shopify/shopify_function": "~1.0.0"
   }
 }

--- a/discounts/javascript/shipping-discounts/default/package.json.liquid
+++ b/discounts/javascript/shipping-discounts/default/package.json.liquid
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
+  },
+  "dependencies": {
+    "@shopify/shopify_function": "~1.0.0"
   }
 }

--- a/order-routing/javascript/fulfillment-constraints/default/package.json.liquid
+++ b/order-routing/javascript/fulfillment-constraints/default/package.json.liquid
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
+  },
+  "dependencies": {
+    "@shopify/shopify_function": "~1.0.0"
   }
 }

--- a/order-routing/javascript/local-pickup-delivery-option-generators/default/package.json.liquid
+++ b/order-routing/javascript/local-pickup-delivery-option-generators/default/package.json.liquid
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
+  },
+  "dependencies": {
+    "@shopify/shopify_function": "~1.0.0"
   }
 }

--- a/order-routing/javascript/location-rules/default/package.json.liquid
+++ b/order-routing/javascript/location-rules/default/package.json.liquid
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
+  },
+  "dependencies": {
+    "@shopify/shopify_function": "~1.0.0"
   }
 }

--- a/order-routing/javascript/pickup-point-delivery-option-generators/default/package.json.liquid
+++ b/order-routing/javascript/pickup-point-delivery-option-generators/default/package.json.liquid
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
+  },
+  "dependencies": {
+    "@shopify/shopify_function": "~1.0.0"
   }
 }

--- a/order-routing/typescript/pickup-point-delivery-option-generators/default/package.json.liquid
+++ b/order-routing/typescript/pickup-point-delivery-option-generators/default/package.json.liquid
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "vitest": "^0.29.8"
+  },
+  "dependencies": {
+    "@shopify/shopify_function": "~1.0.0"
   }
 }


### PR DESCRIPTION
In order to ensure that JS templates are always compatible with the JS NPM package used, they should explicitly be defined in the templates instead of the CLI automatically installing the latest version.