### PR TITLE
Update to use latest shopify_function crate APIs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -26,7 +26,7 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Run tests
         run: cargo test
-      - name: Add wasm32-wasip1 target
-        run: rustup target add wasm32-wasip1
-      - name: Build with wasm32-wasip1 target
-        run: cargo build --release --target wasm32-wasip1
+      - name: Add wasm32-unknown-unknown target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Build with wasm32-unknown-unknown target
+        run: cargo build --release --target wasm32-unknown-unknown

--- a/checkout/rust/cart-checkout-validation/default/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-checkout-validation/default/shopify.extension.toml.liquid
@@ -13,7 +13,7 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = ["src/**/*.rs"]
 

--- a/checkout/rust/cart-checkout-validation/default/src/main.rs
+++ b/checkout/rust/cart-checkout-validation/default/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/checkout/rust/cart-transform/bundles/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-transform/bundles/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/bundles_cart_transform.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/bundles_cart_transform.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/checkout/rust/cart-transform/bundles/src/main.rs
+++ b/checkout/rust/cart-transform/bundles/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/checkout/rust/cart-transform/default/shopify.extension.toml.liquid
+++ b/checkout/rust/cart-transform/default/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/checkout/rust/cart-transform/default/src/main.rs
+++ b/checkout/rust/cart-transform/default/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/checkout/rust/delivery-customization/default/shopify.extension.toml.liquid
+++ b/checkout/rust/delivery-customization/default/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/checkout/rust/delivery-customization/default/src/main.rs
+++ b/checkout/rust/delivery-customization/default/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/checkout/rust/payment-customization/default/shopify.extension.toml.liquid
+++ b/checkout/rust/payment-customization/default/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/checkout/rust/payment-customization/default/src/main.rs
+++ b/checkout/rust/payment-customization/default/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/discounts/rust/discount/default/README.md
+++ b/discounts/rust/discount/default/README.md
@@ -10,7 +10,7 @@
 You can build this individual function using `cargo build`.
 
 ```shell
-cargo build --target=wasm32-wasip1 --release
+cargo build --target=wasm32-unknown-unknown --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/discounts/rust/discount/default/shopify.extension.toml.liquid
+++ b/discounts/rust/discount/default/shopify.extension.toml.liquid
@@ -18,6 +18,6 @@ description = "t:description"
   export = "cart_delivery_options_discounts_generate_run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]

--- a/discounts/rust/discount/default/src/main.rs
+++ b/discounts/rust/discount/default/src/main.rs
@@ -1,8 +1,9 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod cart_delivery_options_discounts_generate_run;
 pub mod cart_lines_discounts_generate_run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/discounts/rust/discounts-allocator/default/README.md
+++ b/discounts/rust/discounts-allocator/default/README.md
@@ -10,7 +10,7 @@
 You can build this individual function using `cargo build`.
 
 ```shell
-cargo build --target=wasm32-wasip1 --release
+cargo build --target=wasm32-unknown-unknown --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/discounts/rust/discounts-allocator/default/shopify.extension.toml.liquid
+++ b/discounts/rust/discounts-allocator/default/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/discounts/rust/discounts-allocator/default/src/main.rs
+++ b/discounts/rust/discounts-allocator/default/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/discounts/rust/order-discounts/default/README.md
+++ b/discounts/rust/order-discounts/default/README.md
@@ -10,7 +10,7 @@
 You can build this individual function using `cargo build`.
 
 ```shell
-cargo build --target=wasm32-wasip1 --release
+cargo build --target=wasm32-unknown-unknown --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/discounts/rust/order-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/order-discounts/default/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/discounts/rust/order-discounts/default/src/main.rs
+++ b/discounts/rust/order-discounts/default/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/discounts/rust/product-discounts/default/README.md
+++ b/discounts/rust/product-discounts/default/README.md
@@ -10,7 +10,7 @@
 You can build this individual function using `cargo build`.
 
 ```shell
-cargo build --target=wasm32-wasip1 --release
+cargo build --target=wasm32-unknown-unknown --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/discounts/rust/product-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/product-discounts/default/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/discounts/rust/product-discounts/default/src/main.rs
+++ b/discounts/rust/product-discounts/default/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/discounts/rust/shipping-discounts/default/README.md
+++ b/discounts/rust/shipping-discounts/default/README.md
@@ -10,7 +10,7 @@
 You can build this individual function using `cargo build`.
 
 ```shell
-cargo build --target=wasm32-wasip1 --release
+cargo build --target=wasm32-unknown-unknown --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/discounts/rust/shipping-discounts/default/shopify.extension.toml.liquid
+++ b/discounts/rust/shipping-discounts/default/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/discounts/rust/shipping-discounts/default/src/main.rs
+++ b/discounts/rust/shipping-discounts/default/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/fulfillment-constraints/default/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/order-routing/rust/fulfillment-constraints/default/src/main.rs
+++ b/order-routing/rust/fulfillment-constraints/default/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/order-routing/rust/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/local-pickup-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/order-routing/rust/local-pickup-delivery-option-generators/default/src/main.rs
+++ b/order-routing/rust/local-pickup-delivery-option-generators/default/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/order-routing/rust/location-rules/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/location-rules/default/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/order-routing/rust/location-rules/default/src/main.rs
+++ b/order-routing/rust/location-rules/default/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/shopify.extension.toml.liquid
@@ -18,8 +18,8 @@ input_query = "src/run.graphql"
 export = "run"
 
 [extensions.build]
-command = "cargo build --target=wasm32-wasip1 --release"
-path = "target/wasm32-wasip1/release/{{handle | replace: " ", "_" | downcase}}.wasm"
+command = "cargo build --target=wasm32-unknown-unknown --release"
+path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "_" | downcase}}.wasm"
 watch = ["src/**/*.rs"]
 
 [extensions.ui.paths]

--- a/order-routing/rust/pickup-point-delivery-option-generators/default/src/main.rs
+++ b/order-routing/rust/pickup-point-delivery-option-generators/default/src/main.rs
@@ -1,8 +1,9 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod fetch;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/shopify.extension.toml
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/shopify.extension.toml
@@ -11,6 +11,6 @@ type = "function"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/bundle_cart_transform.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/bundle_cart_transform.wasm"
   watch = [ "src/**/*.rs" ]

--- a/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/src/main.rs
+++ b/sample-apps/bundles-cart-transform/extensions/cart-merge-expand_rust/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/sample-apps/bundles-price-per-component/extensions/price-per-component-rs/shopify.extension.toml
+++ b/sample-apps/bundles-price-per-component/extensions/price-per-component-rs/shopify.extension.toml
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/cart-transform-3-rust.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/cart-transform-3-rust.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/sample-apps/bundles-price-per-component/extensions/price-per-component-rs/src/main.rs
+++ b/sample-apps/bundles-price-per-component/extensions/price-per-component-rs/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/sample-apps/delivery-customizations/extensions/delivery-customization-rust/shopify.extension.toml
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization-rust/shopify.extension.toml
@@ -12,8 +12,8 @@ type = "function"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/delivery-customization-rust.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/delivery-customization-rust.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/sample-apps/delivery-customizations/extensions/delivery-customization-rust/src/main.rs
+++ b/sample-apps/delivery-customizations/extensions/delivery-customization-rust/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/sample-apps/discounts/extensions/product-discount-rust/README.md
+++ b/sample-apps/discounts/extensions/product-discount-rust/README.md
@@ -10,7 +10,7 @@
 You can build this individual function using `cargo build`.
 
 ```shell
-cargo build --target=wasm32-wasip1 --release
+cargo build --target=wasm32-unknown-unknown --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/sample-apps/discounts/extensions/product-discount-rust/shopify.extension.toml
+++ b/sample-apps/discounts/extensions/product-discount-rust/shopify.extension.toml
@@ -12,8 +12,8 @@ type = "function"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/product-discount-rust.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/product-discount-rust.wasm"
   watch = ["src/**/*.rs"]
 
   [extensions.ui.paths]

--- a/sample-apps/discounts/extensions/product-discount-rust/src/main.rs
+++ b/sample-apps/discounts/extensions/product-discount-rust/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/sample-apps/discounts/extensions/product-discount-rust/src/run.rs
+++ b/sample-apps/discounts/extensions/product-discount-rust/src/run.rs
@@ -58,7 +58,7 @@ fn run(input: input::ResponseData) -> Result<output::FunctionRunResult> {
         .collect::<Vec<output::Target>>();
 
     if targets.is_empty() {
-        eprintln!("No cart lines qualify for volume discount.");
+        log!("No cart lines qualify for volume discount.");
         return Ok(no_discount);
     }
 

--- a/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/shopify.extension.toml
+++ b/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/shopify.extension.toml
@@ -12,8 +12,8 @@ type = "function"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/optional-add-ons-rust.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/optional-add-ons-rust.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/src/main.rs
+++ b/sample-apps/optional-add-ons-cart-transform/extensions/optional-add-ons-rust/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/sample-apps/payment-customizations/extensions/payment-customization-rust/shopify.extension.toml
+++ b/sample-apps/payment-customizations/extensions/payment-customization-rust/shopify.extension.toml
@@ -12,8 +12,8 @@ type = "function"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/payment-customization.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/payment-customization.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/sample-apps/payment-customizations/extensions/payment-customization-rust/src/main.rs
+++ b/sample-apps/payment-customizations/extensions/payment-customization-rust/src/main.rs
@@ -1,7 +1,8 @@
+use shopify_function::prelude::*;
 use std::process;
 pub mod run;
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/sample-apps/payment-customizations/extensions/payment-customization-rust/src/run.rs
+++ b/sample-apps/payment-customizations/extensions/payment-customization-rust/src/run.rs
@@ -33,7 +33,7 @@ fn run(input: input::ResponseData) -> Result<output::FunctionRunResult> {
     // Use the configured cart total instead of a hardcoded value
     let cart_total: f64 = input.cart.cost.total_amount.amount.into();
     if cart_total < config.cart_total {
-        eprintln!("Cart total is not high enough, no need to hide the payment method.");
+        log!("Cart total is not high enough, no need to hide the payment method.");
         return Ok(no_changes);
     }
 


### PR DESCRIPTION
Mostly switching `wasm32-wasip1` to `wasm32-unknown-unknown`, `eprintln!` to `log!`, and `process::exit(1)` to `process::abort()`.